### PR TITLE
fix(release): allow release workflow reruns

### DIFF
--- a/.github/workflows/release-on-version-bump.yml
+++ b/.github/workflows/release-on-version-bump.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - VERSION.txt
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -28,6 +29,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Require CHANGELOG update in release push
+        if: github.event_name == 'push'
         env:
           BEFORE_SHA: ${{ github.event.before }}
         run: |
@@ -144,6 +146,7 @@ jobs:
       - name: Publish GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ needs.prepare-release.outputs.tag_name }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

- What problem does this PR solve?
  The `publish-release` job can build artifacts but cannot call `gh release ...` because the job has no repository context. Also, there is no safe way to rerun the release workflow after a workflow-only fix.
- Why is this approach correct?
  Setting `GH_REPO` gives `gh` an explicit repo target, and adding `workflow_dispatch` allows retrying the release workflow against the current `main` commit without forcing another version bump.

## Changes

- Main user-visible or developer-visible changes:
  - Add `workflow_dispatch` to `release-on-version-bump`.
  - Skip the changelog diff gate for manual runs.
  - Set `GH_REPO=${{ github.repository }}` for the GitHub Release publish step.
- API, config, or compatibility changes:
  - No runtime API changes.

## Validation

- [ ] `make test`
- [ ] `make security-scan`
- [x] Additional manual verification, if needed

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [ ] Tests added or updated for behavior changes
- [ ] Docs and `CHANGELOG.md` updated when needed
- [ ] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [ ] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level:
  Low. This only changes release workflow invocation and repository resolution for `gh`.
- Rollback plan:
  Revert this PR and fall back to another version bump after adding a checkout step in `publish-release`.
