### PR TITLE
feat: add project kanban board api

### DIFF
--- a/internal/project/activity_test.go
+++ b/internal/project/activity_test.go
@@ -11,6 +11,7 @@ func TestStoreActivityRoundtripNewestFirst(t *testing.T) {
 	root := t.TempDir()
 	times := []time.Time{
 		time.Date(2026, 3, 14, 8, 59, 0, 0, time.UTC),
+		time.Date(2026, 3, 14, 8, 59, 30, 0, time.UTC),
 		time.Date(2026, 3, 14, 9, 0, 0, 0, time.UTC),
 		time.Date(2026, 3, 14, 9, 1, 0, 0, time.UTC),
 	}

--- a/internal/project/kanban.go
+++ b/internal/project/kanban.go
@@ -1,0 +1,222 @@
+package project
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+const projectBoardDocumentName = "KANBAN.md"
+
+var defaultBoardColumns = []string{"todo", "in_progress", "review", "done"}
+
+type BoardTask struct {
+	ID             string `json:"id" yaml:"id"`
+	Title          string `json:"title" yaml:"title"`
+	Status         string `json:"status" yaml:"status"`
+	Assignee       string `json:"assignee,omitempty" yaml:"assignee,omitempty"`
+	Role           string `json:"role,omitempty" yaml:"role,omitempty"`
+	ReviewRequired bool   `json:"review_required,omitempty" yaml:"review_required,omitempty"`
+	TestCommand    string `json:"test_command,omitempty" yaml:"test_command,omitempty"`
+	BuildCommand   string `json:"build_command,omitempty" yaml:"build_command,omitempty"`
+}
+
+type Board struct {
+	ProjectID string      `json:"project_id" yaml:"project_id"`
+	UpdatedAt string      `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
+	Columns   []string    `json:"columns" yaml:"columns"`
+	Tasks     []BoardTask `json:"tasks,omitempty" yaml:"tasks,omitempty"`
+	Path      string      `json:"path,omitempty" yaml:"-"`
+}
+
+type BoardUpdateInput struct {
+	Columns []string
+	Tasks   []BoardTask
+}
+
+func (s *Store) BoardPath(projectID string) string {
+	return filepath.Join(s.workspaceDir, "projects", strings.TrimSpace(projectID), projectBoardDocumentName)
+}
+
+func (s *Store) GetBoard(projectID string) (Board, error) {
+	if s == nil {
+		return Board{}, fmt.Errorf("project store is nil")
+	}
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return Board{}, fmt.Errorf("project id is required")
+	}
+	if _, err := s.Get(projectID); err != nil {
+		return Board{}, err
+	}
+	path := s.BoardPath(projectID)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			board := defaultBoard(projectID, s.nowFn().UTC())
+			if err := s.writeBoard(board); err != nil {
+				return Board{}, err
+			}
+			return s.GetBoard(projectID)
+		}
+		return Board{}, err
+	}
+	board, err := parseBoardDocument(string(raw))
+	if err != nil {
+		return Board{}, err
+	}
+	if strings.TrimSpace(board.ProjectID) == "" {
+		board.ProjectID = projectID
+	}
+	board.Columns = normalizeBoardColumns(board.Columns)
+	board.Tasks = normalizeBoardTasks(board.Tasks, board.Columns)
+	board.Path = filepath.Dir(path)
+	return board, nil
+}
+
+func (s *Store) UpdateBoard(projectID string, input BoardUpdateInput) (Board, error) {
+	if s == nil {
+		return Board{}, fmt.Errorf("project store is nil")
+	}
+	board, err := s.GetBoard(projectID)
+	if err != nil {
+		return Board{}, err
+	}
+	if input.Columns != nil {
+		board.Columns = normalizeBoardColumns(input.Columns)
+	}
+	if input.Tasks != nil {
+		board.Tasks = normalizeBoardTasks(input.Tasks, board.Columns)
+	}
+	board.UpdatedAt = s.nowFn().UTC().Format(time.RFC3339)
+	if err := validateBoard(board); err != nil {
+		return Board{}, err
+	}
+	if err := s.writeBoard(board); err != nil {
+		return Board{}, err
+	}
+	return s.GetBoard(projectID)
+}
+
+func (s *Store) writeBoard(board Board) error {
+	board.ProjectID = strings.TrimSpace(board.ProjectID)
+	if board.ProjectID == "" {
+		return fmt.Errorf("project id is required")
+	}
+	board.Columns = normalizeBoardColumns(board.Columns)
+	board.Tasks = normalizeBoardTasks(board.Tasks, board.Columns)
+	if err := validateBoard(board); err != nil {
+		return err
+	}
+	dir := filepath.Dir(s.BoardPath(board.ProjectID))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(s.BoardPath(board.ProjectID), []byte(buildBoardDocument(board)), 0o644)
+}
+
+func defaultBoard(projectID string, now time.Time) Board {
+	return Board{
+		ProjectID: strings.TrimSpace(projectID),
+		UpdatedAt: now.UTC().Format(time.RFC3339),
+		Columns:   append([]string(nil), defaultBoardColumns...),
+		Tasks:     []BoardTask{},
+	}
+}
+
+func parseBoardDocument(raw string) (Board, error) {
+	metaRaw, _, hasMeta, err := splitFrontmatter(raw)
+	if err != nil {
+		return Board{}, err
+	}
+	if !hasMeta {
+		return Board{Columns: append([]string(nil), defaultBoardColumns...)}, nil
+	}
+	var item Board
+	if err := yaml.Unmarshal([]byte(metaRaw), &item); err != nil {
+		return Board{}, fmt.Errorf("parse board frontmatter: %w", err)
+	}
+	return item, nil
+}
+
+func buildBoardDocument(board Board) string {
+	item := Board{
+		ProjectID: strings.TrimSpace(board.ProjectID),
+		UpdatedAt: strings.TrimSpace(board.UpdatedAt),
+		Columns:   normalizeBoardColumns(board.Columns),
+		Tasks:     normalizeBoardTasks(board.Tasks, board.Columns),
+	}
+	meta, _ := yaml.Marshal(item)
+	return "---\n" + string(meta) + "---\n"
+}
+
+func validateBoard(board Board) error {
+	if strings.TrimSpace(board.ProjectID) == "" {
+		return fmt.Errorf("project id is required")
+	}
+	for _, task := range board.Tasks {
+		if strings.TrimSpace(task.ID) == "" {
+			return fmt.Errorf("task id is required")
+		}
+		if strings.TrimSpace(task.Title) == "" {
+			return fmt.Errorf("task title is required")
+		}
+	}
+	return nil
+}
+
+func normalizeBoardColumns(raw []string) []string {
+	if len(raw) == 0 {
+		return append([]string(nil), defaultBoardColumns...)
+	}
+	out := make([]string, 0, len(raw))
+	seen := map[string]struct{}{}
+	for _, item := range raw {
+		trimmed := strings.ToLower(strings.TrimSpace(item))
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	if len(out) == 0 {
+		return append([]string(nil), defaultBoardColumns...)
+	}
+	return out
+}
+
+func normalizeBoardTasks(raw []BoardTask, columns []string) []BoardTask {
+	if len(raw) == 0 {
+		return []BoardTask{}
+	}
+	allowedStatus := map[string]struct{}{}
+	normalizedColumns := normalizeBoardColumns(columns)
+	for _, col := range normalizedColumns {
+		allowedStatus[col] = struct{}{}
+	}
+	out := make([]BoardTask, 0, len(raw))
+	for _, task := range raw {
+		item := BoardTask{
+			ID:             strings.TrimSpace(task.ID),
+			Title:          strings.TrimSpace(task.Title),
+			Status:         strings.ToLower(strings.TrimSpace(task.Status)),
+			Assignee:       strings.TrimSpace(task.Assignee),
+			Role:           strings.TrimSpace(task.Role),
+			ReviewRequired: task.ReviewRequired,
+			TestCommand:    strings.TrimSpace(task.TestCommand),
+			BuildCommand:   strings.TrimSpace(task.BuildCommand),
+		}
+		if _, ok := allowedStatus[item.Status]; !ok {
+			item.Status = normalizedColumns[0]
+		}
+		out = append(out, item)
+	}
+	return out
+}

--- a/internal/project/kanban_test.go
+++ b/internal/project/kanban_test.go
@@ -1,0 +1,87 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestStoreCreateSeedsKanbanBoard(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 3, 14, 12, 0, 0, 0, time.UTC)
+	store := NewStore(root, func() time.Time { return now })
+
+	created, err := store.Create(CreateInput{Name: "Kanban Project"})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(root, "projects", created.ID, "KANBAN.md")); err != nil {
+		t.Fatalf("expected KANBAN.md to be created: %v", err)
+	}
+
+	board, err := store.GetBoard(created.ID)
+	if err != nil {
+		t.Fatalf("get board: %v", err)
+	}
+	if board.ProjectID != created.ID {
+		t.Fatalf("expected project id %q, got %q", created.ID, board.ProjectID)
+	}
+	if got := len(board.Columns); got != 4 {
+		t.Fatalf("expected 4 default columns, got %d", got)
+	}
+}
+
+func TestStoreBoardRoundtrip(t *testing.T) {
+	root := t.TempDir()
+	times := []time.Time{
+		time.Date(2026, 3, 14, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, 3, 14, 12, 5, 0, 0, time.UTC),
+	}
+	nowIndex := 0
+	store := NewStore(root, func() time.Time {
+		current := times[nowIndex]
+		if nowIndex < len(times)-1 {
+			nowIndex++
+		}
+		return current
+	})
+
+	created, err := store.Create(CreateInput{Name: "Kanban Project"})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	updated, err := store.UpdateBoard(created.ID, BoardUpdateInput{
+		Tasks: []BoardTask{
+			{
+				ID:             "task-1",
+				Title:          "Build activity feed",
+				Status:         "in_progress",
+				Assignee:       "dev-1",
+				Role:           "developer",
+				ReviewRequired: true,
+				TestCommand:    "go test ./internal/project",
+				BuildCommand:   "go test ./internal/tarsserver",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("update board: %v", err)
+	}
+	if updated.UpdatedAt != times[1].UTC().Format(time.RFC3339) {
+		t.Fatalf("unexpected updated_at: %q", updated.UpdatedAt)
+	}
+	if len(updated.Tasks) != 1 || updated.Tasks[0].Status != "in_progress" {
+		t.Fatalf("unexpected updated tasks: %+v", updated.Tasks)
+	}
+
+	loaded, err := store.GetBoard(created.ID)
+	if err != nil {
+		t.Fatalf("get board: %v", err)
+	}
+	if len(loaded.Tasks) != 1 || loaded.Tasks[0].Assignee != "dev-1" {
+		t.Fatalf("unexpected loaded tasks: %+v", loaded.Tasks)
+	}
+}

--- a/internal/project/store.go
+++ b/internal/project/store.go
@@ -97,6 +97,9 @@ func (s *Store) Create(input CreateInput) (Project, error) {
 	if err := s.write(project); err != nil {
 		return Project{}, err
 	}
+	if err := s.writeBoard(defaultBoard(project.ID, s.nowFn().UTC())); err != nil {
+		return Project{}, err
+	}
 	if input.CloneRepo && project.GitRepo != "" {
 		if err := cloneProjectRepo(filepath.Join(s.workspaceDir, "projects", project.ID), project.GitRepo); err != nil {
 			return Project{}, err

--- a/internal/tarsserver/handler_project.go
+++ b/internal/tarsserver/handler_project.go
@@ -370,6 +370,54 @@ func newProjectAPIHandler(store *project.Store, sessionStore *session.Store, mai
 			return
 		}
 
+		if len(parts) == 2 && parts[1] == "board" {
+			switch r.Method {
+			case http.MethodGet:
+				item, err := store.GetBoard(projectID)
+				if err != nil {
+					if strings.Contains(strings.ToLower(err.Error()), "not found") {
+						writeJSON(w, http.StatusNotFound, map[string]string{"error": "project not found"})
+						return
+					}
+					logger.Error().Err(err).Str("project_id", projectID).Msg("get project board failed")
+					writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "get project board failed"})
+					return
+				}
+				writeJSON(w, http.StatusOK, item)
+			case http.MethodPatch:
+				var req struct {
+					Columns []string            `json:"columns,omitempty"`
+					Tasks   []project.BoardTask `json:"tasks,omitempty"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+					return
+				}
+				item, err := store.UpdateBoard(projectID, project.BoardUpdateInput{
+					Columns: req.Columns,
+					Tasks:   req.Tasks,
+				})
+				if err != nil {
+					lower := strings.ToLower(err.Error())
+					if strings.Contains(lower, "not found") {
+						writeJSON(w, http.StatusNotFound, map[string]string{"error": "project not found"})
+						return
+					}
+					if strings.Contains(lower, "required") || strings.Contains(lower, "invalid") {
+						writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+						return
+					}
+					logger.Error().Err(err).Str("project_id", projectID).Msg("update project board failed")
+					writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "update project board failed"})
+					return
+				}
+				writeJSON(w, http.StatusOK, item)
+			default:
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			}
+			return
+		}
+
 		if len(parts) == 2 && parts[1] == "activate" {
 			if r.Method != http.MethodPost {
 				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)

--- a/internal/tarsserver/handler_project_test.go
+++ b/internal/tarsserver/handler_project_test.go
@@ -271,3 +271,54 @@ func TestProjectAPI_ActivityRoutes(t *testing.T) {
 		t.Fatalf("expected newest activity first, got %+v", payload.Items)
 	}
 }
+
+func TestProjectAPI_BoardRoutes(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "workspace")
+	if err := memory.EnsureWorkspace(root); err != nil {
+		t.Fatalf("ensure workspace: %v", err)
+	}
+	store := session.NewStore(root)
+	projectStore := project.NewStore(root, nil)
+	handler := newProjectAPIHandler(projectStore, store, "", zerolog.New(io.Discard))
+
+	created, err := projectStore.Create(project.CreateInput{Name: "Ops A", Type: "operations"})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/v1/projects/"+created.ID+"/board", nil)
+	getRec := httptest.NewRecorder()
+	handler.ServeHTTP(getRec, getReq)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for board get, got %d body=%q", getRec.Code, getRec.Body.String())
+	}
+
+	patchReq := httptest.NewRequest(http.MethodPatch, "/v1/projects/"+created.ID+"/board", strings.NewReader(`{
+		"tasks":[
+			{
+				"id":"task-1",
+				"title":"Build dashboard",
+				"status":"review",
+				"assignee":"dev-1",
+				"role":"developer",
+				"review_required":true,
+				"test_command":"go test ./internal/tarsserver",
+				"build_command":"go test ./..."
+			}
+		]
+	}`))
+	patchReq.Header.Set("Content-Type", "application/json")
+	patchRec := httptest.NewRecorder()
+	handler.ServeHTTP(patchRec, patchReq)
+	if patchRec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for board patch, got %d body=%q", patchRec.Code, patchRec.Body.String())
+	}
+
+	var board project.Board
+	if err := json.Unmarshal(patchRec.Body.Bytes(), &board); err != nil {
+		t.Fatalf("decode patched board: %v", err)
+	}
+	if len(board.Tasks) != 1 || board.Tasks[0].Status != "review" {
+		t.Fatalf("unexpected patched board: %+v", board)
+	}
+}


### PR DESCRIPTION
## Summary

- What problem does this PR solve?
- Adds durable project board storage so PM and agents can persist task state in the workspace. Closes #14.
- Why is this approach correct?
- It introduces a small board model and API on top of the existing project store without coupling it to orchestration yet.

## Changes

- Main user-visible or developer-visible changes:
- Seed `KANBAN.md` for each new project.
- Add `GET/PATCH /v1/projects/{project_id}/board`.
- Normalize and persist board columns and tasks in the project workspace.
- API, config, or compatibility changes:
- New project API endpoint only; no config or breaking changes.

## Validation

- [x] `make test`
- [x] `make security-scan`
- [x] Additional manual verification, if needed
- `go test ./internal/project ./internal/tarsserver`

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [ ] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [ ] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level: low
- Rollback plan: revert commit `5feed89` or remove the board document/API paths.