### PR TITLE
feat: add project activity log api

### DIFF
--- a/internal/project/activity.go
+++ b/internal/project/activity.go
@@ -1,0 +1,179 @@
+package project
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const projectActivityDocumentName = "ACTIVITY.jsonl"
+
+type Activity struct {
+	ID        string            `json:"id"`
+	ProjectID string            `json:"project_id"`
+	TaskID    string            `json:"task_id,omitempty"`
+	Source    string            `json:"source"`
+	Agent     string            `json:"agent,omitempty"`
+	Kind      string            `json:"kind"`
+	Status    string            `json:"status,omitempty"`
+	Message   string            `json:"message,omitempty"`
+	Timestamp string            `json:"timestamp"`
+	Meta      map[string]string `json:"meta,omitempty"`
+}
+
+type ActivityAppendInput struct {
+	TaskID    string
+	Source    string
+	Agent     string
+	Kind      string
+	Status    string
+	Message   string
+	Timestamp string
+	Meta      map[string]string
+}
+
+func (s *Store) ActivityPath(projectID string) string {
+	return filepath.Join(s.workspaceDir, "projects", strings.TrimSpace(projectID), projectActivityDocumentName)
+}
+
+func (s *Store) AppendActivity(projectID string, input ActivityAppendInput) (Activity, error) {
+	if s == nil {
+		return Activity{}, fmt.Errorf("project store is nil")
+	}
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return Activity{}, fmt.Errorf("project id is required")
+	}
+	if _, err := s.Get(projectID); err != nil {
+		return Activity{}, err
+	}
+	source := strings.ToLower(strings.TrimSpace(input.Source))
+	if source == "" {
+		return Activity{}, fmt.Errorf("source is required")
+	}
+	kind := strings.ToLower(strings.TrimSpace(input.Kind))
+	if kind == "" {
+		return Activity{}, fmt.Errorf("kind is required")
+	}
+
+	existing, err := s.readActivity(projectID)
+	if err != nil {
+		return Activity{}, err
+	}
+	now := s.nowFn().UTC()
+	timestamp := strings.TrimSpace(input.Timestamp)
+	if timestamp == "" {
+		timestamp = now.Format(time.RFC3339)
+	}
+	item := Activity{
+		ID:        fmt.Sprintf("act_%s_%03d", now.Format("20060102T150405.000000000"), len(existing)+1),
+		ProjectID: projectID,
+		TaskID:    strings.TrimSpace(input.TaskID),
+		Source:    source,
+		Agent:     strings.TrimSpace(input.Agent),
+		Kind:      kind,
+		Status:    strings.ToLower(strings.TrimSpace(input.Status)),
+		Message:   strings.TrimSpace(input.Message),
+		Timestamp: timestamp,
+		Meta:      normalizeActivityMeta(input.Meta),
+	}
+
+	path := s.ActivityPath(projectID)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return Activity{}, err
+	}
+	encoded, err := json.Marshal(item)
+	if err != nil {
+		return Activity{}, fmt.Errorf("marshal activity: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return Activity{}, err
+	}
+	defer f.Close()
+	if _, err := f.Write(append(encoded, '\n')); err != nil {
+		return Activity{}, err
+	}
+	return item, nil
+}
+
+func (s *Store) ListActivity(projectID string, limit int) ([]Activity, error) {
+	if s == nil {
+		return nil, fmt.Errorf("project store is nil")
+	}
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return nil, fmt.Errorf("project id is required")
+	}
+	if _, err := s.Get(projectID); err != nil {
+		return nil, err
+	}
+	items, err := s.readActivity(projectID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Activity, 0, len(items))
+	for i := len(items) - 1; i >= 0; i-- {
+		out = append(out, items[i])
+	}
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	if out == nil {
+		return []Activity{}, nil
+	}
+	return out, nil
+}
+
+func (s *Store) readActivity(projectID string) ([]Activity, error) {
+	path := s.ActivityPath(projectID)
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []Activity{}, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	items := []Activity{}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var item Activity
+		if err := json.Unmarshal([]byte(line), &item); err != nil {
+			return nil, fmt.Errorf("decode activity: %w", err)
+		}
+		item.ProjectID = strings.TrimSpace(item.ProjectID)
+		items = append(items, item)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+func normalizeActivityMeta(raw map[string]string) map[string]string {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(raw))
+	for key, value := range raw {
+		trimmedKey := strings.TrimSpace(key)
+		if trimmedKey == "" {
+			continue
+		}
+		out[trimmedKey] = strings.TrimSpace(value)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/project/activity_test.go
+++ b/internal/project/activity_test.go
@@ -1,0 +1,81 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestStoreActivityRoundtripNewestFirst(t *testing.T) {
+	root := t.TempDir()
+	times := []time.Time{
+		time.Date(2026, 3, 14, 8, 59, 0, 0, time.UTC),
+		time.Date(2026, 3, 14, 9, 0, 0, 0, time.UTC),
+		time.Date(2026, 3, 14, 9, 1, 0, 0, time.UTC),
+	}
+	nowIndex := 0
+	store := NewStore(root, func() time.Time {
+		current := times[nowIndex]
+		if nowIndex < len(times)-1 {
+			nowIndex++
+		}
+		return current
+	})
+
+	created, err := store.Create(CreateInput{Name: "Dashboard Project"})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	first, err := store.AppendActivity(created.ID, ActivityAppendInput{
+		TaskID:  "task-1",
+		Source:  "pm",
+		Kind:    "assignment",
+		Status:  "queued",
+		Message: "Assign task-1 to dev-1",
+		Meta:    map[string]string{"agent": "dev-1"},
+	})
+	if err != nil {
+		t.Fatalf("append first activity: %v", err)
+	}
+	if first.ProjectID != created.ID {
+		t.Fatalf("expected project id %q, got %q", created.ID, first.ProjectID)
+	}
+
+	second, err := store.AppendActivity(created.ID, ActivityAppendInput{
+		TaskID:  "task-1",
+		Source:  "agent",
+		Agent:   "dev-1",
+		Kind:    "task_status",
+		Status:  "in_progress",
+		Message: "Started implementing tests",
+	})
+	if err != nil {
+		t.Fatalf("append second activity: %v", err)
+	}
+	if second.Agent != "dev-1" {
+		t.Fatalf("expected agent dev-1, got %q", second.Agent)
+	}
+
+	if _, err := os.Stat(filepath.Join(root, "projects", created.ID, "ACTIVITY.jsonl")); err != nil {
+		t.Fatalf("expected ACTIVITY.jsonl to be created: %v", err)
+	}
+
+	items, err := store.ListActivity(created.ID, 10)
+	if err != nil {
+		t.Fatalf("list activity: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 activity items, got %d", len(items))
+	}
+	if items[0].Status != "in_progress" {
+		t.Fatalf("expected newest item first, got %+v", items)
+	}
+	if items[1].Source != "pm" {
+		t.Fatalf("expected older item second, got %+v", items)
+	}
+	if items[0].Timestamp <= items[1].Timestamp {
+		t.Fatalf("expected newest timestamp first, got %+v", items)
+	}
+}

--- a/internal/tarsserver/handler_project.go
+++ b/internal/tarsserver/handler_project.go
@@ -306,6 +306,70 @@ func newProjectAPIHandler(store *project.Store, sessionStore *session.Store, mai
 			return
 		}
 
+		if len(parts) == 2 && parts[1] == "activity" {
+			switch r.Method {
+			case http.MethodGet:
+				limit, ok := parsePositiveLimit(w, r, 50)
+				if !ok {
+					return
+				}
+				items, err := store.ListActivity(projectID, limit)
+				if err != nil {
+					if strings.Contains(strings.ToLower(err.Error()), "not found") {
+						writeJSON(w, http.StatusNotFound, map[string]string{"error": "project not found"})
+						return
+					}
+					logger.Error().Err(err).Str("project_id", projectID).Msg("list project activity failed")
+					writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "list project activity failed"})
+					return
+				}
+				writeJSON(w, http.StatusOK, map[string]any{"count": len(items), "items": items})
+			case http.MethodPost:
+				var req struct {
+					TaskID    string            `json:"task_id,omitempty"`
+					Source    string            `json:"source"`
+					Agent     string            `json:"agent,omitempty"`
+					Kind      string            `json:"kind"`
+					Status    string            `json:"status,omitempty"`
+					Message   string            `json:"message,omitempty"`
+					Timestamp string            `json:"timestamp,omitempty"`
+					Meta      map[string]string `json:"meta,omitempty"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+					return
+				}
+				item, err := store.AppendActivity(projectID, project.ActivityAppendInput{
+					TaskID:    req.TaskID,
+					Source:    req.Source,
+					Agent:     req.Agent,
+					Kind:      req.Kind,
+					Status:    req.Status,
+					Message:   req.Message,
+					Timestamp: req.Timestamp,
+					Meta:      req.Meta,
+				})
+				if err != nil {
+					lower := strings.ToLower(err.Error())
+					if strings.Contains(lower, "not found") {
+						writeJSON(w, http.StatusNotFound, map[string]string{"error": "project not found"})
+						return
+					}
+					if strings.Contains(lower, "required") || strings.Contains(lower, "invalid") {
+						writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+						return
+					}
+					logger.Error().Err(err).Str("project_id", projectID).Msg("append project activity failed")
+					writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "append project activity failed"})
+					return
+				}
+				writeJSON(w, http.StatusOK, item)
+			default:
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			}
+			return
+		}
+
 		if len(parts) == 2 && parts[1] == "activate" {
 			if r.Method != http.MethodPost {
 				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)

--- a/internal/tarsserver/handler_project_test.go
+++ b/internal/tarsserver/handler_project_test.go
@@ -205,3 +205,69 @@ func TestProjectAPI_BriefFinalizeAndStateRoutes(t *testing.T) {
 		t.Fatalf("expected next_action in state patch response, got %q", statePatchRec.Body.String())
 	}
 }
+
+func TestProjectAPI_ActivityRoutes(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "workspace")
+	if err := memory.EnsureWorkspace(root); err != nil {
+		t.Fatalf("ensure workspace: %v", err)
+	}
+	store := session.NewStore(root)
+	projectStore := project.NewStore(root, nil)
+	handler := newProjectAPIHandler(projectStore, store, "", zerolog.New(io.Discard))
+
+	created, err := projectStore.Create(project.CreateInput{Name: "Ops A", Type: "operations"})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	appendReq := httptest.NewRequest(http.MethodPost, "/v1/projects/"+created.ID+"/activity", strings.NewReader(`{
+		"task_id":"task-1",
+		"source":"pm",
+		"kind":"assignment",
+		"status":"queued",
+		"message":"Assign task-1 to dev-1",
+		"meta":{"agent":"dev-1"}
+	}`))
+	appendReq.Header.Set("Content-Type", "application/json")
+	appendRec := httptest.NewRecorder()
+	handler.ServeHTTP(appendRec, appendReq)
+	if appendRec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for activity append, got %d body=%q", appendRec.Code, appendRec.Body.String())
+	}
+
+	secondReq := httptest.NewRequest(http.MethodPost, "/v1/projects/"+created.ID+"/activity", strings.NewReader(`{
+		"task_id":"task-1",
+		"source":"agent",
+		"agent":"dev-1",
+		"kind":"task_status",
+		"status":"in_progress",
+		"message":"Started implementing tests"
+	}`))
+	secondReq.Header.Set("Content-Type", "application/json")
+	secondRec := httptest.NewRecorder()
+	handler.ServeHTTP(secondRec, secondReq)
+	if secondRec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for second activity append, got %d body=%q", secondRec.Code, secondRec.Body.String())
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/v1/projects/"+created.ID+"/activity?limit=1", nil)
+	listRec := httptest.NewRecorder()
+	handler.ServeHTTP(listRec, listReq)
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for activity list, got %d body=%q", listRec.Code, listRec.Body.String())
+	}
+
+	var payload struct {
+		Count int                `json:"count"`
+		Items []project.Activity `json:"items"`
+	}
+	if err := json.Unmarshal(listRec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode activity payload: %v", err)
+	}
+	if payload.Count != 1 || len(payload.Items) != 1 {
+		t.Fatalf("expected one limited activity item, got %+v", payload)
+	}
+	if payload.Items[0].Status != "in_progress" {
+		t.Fatalf("expected newest activity first, got %+v", payload.Items)
+	}
+}


### PR DESCRIPTION
## Summary

- What problem does this PR solve?
- Adds durable per-project activity logging so dashboard and orchestration work can observe PM, agent, and delivery events. Closes #10.
- Why is this approach correct?
- It keeps the first slice small by adding only store + API behavior on top of the existing project workspace model.

## Changes

- Main user-visible or developer-visible changes:
- Add `ACTIVITY.jsonl` append/list support under each project workspace.
- Add `/v1/projects/{id}/activity` GET/POST routes with tests.
- API, config, or compatibility changes:
- New project API endpoint only; no config or breaking changes.

## Validation

- [x] `make test`
- [x] `make security-scan`
- [x] Additional manual verification, if needed
- `go test ./internal/project ./internal/tarsserver`

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [ ] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [ ] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level: low
- Rollback plan: revert commit `1152d12` or remove the new activity store/API paths.