### PR TITLE
fix(release): complete publish automation flow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,7 @@
 - [ ] Commit messages follow `feat/fix/chore`
 - [ ] Tests added or updated for behavior changes
 - [ ] Docs and `CHANGELOG.md` updated when needed
+- [ ] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
 - [ ] Breaking changes include migration notes
 - [ ] No secrets, private keys, or local absolute paths included
 

--- a/.github/workflows/release-on-version-bump.yml
+++ b/.github/workflows/release-on-version-bump.yml
@@ -1,0 +1,222 @@
+name: release-on-version-bump
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - VERSION.txt
+
+permissions:
+  contents: write
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Require CHANGELOG update in release push
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          if [ "${BEFORE_SHA}" = "0000000000000000000000000000000000000000" ]; then
+            changed_files="$(git show --pretty='' --name-only HEAD)"
+          else
+            changed_files="$(git diff --name-only "${BEFORE_SHA}" "${GITHUB_SHA}")"
+          fi
+          printf '%s\n' "${changed_files}"
+          if ! printf '%s\n' "${changed_files}" | grep -Fxq 'CHANGELOG.md'; then
+            echo "release pushes must update CHANGELOG.md together with VERSION.txt" >&2
+            exit 1
+          fi
+
+      - name: Validate release bundle
+        id: release
+        run: |
+          set -euo pipefail
+          version="$(go run ./cmd/releasectl validate-release --version-file VERSION.txt --changelog CHANGELOG.md)"
+          printf 'version=%s\n' "${version}" >> "${GITHUB_OUTPUT}"
+          printf 'tag_name=v%s\n' "${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Ensure existing tag, if any, points at this commit
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          git fetch --tags origin
+          if ! git rev-parse "refs/tags/v${VERSION}" >/dev/null 2>&1; then
+            exit 0
+          fi
+          remote_tag_commit="$(git rev-list -n 1 "refs/tags/v${VERSION}")"
+          if [ "${remote_tag_commit}" != "${GITHUB_SHA}" ]; then
+            echo "tag v${VERSION} already exists on ${remote_tag_commit}" >&2
+            exit 1
+          fi
+
+  build-assets:
+    needs: prepare-release
+    strategy:
+      matrix:
+        include:
+          - runner: macos-14
+            goarch: arm64
+          - runner: macos-13
+            goarch: amd64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build release archive
+        env:
+          RELEASE_GOARCH: ${{ matrix.goarch }}
+        run: |
+          set -euo pipefail
+          make release-asset RELEASE_GOOS=darwin RELEASE_GOARCH="${RELEASE_GOARCH}" DIST_DIR=dist
+
+      - name: Verify archive version output
+        env:
+          VERSION: ${{ needs.prepare-release.outputs.version }}
+          RELEASE_GOARCH: ${{ matrix.goarch }}
+        run: |
+          set -euo pipefail
+          archive="dist/tars_${VERSION}_darwin_${RELEASE_GOARCH}.tar.gz"
+          test -f "${archive}"
+          rm -rf dist/check
+          mkdir -p dist/check
+          tar -xzf "${archive}" -C dist/check
+          dist/check/tars --version | grep -F "tars ${VERSION} ("
+
+      - name: Upload archive artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.goarch }}
+          path: dist/*.tar.gz
+
+  publish-release:
+    needs:
+      - prepare-release
+      - build-assets
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.checksums.outputs.version }}
+      arm64_sha: ${{ steps.checksums.outputs.arm64_sha }}
+      amd64_sha: ${{ steps.checksums.outputs.amd64_sha }}
+    steps:
+      - name: Download built archives
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: release-*
+          merge-multiple: true
+
+      - name: Compute checksums
+        id: checksums
+        env:
+          VERSION: ${{ needs.prepare-release.outputs.version }}
+        run: |
+          set -euo pipefail
+          arm64_asset="dist/tars_${VERSION}_darwin_arm64.tar.gz"
+          amd64_asset="dist/tars_${VERSION}_darwin_amd64.tar.gz"
+          arm64_sha="$(shasum -a 256 "${arm64_asset}" | awk '{print $1}')"
+          amd64_sha="$(shasum -a 256 "${amd64_asset}" | awk '{print $1}')"
+          {
+            printf '%s  %s\n' "${arm64_sha}" "$(basename "${arm64_asset}")"
+            printf '%s  %s\n' "${amd64_sha}" "$(basename "${amd64_asset}")"
+          } > dist/checksums.txt
+          printf 'version=%s\n' "${VERSION}" >> "${GITHUB_OUTPUT}"
+          printf 'arm64_sha=%s\n' "${arm64_sha}" >> "${GITHUB_OUTPUT}"
+          printf 'amd64_sha=%s\n' "${amd64_sha}" >> "${GITHUB_OUTPUT}"
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ needs.prepare-release.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          printf 'Release %s\n\nSee CHANGELOG.md for details.\n' "${TAG_NAME}" > release-notes.txt
+          if gh release view "${TAG_NAME}" >/dev/null 2>&1; then
+            gh release upload "${TAG_NAME}" dist/*.tar.gz dist/checksums.txt --clobber
+            gh release edit "${TAG_NAME}" --title "${TAG_NAME}" --notes-file release-notes.txt
+          else
+            gh release create "${TAG_NAME}" dist/*.tar.gz dist/checksums.txt --target "${GITHUB_SHA}" --title "${TAG_NAME}" --notes-file release-notes.txt
+          fi
+
+  update-homebrew:
+    needs: publish-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout TARS repository
+        uses: actions/checkout@v4
+        with:
+          path: repo
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: repo/go.mod
+
+      - name: Require tap token
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${HOMEBREW_TAP_TOKEN}" ]; then
+            echo "HOMEBREW_TAP_TOKEN is required to update devlikebear/homebrew-tars" >&2
+            exit 1
+          fi
+
+      - name: Checkout Homebrew tap repository
+        uses: actions/checkout@v4
+        with:
+          repository: devlikebear/homebrew-tars
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Render formula
+        env:
+          VERSION: ${{ needs.publish-release.outputs.version }}
+          ARM64_SHA: ${{ needs.publish-release.outputs.arm64_sha }}
+          AMD64_SHA: ${{ needs.publish-release.outputs.amd64_sha }}
+        working-directory: repo
+        run: |
+          set -euo pipefail
+          mkdir -p ../homebrew-tap/Formula
+          go run ./cmd/releasectl homebrew-formula \
+            --repo devlikebear/tars \
+            --version "${VERSION}" \
+            --arm64-sha "${ARM64_SHA}" \
+            --amd64-sha "${AMD64_SHA}" \
+            > ../homebrew-tap/Formula/tars.rb
+
+      - name: Commit and push formula update
+        working-directory: homebrew-tap
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/tars.rb
+          if git diff --cached --quiet; then
+            echo "formula already up to date"
+            exit 0
+          fi
+          git commit -m "tars ${{ needs.publish-release.outputs.version }}"
+          git push origin HEAD:main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,17 @@ The format is based on Keep a Changelog and the project follows Semantic Version
 
 ## [Unreleased]
 
+### Added
+
+- Automated release workflow driven by `VERSION.txt` changes on `main`, including tag/release publishing and Homebrew tap updates
+- Public `install.sh` for curl-based macOS installs from GitHub Releases
+- Homebrew tap formula generation for `devlikebear/homebrew-tars`
+
 ### Changed
 
 - Public documentation is maintained in English for the published repository surface
+- `install.sh` now installs the latest published GitHub Release by default
+- Release PRs must update `VERSION.txt` and `CHANGELOG.md` together
 
 ## [0.1.0] - 2026-03-08
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,10 +35,11 @@ TARS uses Semantic Versioning: `MAJOR.MINOR.PATCH`.
 
 Release metadata rules:
 
-- Update [`VERSION.txt`](VERSION.txt) when preparing a release
+- Update [`VERSION.txt`](VERSION.txt) and [`CHANGELOG.md`](CHANGELOG.md) together when preparing a release PR
 - Record user-visible changes in [`CHANGELOG.md`](CHANGELOG.md)
 - Add migration notes for any breaking change
 - Tag releases as `vX.Y.Z`
+- Merging a release PR to `main` is the release approval event: it creates the tag, publishes the GitHub Release, updates the Homebrew tap, and powers the curl installer
 
 ## Required Checks
 
@@ -56,6 +57,7 @@ make security-scan
 - [ ] `make test` passes
 - [ ] `make security-scan` passes
 - [ ] `CHANGELOG.md` and docs are updated when needed
+- [ ] Release PRs update `VERSION.txt` and `CHANGELOG.md` together
 - [ ] No secrets, private keys, or local absolute paths are committed
 
 ## Compatibility Notes
@@ -63,3 +65,12 @@ make security-scan
 - The primary plugin manifest filename is `tars.plugin.json`
 - The primary user extension directories are `~/.tars/skills` and `~/.tars/plugins`
 - One release of fallback compatibility is kept for legacy pre-publication extension paths and manifest names
+
+## Release Automation Notes
+
+- `release-on-version-bump` runs only when `VERSION.txt` changes on `main`
+- The release workflow validates `CHANGELOG.md`, builds macOS archives, creates or updates the GitHub Release, and then updates the Homebrew tap
+- The release workflow fails if `CHANGELOG.md` is not updated in the same push
+- GitHub Releases publish macOS `arm64` and `amd64` archives plus `checksums.txt`
+- `HOMEBREW_TAP_TOKEN` is required; if it is missing or the tap update fails, the release workflow fails
+- `install.sh` installs the latest published GitHub Release by default, or a pinned version when `VERSION=...` is provided

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 GO ?= go
 BIN_DIR ?= bin
+DIST_DIR ?= dist
 VERSION_FILE ?= VERSION.txt
 WORKSPACE_DIR ?= ./workspace
 API_ADDR ?= 127.0.0.1:43180
@@ -39,12 +40,17 @@ GIT_COMMIT ?= $(strip $(shell git rev-parse --short HEAD 2>/dev/null || printf '
 BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 BUILDINFO_PKG ?= github.com/devlikebear/tars/internal/buildinfo
 GO_LDFLAGS ?= -X $(BUILDINFO_PKG).Version=$(VERSION) -X $(BUILDINFO_PKG).Commit=$(GIT_COMMIT) -X $(BUILDINFO_PKG).Date=$(BUILD_DATE)
+RELEASE_GOOS ?= $(shell $(GO) env GOOS)
+RELEASE_GOARCH ?= $(shell $(GO) env GOARCH)
+RELEASE_CGO_ENABLED ?= 1
+RELEASE_ARCHIVE_NAME ?= tars_$(VERSION)_$(RELEASE_GOOS)_$(RELEASE_GOARCH).tar.gz
+RELEASE_STAGE_DIR ?= $(DIST_DIR)/release-$(RELEASE_GOOS)-$(RELEASE_GOARCH)
 
 .DEFAULT_GOAL := help
 
 .PHONY: help \
 	test test-v test-one test-nocache test-race test-cover \
-	build build-bins clean tidy fmt vet lint \
+	build build-bins release-asset clean tidy fmt vet lint \
 	browser-install \
 	install install-server install-assistant uninstall uninstall-server uninstall-assistant reinstall \
 	restart restart-server restart-assistant reload-config reload-server-config reload-assistant-config \
@@ -75,6 +81,7 @@ help:
 	@echo "Build/quality targets:"
 	@echo "  make build         - go build ./..."
 	@echo "  make build-bins    - build cmd binaries to $(BIN_DIR)"
+	@echo "  make release-asset - build a versioned release archive to $(DIST_DIR)"
 	@echo "  make browser-install - npm install + playwright chromium install"
 	@echo "  make install       - build $(TARS_BIN) and (re)install io.tars.server + io.tars.assistant launch agents"
 	@echo "  make uninstall     - stop and remove io.tars.server + io.tars.assistant launch agents"
@@ -138,6 +145,13 @@ build:
 build-bins:
 	mkdir -p $(BIN_DIR)
 	$(GO) build -ldflags "$(GO_LDFLAGS)" -o $(BIN_DIR)/tars ./cmd/tars
+
+release-asset:
+	mkdir -p "$(DIST_DIR)"
+	rm -rf "$(RELEASE_STAGE_DIR)"
+	mkdir -p "$(RELEASE_STAGE_DIR)"
+	CGO_ENABLED=$(RELEASE_CGO_ENABLED) GOOS=$(RELEASE_GOOS) GOARCH=$(RELEASE_GOARCH) $(GO) build -ldflags "$(GO_LDFLAGS)" -o "$(RELEASE_STAGE_DIR)/tars" ./cmd/tars
+	tar -C "$(RELEASE_STAGE_DIR)" -czf "$(DIST_DIR)/$(RELEASE_ARCHIVE_NAME)" tars
 
 browser-install:
 	npm install

--- a/README.md
+++ b/README.md
@@ -27,6 +27,29 @@ It combines a terminal client, a local HTTP runtime, agent tools, sessions, sche
 - Provider credentials for the models you want to use
 - Optional: Node.js for Playwright browser installation
 
+## Install
+
+Homebrew tap:
+
+```bash
+brew tap devlikebear/tars
+brew install devlikebear/tars/tars
+```
+
+Curl installer:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/devlikebear/tars/main/install.sh | sh
+```
+
+The installer downloads the latest published GitHub Release by default.
+
+Install to a custom path or pin a version:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/devlikebear/tars/main/install.sh | INSTALL_DIR="$HOME/.local/bin" VERSION=0.1.0 sh
+```
+
 ## Quick Start
 
 1. Review the example config:
@@ -62,6 +85,12 @@ Build the binary with version metadata from [`VERSION.txt`](VERSION.txt):
 ```bash
 make build-bins
 bin/tars version
+```
+
+Build a macOS release archive with the same version metadata used by GitHub Releases:
+
+```bash
+make release-asset RELEASE_GOOS=darwin RELEASE_GOARCH=arm64
 ```
 
 ## Browser Automation

--- a/cmd/releasectl/main.go
+++ b/cmd/releasectl/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/devlikebear/tars/internal/release"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+
+	switch os.Args[1] {
+	case "validate-release":
+		validateRelease(os.Args[2:])
+	case "homebrew-formula":
+		homebrewFormula(os.Args[2:])
+	default:
+		usage()
+		os.Exit(2)
+	}
+}
+
+func validateRelease(args []string) {
+	fs := flag.NewFlagSet("validate-release", flag.ExitOnError)
+	versionFile := fs.String("version-file", "VERSION.txt", "path to VERSION.txt")
+	changelogFile := fs.String("changelog", "CHANGELOG.md", "path to CHANGELOG.md")
+	_ = fs.Parse(args)
+
+	version, err := release.ValidateReleaseBundle(*versionFile, *changelogFile)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Fprintln(os.Stdout, version)
+}
+
+func homebrewFormula(args []string) {
+	fs := flag.NewFlagSet("homebrew-formula", flag.ExitOnError)
+	repoSlug := fs.String("repo", "devlikebear/tars", "GitHub repo slug")
+	version := fs.String("version", "", "release version without v prefix")
+	arm64SHA := fs.String("arm64-sha", "", "SHA256 for darwin arm64 asset")
+	amd64SHA := fs.String("amd64-sha", "", "SHA256 for darwin amd64 asset")
+	_ = fs.Parse(args)
+
+	formula, err := release.HomebrewFormula(*repoSlug, *version, *arm64SHA, *amd64SHA)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Fprint(os.Stdout, formula)
+}
+
+func usage() {
+	fmt.Fprintln(os.Stderr, "usage: releasectl <validate-release|homebrew-formula> [flags]")
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env sh
+set -eu
+
+REPO_SLUG="${REPO_SLUG:-devlikebear/tars}"
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
+REPOSITORY_URL="${REPOSITORY_URL:-https://github.com/$REPO_SLUG}"
+LATEST_RELEASE_URL="${LATEST_RELEASE_URL:-$REPOSITORY_URL/releases/latest}"
+RELEASE_BASE_URL="${RELEASE_BASE_URL:-$REPOSITORY_URL/releases/download}"
+
+log() {
+  printf '%s\n' "$*" >&2
+}
+
+fail() {
+  log "install.sh: $*"
+  exit 1
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    fail "required command not found: $1"
+  fi
+}
+
+detect_goarch() {
+  case "$(uname -m)" in
+    arm64)
+      printf 'arm64\n'
+      ;;
+    x86_64|amd64)
+      printf 'amd64\n'
+      ;;
+    *)
+      fail "unsupported architecture: $(uname -m)"
+      ;;
+  esac
+}
+
+detect_goos() {
+  case "$(uname -s)" in
+    Darwin)
+      printf 'darwin\n'
+      ;;
+    *)
+      fail "unsupported operating system: $(uname -s)"
+      ;;
+  esac
+}
+
+fetch_latest_version() {
+  if ! resolved_url="$(curl -fsSIL -o /dev/null -w '%{url_effective}' "$LATEST_RELEASE_URL")"; then
+    fail "failed to fetch latest release from $LATEST_RELEASE_URL"
+  fi
+  tag_name="${resolved_url##*/}"
+  version="${tag_name#v}"
+  if [ -z "$tag_name" ] || [ -z "$version" ] || [ "$tag_name" = "$version" ]; then
+    fail "failed to resolve latest release version from $LATEST_RELEASE_URL"
+  fi
+  printf '%s\n' "$version"
+}
+
+download_asset() {
+  asset_url="$1"
+  destination="$2"
+  if ! curl -fsSL "$asset_url" >"$destination"; then
+    fail "failed to download release asset: $asset_url"
+  fi
+}
+
+require_cmd curl
+require_cmd tar
+require_cmd uname
+require_cmd install
+require_cmd mktemp
+require_cmd find
+
+GOOS="$(detect_goos)"
+GOARCH="$(detect_goarch)"
+VERSION="${VERSION:-}"
+if [ -z "$VERSION" ]; then
+  VERSION="$(fetch_latest_version)"
+fi
+VERSION="$(printf '%s' "$VERSION" | tr -d '[:space:]')"
+[ -n "$VERSION" ] || fail "release version is empty"
+
+ARCHIVE_NAME="tars_${VERSION}_${GOOS}_${GOARCH}.tar.gz"
+ASSET_URL="$RELEASE_BASE_URL/v$VERSION/$ARCHIVE_NAME"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' 0 INT HUP TERM
+
+ARCHIVE_PATH="$TMP_DIR/$ARCHIVE_NAME"
+download_asset "$ASSET_URL" "$ARCHIVE_PATH"
+mkdir -p "$INSTALL_DIR"
+if ! tar -xzf "$ARCHIVE_PATH" -C "$TMP_DIR"; then
+  fail "failed to extract archive: $ARCHIVE_PATH"
+fi
+EXTRACTED_BINARY="$(find "$TMP_DIR" -type f -name tars -print -quit)"
+if [ -z "$EXTRACTED_BINARY" ]; then
+  fail "release archive did not contain a tars binary: $ASSET_URL"
+fi
+
+TARGET_PATH="$INSTALL_DIR/tars"
+install -m 0755 "$EXTRACTED_BINARY" "$TARGET_PATH"
+if ! "$TARGET_PATH" --version >/dev/null 2>&1; then
+  fail "installed binary failed version check: $TARGET_PATH --version"
+fi
+
+printf 'Installed tars to %s\n' "$TARGET_PATH"

--- a/internal/release/install_script_test.go
+++ b/internal/release/install_script_test.go
@@ -1,0 +1,183 @@
+package release
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallScript_FetchesLatestReleaseAndInstallsBinary(t *testing.T) {
+	t.Parallel()
+
+	rootDir := repoRoot(t)
+	installScript := filepath.Join(rootDir, "install.sh")
+	for _, tc := range []struct {
+		name string
+		arch string
+	}{
+		{name: "arm64", arch: "arm64"},
+		{name: "amd64", arch: "x86_64"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			binDir := filepath.Join(tempDir, "bin")
+			homeDir := filepath.Join(tempDir, "home")
+			installDir := filepath.Join(tempDir, "install")
+			if err := os.MkdirAll(binDir, 0o755); err != nil {
+				t.Fatalf("mkdir bin dir: %v", err)
+			}
+			if err := os.MkdirAll(homeDir, 0o755); err != nil {
+				t.Fatalf("mkdir home dir: %v", err)
+			}
+
+			archivePath := filepath.Join(tempDir, "archive.tar.gz")
+			if err := writeTarballWithBinary(archivePath, "#!/bin/sh\necho 'tars 0.1.0 (test123, 2026-03-08T00:00:00Z)'\n"); err != nil {
+				t.Fatalf("write tarball: %v", err)
+			}
+			curlLog := filepath.Join(tempDir, "curl.log")
+			writeExecutable(t, filepath.Join(binDir, "uname"), "#!/bin/sh\nif [ \"$1\" = \"-s\" ]; then\n  printf 'Darwin\\n'\n  exit 0\nfi\nif [ \"$1\" = \"-m\" ]; then\n  printf '"+tc.arch+"\\n'\n  exit 0\nfi\nprintf 'unsupported uname args: %s\\n' \"$*\" >&2\nexit 1\n")
+			writeExecutable(t, filepath.Join(binDir, "curl"), "#!/bin/sh\nfor arg in \"$@\"; do url=\"$arg\"; done\nprintf '%s\\n' \"$url\" >> \"$TEST_CURL_LOG\"\ncase \"$url\" in\n  */releases/latest)\n    printf 'https://github.com/devlikebear/tars/releases/tag/v0.1.0'\n    ;;\n  *tars_0.1.0_darwin_arm64.tar.gz|*tars_0.1.0_darwin_amd64.tar.gz)\n    cat \"$TEST_ARCHIVE_SOURCE\"\n    ;;\n  *)\n    printf 'unexpected url: %s\\n' \"$url\" >&2\n    exit 22\n    ;;\nesac\n")
+
+			cmd := exec.Command("sh", installScript)
+			cmd.Env = append(os.Environ(),
+				"PATH="+binDir+":"+os.Getenv("PATH"),
+				"HOME="+homeDir,
+				"INSTALL_DIR="+installDir,
+				"TEST_ARCHIVE_SOURCE="+archivePath,
+				"TEST_CURL_LOG="+curlLog,
+			)
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("install.sh failed: %v\n%s", err, output)
+			}
+
+			installedBinary := filepath.Join(installDir, "tars")
+			data, err := os.ReadFile(installedBinary)
+			if err != nil {
+				t.Fatalf("read installed binary: %v", err)
+			}
+			if !strings.Contains(string(data), "tars 0.1.0") {
+				t.Fatalf("installed binary missing expected version output: %s", data)
+			}
+
+			logData, err := os.ReadFile(curlLog)
+			if err != nil {
+				t.Fatalf("read curl log: %v", err)
+			}
+			gotLog := string(logData)
+			if !strings.Contains(gotLog, "/releases/latest") {
+				t.Fatalf("expected install.sh to query latest release, log:\n%s", gotLog)
+			}
+			if strings.Contains(gotLog, "VERSION.txt") {
+				t.Fatalf("install.sh should not fetch VERSION.txt anymore, log:\n%s", gotLog)
+			}
+		})
+	}
+}
+
+func TestInstallScript_ReportsMissingAssetURL(t *testing.T) {
+	t.Parallel()
+
+	rootDir := repoRoot(t)
+	installScript := filepath.Join(rootDir, "install.sh")
+	tempDir := t.TempDir()
+	binDir := filepath.Join(tempDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin dir: %v", err)
+	}
+
+	writeExecutable(t, filepath.Join(binDir, "uname"), "#!/bin/sh\nif [ \"$1\" = \"-s\" ]; then\n  printf 'Darwin\\n'\n  exit 0\nfi\nif [ \"$1\" = \"-m\" ]; then\n  printf 'arm64\\n'\n  exit 0\nfi\nexit 1\n")
+	writeExecutable(t, filepath.Join(binDir, "curl"), "#!/bin/sh\nfor arg in \"$@\"; do url=\"$arg\"; done\ncase \"$url\" in\n  */releases/latest)\n    printf 'https://github.com/devlikebear/tars/releases/tag/v9.9.9'\n    ;;\n  *)\n    printf 'curl 404 for %s\\n' \"$url\" >&2\n    exit 22\n    ;;\nesac\n")
+
+	cmd := exec.Command("sh", installScript)
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"HOME="+filepath.Join(tempDir, "home"),
+		"INSTALL_DIR="+filepath.Join(tempDir, "install"),
+	)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected install.sh to fail for missing asset")
+	}
+	got := string(output)
+	want := "https://github.com/devlikebear/tars/releases/download/v9.9.9/tars_9.9.9_darwin_arm64.tar.gz"
+	if !strings.Contains(got, want) {
+		t.Fatalf("expected output to mention missing asset URL %q, got:\n%s", want, got)
+	}
+}
+
+func TestInstallScript_ReportsLatestReleaseLookupFailure(t *testing.T) {
+	t.Parallel()
+
+	rootDir := repoRoot(t)
+	installScript := filepath.Join(rootDir, "install.sh")
+	tempDir := t.TempDir()
+	binDir := filepath.Join(tempDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin dir: %v", err)
+	}
+
+	writeExecutable(t, filepath.Join(binDir, "uname"), "#!/bin/sh\nif [ \"$1\" = \"-s\" ]; then\n  printf 'Darwin\\n'\n  exit 0\nfi\nif [ \"$1\" = \"-m\" ]; then\n  printf 'arm64\\n'\n  exit 0\nfi\nexit 1\n")
+	writeExecutable(t, filepath.Join(binDir, "curl"), "#!/bin/sh\nfor arg in \"$@\"; do url=\"$arg\"; done\nprintf 'curl 404 for %s\\n' \"$url\" >&2\nexit 22\n")
+
+	cmd := exec.Command("sh", installScript)
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+":"+os.Getenv("PATH"),
+		"HOME="+filepath.Join(tempDir, "home"),
+		"INSTALL_DIR="+filepath.Join(tempDir, "install"),
+	)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected install.sh to fail when latest release lookup fails")
+	}
+	got := string(output)
+	want := "https://github.com/devlikebear/tars/releases/latest"
+	if !strings.Contains(got, want) {
+		t.Fatalf("expected output to mention latest release URL %q, got:\n%s", want, got)
+	}
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	return filepath.Clean(filepath.Join(wd, "..", ".."))
+}
+
+func writeExecutable(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), 0o755); err != nil {
+		t.Fatalf("write executable %s: %v", path, err)
+	}
+}
+
+func writeTarballWithBinary(path, contents string) error {
+	var archive bytes.Buffer
+	gzipWriter := gzip.NewWriter(&archive)
+	tarWriter := tar.NewWriter(gzipWriter)
+	if err := tarWriter.WriteHeader(&tar.Header{
+		Name: "tars",
+		Mode: 0o755,
+		Size: int64(len(contents)),
+	}); err != nil {
+		return err
+	}
+	if _, err := tarWriter.Write([]byte(contents)); err != nil {
+		return err
+	}
+	if err := tarWriter.Close(); err != nil {
+		return err
+	}
+	if err := gzipWriter.Close(); err != nil {
+		return err
+	}
+	return os.WriteFile(path, archive.Bytes(), 0o644)
+}

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -1,0 +1,101 @@
+package release
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+var semverPattern = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$`)
+
+func ValidateReleaseBundle(versionFile, changelogFile string) (string, error) {
+	versionBytes, err := os.ReadFile(versionFile)
+	if err != nil {
+		return "", fmt.Errorf("read version file: %w", err)
+	}
+	version := strings.TrimSpace(string(versionBytes))
+	if err := ValidateVersion(version); err != nil {
+		return "", err
+	}
+
+	changelogBytes, err := os.ReadFile(changelogFile)
+	if err != nil {
+		return "", fmt.Errorf("read changelog file: %w", err)
+	}
+	if !strings.Contains(string(changelogBytes), fmt.Sprintf("## [%s]", version)) {
+		return "", fmt.Errorf("missing changelog section for version %s", version)
+	}
+	return version, nil
+}
+
+func ValidateVersion(version string) error {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return fmt.Errorf("release version must not be empty")
+	}
+	if !semverPattern.MatchString(version) {
+		return fmt.Errorf("release version must be valid semver, got %q", version)
+	}
+	return nil
+}
+
+func ReleaseTag(version string) string {
+	return "v" + strings.TrimSpace(version)
+}
+
+func AssetArchiveName(version, goos, goarch string) string {
+	return fmt.Sprintf("tars_%s_%s_%s.tar.gz", strings.TrimSpace(version), strings.TrimSpace(goos), strings.TrimSpace(goarch))
+}
+
+func ReleaseAssetURL(repoSlug, version, goos, goarch string) string {
+	return fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", strings.TrimSpace(repoSlug), ReleaseTag(version), AssetArchiveName(version, goos, goarch))
+}
+
+func HomebrewFormula(repoSlug, version, arm64SHA, amd64SHA string) (string, error) {
+	if err := ValidateVersion(version); err != nil {
+		return "", err
+	}
+	repoSlug = strings.TrimSpace(repoSlug)
+	if repoSlug == "" {
+		return "", fmt.Errorf("repository slug must not be empty")
+	}
+	arm64SHA = strings.TrimSpace(arm64SHA)
+	amd64SHA = strings.TrimSpace(amd64SHA)
+	if arm64SHA == "" || amd64SHA == "" {
+		return "", fmt.Errorf("arm64 and amd64 SHA256 values are required")
+	}
+
+	return fmt.Sprintf(`class Tars < Formula
+  desc "Local-first automation runtime written in Go"
+  homepage "https://github.com/%[1]s"
+  version "%[2]s"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "%[3]s"
+      sha256 "%[4]s"
+    else
+      url "%[5]s"
+      sha256 "%[6]s"
+    end
+  end
+
+  def install
+    bin.install "tars"
+  end
+
+  def caveats
+    <<~EOS
+      Optional assistant dependencies are not installed by this formula.
+      Install them separately when needed:
+        brew install ffmpeg whisper-cpp
+    EOS
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/tars --version")
+  end
+end
+`, repoSlug, version, ReleaseAssetURL(repoSlug, version, "darwin", "arm64"), arm64SHA, ReleaseAssetURL(repoSlug, version, "darwin", "amd64"), amd64SHA), nil
+}

--- a/internal/release/release_test.go
+++ b/internal/release/release_test.go
@@ -1,0 +1,84 @@
+package release
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateReleaseBundle(t *testing.T) {
+	dir := t.TempDir()
+	versionFile := filepath.Join(dir, "VERSION.txt")
+	changelogFile := filepath.Join(dir, "CHANGELOG.md")
+	if err := os.WriteFile(versionFile, []byte("1.2.3\n"), 0o644); err != nil {
+		t.Fatalf("write version file: %v", err)
+	}
+	if err := os.WriteFile(changelogFile, []byte("# Changelog\n\n## [1.2.3] - 2026-03-08\n"), 0o644); err != nil {
+		t.Fatalf("write changelog file: %v", err)
+	}
+
+	version, err := ValidateReleaseBundle(versionFile, changelogFile)
+	if err != nil {
+		t.Fatalf("validate release bundle: %v", err)
+	}
+	if version != "1.2.3" {
+		t.Fatalf("unexpected version: %q", version)
+	}
+}
+
+func TestValidateReleaseBundle_RequiresSemverAndMatchingChangelog(t *testing.T) {
+	dir := t.TempDir()
+	versionFile := filepath.Join(dir, "VERSION.txt")
+	changelogFile := filepath.Join(dir, "CHANGELOG.md")
+	if err := os.WriteFile(versionFile, []byte("not-a-version\n"), 0o644); err != nil {
+		t.Fatalf("write version file: %v", err)
+	}
+	if err := os.WriteFile(changelogFile, []byte("# Changelog\n\n## [0.1.0] - 2026-03-08\n"), 0o644); err != nil {
+		t.Fatalf("write changelog file: %v", err)
+	}
+
+	if _, err := ValidateReleaseBundle(versionFile, changelogFile); err == nil {
+		t.Fatal("expected invalid semver to fail")
+	}
+
+	if err := os.WriteFile(versionFile, []byte("1.2.3\n"), 0o644); err != nil {
+		t.Fatalf("rewrite version file: %v", err)
+	}
+	if _, err := ValidateReleaseBundle(versionFile, changelogFile); err == nil {
+		t.Fatal("expected missing changelog version section to fail")
+	}
+}
+
+func TestHomebrewFormulaIncludesBothMacArchitectures(t *testing.T) {
+	formula, err := HomebrewFormula("devlikebear/tars", "1.2.3", "arm64-sha", "amd64-sha")
+	if err != nil {
+		t.Fatalf("homebrew formula: %v", err)
+	}
+
+	wantSnippets := []string{
+		"class Tars < Formula",
+		"https://github.com/devlikebear/tars/releases/download/v1.2.3/tars_1.2.3_darwin_arm64.tar.gz",
+		"https://github.com/devlikebear/tars/releases/download/v1.2.3/tars_1.2.3_darwin_amd64.tar.gz",
+		"sha256 \"arm64-sha\"",
+		"sha256 \"amd64-sha\"",
+		"brew install ffmpeg whisper-cpp",
+	}
+	for _, snippet := range wantSnippets {
+		if !strings.Contains(formula, snippet) {
+			t.Fatalf("formula missing snippet %q:\n%s", snippet, formula)
+		}
+	}
+}
+
+func TestReleaseAssetMetadata(t *testing.T) {
+	if got := AssetArchiveName("1.2.3", "darwin", "arm64"); got != "tars_1.2.3_darwin_arm64.tar.gz" {
+		t.Fatalf("unexpected asset archive name: %q", got)
+	}
+	if got := ReleaseTag("1.2.3"); got != "v1.2.3" {
+		t.Fatalf("unexpected release tag: %q", got)
+	}
+	if got := ReleaseAssetURL("devlikebear/tars", "1.2.3", "darwin", "amd64"); got != "https://github.com/devlikebear/tars/releases/download/v1.2.3/tars_1.2.3_darwin_amd64.tar.gz" {
+		t.Fatalf("unexpected release asset url: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- What problem does this PR solve?
  This fixes the release automation path so a version bump on `main` completes tag/release/Homebrew publication in one workflow instead of relying on a tag-trigger chain that would not fire.
- Why is this approach correct?
  The workflow now owns the full release transaction directly, and `install.sh` resolves the latest published GitHub Release instead of reading `main/VERSION.txt`, which avoids installer breakage on unpublished bumps.

## Changes

- Main user-visible or developer-visible changes:
  - Consolidate release automation into `.github/workflows/release-on-version-bump.yml`
  - Make Homebrew update a required part of the release workflow
  - Change `install.sh` default behavior to install the latest published GitHub Release
  - Add release helper tests and documentation updates
- API, config, or compatibility changes:
  - `install.sh` default source changes from `main/VERSION.txt` to the latest GitHub Release

## Validation

- [ ] `make test`
- [x] `make security-scan`
- [x] Additional manual verification, if needed

Manual verification:
- `GOCACHE=/tmp/tars-go-build-cache go test ./internal/release/... ./cmd/releasectl/...`
- `sh -n install.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-on-version-bump.yml")'`
- `git diff --check`
- `GOCACHE=/tmp/tars-go-build-cache make release-asset RELEASE_GOOS=darwin RELEASE_GOARCH=arm64 DIST_DIR=/tmp/tars-release-check`

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [ ] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [ ] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level:
  Medium. This changes release automation and installer version resolution.
- Rollback plan:
  Revert this PR to restore the previous release flow and installer behavior.
