### PR TITLE
feat: wire automatic project activity events

### DIFF
--- a/internal/project/activity.go
+++ b/internal/project/activity.go
@@ -12,6 +12,29 @@ import (
 
 const projectActivityDocumentName = "ACTIVITY.jsonl"
 
+const defaultRecentActivityLimit = 50
+
+const (
+	ActivitySourceSystem = "system"
+	ActivitySourcePM     = "pm"
+	ActivitySourceAgent  = "agent"
+)
+
+const (
+	ActivityKindAssignment       = "assignment"
+	ActivityKindTaskStatus       = "task_status"
+	ActivityKindProjectCreated   = "project_created"
+	ActivityKindProjectUpdated   = "project_updated"
+	ActivityKindProjectArchived  = "project_archived"
+	ActivityKindStateChanged     = "state_changed"
+	ActivityKindBoardTaskCreated = "board_task_created"
+	ActivityKindBoardTaskUpdated = "board_task_updated"
+	ActivityKindTestStatus       = "test_status"
+	ActivityKindBuildStatus      = "build_status"
+	ActivityKindIssueStatus      = "issue_status"
+	ActivityKindPRStatus         = "pr_status"
+)
+
 type Activity struct {
 	ID        string            `json:"id"`
 	ProjectID string            `json:"project_id"`
@@ -55,7 +78,7 @@ func (s *Store) AppendActivity(projectID string, input ActivityAppendInput) (Act
 	if source == "" {
 		return Activity{}, fmt.Errorf("source is required")
 	}
-	kind := strings.ToLower(strings.TrimSpace(input.Kind))
+	kind := normalizeActivityKind(input.Kind)
 	if kind == "" {
 		return Activity{}, fmt.Errorf("kind is required")
 	}
@@ -99,6 +122,10 @@ func (s *Store) AppendActivity(projectID string, input ActivityAppendInput) (Act
 		return Activity{}, err
 	}
 	return item, nil
+}
+
+func (s *Store) ListRecentActivity(projectID string) ([]Activity, error) {
+	return s.ListActivity(projectID, defaultRecentActivityLimit)
 }
 
 func (s *Store) ListActivity(projectID string, limit int) ([]Activity, error) {
@@ -176,4 +203,8 @@ func normalizeActivityMeta(raw map[string]string) map[string]string {
 		return nil
 	}
 	return out
+}
+
+func normalizeActivityKind(raw string) string {
+	return strings.ToLower(strings.TrimSpace(raw))
 }

--- a/internal/project/activity_auto.go
+++ b/internal/project/activity_auto.go
@@ -1,0 +1,69 @@
+package project
+
+import (
+	"fmt"
+	"strings"
+)
+
+func (s *Store) appendSystemActivity(projectID string, input ActivityAppendInput) error {
+	if s == nil {
+		return fmt.Errorf("project store is nil")
+	}
+	if strings.TrimSpace(input.Source) == "" {
+		input.Source = ActivitySourceSystem
+	}
+	_, err := s.AppendActivity(projectID, input)
+	return err
+}
+
+func projectActivityChanged(before, after Project) bool {
+	return before.Name != after.Name ||
+		before.Type != after.Type ||
+		before.Status != after.Status ||
+		before.GitRepo != after.GitRepo ||
+		before.Objective != after.Objective ||
+		before.Body != after.Body ||
+		!stringSlicesEqual(before.ToolsAllow, after.ToolsAllow) ||
+		!stringSlicesEqual(before.ToolsAllowGroups, after.ToolsAllowGroups) ||
+		!stringSlicesEqual(before.ToolsAllowPatterns, after.ToolsAllowPatterns) ||
+		!stringSlicesEqual(before.ToolsDeny, after.ToolsDeny) ||
+		before.ToolsRiskMax != after.ToolsRiskMax ||
+		!stringSlicesEqual(before.SkillsAllow, after.SkillsAllow) ||
+		!stringSlicesEqual(before.MCPServers, after.MCPServers) ||
+		!stringSlicesEqual(before.SecretsRefs, after.SecretsRefs)
+}
+
+func projectStateActivityChanged(before, after ProjectState) bool {
+	return before.Goal != after.Goal ||
+		before.Phase != after.Phase ||
+		before.Status != after.Status ||
+		before.NextAction != after.NextAction ||
+		!stringSlicesEqual(before.RemainingTasks, after.RemainingTasks) ||
+		before.CompletionSummary != after.CompletionSummary ||
+		before.LastRunSummary != after.LastRunSummary ||
+		before.LastRunAt != after.LastRunAt ||
+		before.StopReason != after.StopReason ||
+		before.Body != after.Body
+}
+
+func boardTaskActivityChanged(before, after BoardTask) bool {
+	return before.Title != after.Title ||
+		before.Status != after.Status ||
+		before.Assignee != after.Assignee ||
+		before.Role != after.Role ||
+		before.ReviewRequired != after.ReviewRequired ||
+		before.TestCommand != after.TestCommand ||
+		before.BuildCommand != after.BuildCommand
+}
+
+func stringSlicesEqual(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/project/activity_test.go
+++ b/internal/project/activity_test.go
@@ -67,16 +67,47 @@ func TestStoreActivityRoundtripNewestFirst(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list activity: %v", err)
 	}
-	if len(items) != 2 {
-		t.Fatalf("expected 2 activity items, got %d", len(items))
+	if len(items) != 3 {
+		t.Fatalf("expected 3 activity items, got %d", len(items))
 	}
 	if items[0].Status != "in_progress" {
 		t.Fatalf("expected newest item first, got %+v", items)
 	}
 	if items[1].Source != "pm" {
-		t.Fatalf("expected older item second, got %+v", items)
+		t.Fatalf("expected manual pm item second, got %+v", items)
 	}
-	if items[0].Timestamp <= items[1].Timestamp {
-		t.Fatalf("expected newest timestamp first, got %+v", items)
+	if items[2].Kind != ActivityKindProjectCreated {
+		t.Fatalf("expected oldest create item, got %+v", items)
+	}
+}
+
+func TestStoreListRecentActivityReturnsLatest50Items(t *testing.T) {
+	root := t.TempDir()
+	store := NewStore(root, func() time.Time {
+		return time.Date(2026, 3, 14, 9, 0, 0, 0, time.UTC)
+	})
+
+	created, err := store.Create(CreateInput{Name: "Recent Activity Project"})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	for i := 0; i < 55; i++ {
+		if _, err := store.AppendActivity(created.ID, ActivityAppendInput{
+			Source:  "agent",
+			Kind:    ActivityKindTaskStatus,
+			Status:  "in_progress",
+			Message: "item",
+		}); err != nil {
+			t.Fatalf("append activity %d: %v", i, err)
+		}
+	}
+
+	items, err := store.ListRecentActivity(created.ID)
+	if err != nil {
+		t.Fatalf("list recent activity: %v", err)
+	}
+	if len(items) != 50 {
+		t.Fatalf("expected 50 recent items, got %d", len(items))
 	}
 }

--- a/internal/project/brief_state.go
+++ b/internal/project/brief_state.go
@@ -188,6 +188,7 @@ func (s *Store) UpdateState(projectID string, input ProjectStateUpdateInput) (Pr
 		return ProjectState{}, fmt.Errorf("project id is required")
 	}
 	item, err := s.GetState(projectID)
+	hadState := err == nil
 	if err != nil {
 		if !strings.Contains(strings.ToLower(err.Error()), "project state not found") {
 			return ProjectState{}, err
@@ -197,6 +198,7 @@ func (s *Store) UpdateState(projectID string, input ProjectStateUpdateInput) (Pr
 		}
 		item = ProjectState{ProjectID: projectID, Phase: "planning", Status: "active"}
 	}
+	before := item
 	applyProjectStateUpdateInput(&item, input)
 	item.ProjectID = projectID
 	item.Phase = normalizeProjectStatePhase(item.Phase)
@@ -204,7 +206,29 @@ func (s *Store) UpdateState(projectID string, input ProjectStateUpdateInput) (Pr
 	if err := s.writeState(item); err != nil {
 		return ProjectState{}, err
 	}
-	return s.GetState(projectID)
+	updated, err := s.GetState(projectID)
+	if err != nil {
+		return ProjectState{}, err
+	}
+	if hadState && !projectStateActivityChanged(before, updated) {
+		return updated, nil
+	}
+	message := "Project state updated"
+	if !hadState {
+		message = "Project state initialized"
+	}
+	if err := s.appendSystemActivity(projectID, ActivityAppendInput{
+		Kind:    ActivityKindStateChanged,
+		Status:  updated.Status,
+		Message: message,
+		Meta: map[string]string{
+			"phase":       updated.Phase,
+			"next_action": updated.NextAction,
+		},
+	}); err != nil {
+		return ProjectState{}, err
+	}
+	return updated, nil
 }
 
 func (s *Store) FinalizeBrief(id string, sessionStore *session.Store) (Project, Brief, error) {

--- a/internal/project/brief_state_test.go
+++ b/internal/project/brief_state_test.go
@@ -116,6 +116,20 @@ func TestStoreStateRoundtripAndNormalization(t *testing.T) {
 	if got := strings.Join(loaded.RemainingTasks, ","); got != "Summarize blockers,Define next checkpoint" {
 		t.Fatalf("unexpected remaining_tasks: %q", got)
 	}
+
+	activity, err := store.ListActivity(created.ID, 10)
+	if err != nil {
+		t.Fatalf("list activity: %v", err)
+	}
+	if len(activity) < 2 {
+		t.Fatalf("expected state activity to be recorded, got %d items", len(activity))
+	}
+	if activity[0].Kind != ActivityKindStateChanged {
+		t.Fatalf("expected newest activity kind %q, got %+v", ActivityKindStateChanged, activity[0])
+	}
+	if activity[0].Status != "paused" {
+		t.Fatalf("expected state activity status paused, got %+v", activity[0])
+	}
 }
 
 func TestStoreStatePreservesDraftingPhase(t *testing.T) {

--- a/internal/project/kanban.go
+++ b/internal/project/kanban.go
@@ -86,6 +86,7 @@ func (s *Store) UpdateBoard(projectID string, input BoardUpdateInput) (Board, er
 	if err != nil {
 		return Board{}, err
 	}
+	previous := board
 	if input.Columns != nil {
 		board.Columns = normalizeBoardColumns(input.Columns)
 	}
@@ -99,7 +100,50 @@ func (s *Store) UpdateBoard(projectID string, input BoardUpdateInput) (Board, er
 	if err := s.writeBoard(board); err != nil {
 		return Board{}, err
 	}
-	return s.GetBoard(projectID)
+	updated, err := s.GetBoard(projectID)
+	if err != nil {
+		return Board{}, err
+	}
+	previousTasks := make(map[string]BoardTask, len(previous.Tasks))
+	for _, task := range previous.Tasks {
+		previousTasks[task.ID] = task
+	}
+	for _, task := range updated.Tasks {
+		before, existed := previousTasks[task.ID]
+		if !existed {
+			if err := s.appendSystemActivity(projectID, ActivityAppendInput{
+				TaskID:  task.ID,
+				Kind:    ActivityKindBoardTaskCreated,
+				Status:  task.Status,
+				Message: "Board task created",
+				Meta: map[string]string{
+					"title":    task.Title,
+					"assignee": task.Assignee,
+					"role":     task.Role,
+				},
+			}); err != nil {
+				return Board{}, err
+			}
+			continue
+		}
+		if !boardTaskActivityChanged(before, task) {
+			continue
+		}
+		if err := s.appendSystemActivity(projectID, ActivityAppendInput{
+			TaskID:  task.ID,
+			Kind:    ActivityKindBoardTaskUpdated,
+			Status:  task.Status,
+			Message: "Board task updated",
+			Meta: map[string]string{
+				"title":    task.Title,
+				"assignee": task.Assignee,
+				"role":     task.Role,
+			},
+		}); err != nil {
+			return Board{}, err
+		}
+	}
+	return updated, nil
 }
 
 func (s *Store) writeBoard(board Board) error {

--- a/internal/project/kanban_test.go
+++ b/internal/project/kanban_test.go
@@ -84,4 +84,37 @@ func TestStoreBoardRoundtrip(t *testing.T) {
 	if len(loaded.Tasks) != 1 || loaded.Tasks[0].Assignee != "dev-1" {
 		t.Fatalf("unexpected loaded tasks: %+v", loaded.Tasks)
 	}
+
+	second, err := store.UpdateBoard(created.ID, BoardUpdateInput{
+		Tasks: []BoardTask{
+			{
+				ID:             "task-1",
+				Title:          "Build activity feed",
+				Status:         "review",
+				Assignee:       "dev-1",
+				Role:           "developer",
+				ReviewRequired: true,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("update board second time: %v", err)
+	}
+	if second.Tasks[0].Status != "review" {
+		t.Fatalf("expected review status, got %+v", second.Tasks[0])
+	}
+
+	activity, err := store.ListActivity(created.ID, 10)
+	if err != nil {
+		t.Fatalf("list activity: %v", err)
+	}
+	if len(activity) < 3 {
+		t.Fatalf("expected board activities, got %d items", len(activity))
+	}
+	if activity[0].Kind != ActivityKindBoardTaskUpdated {
+		t.Fatalf("expected newest board update activity, got %+v", activity[0])
+	}
+	if activity[1].Kind != ActivityKindBoardTaskCreated {
+		t.Fatalf("expected board task create activity next, got %+v", activity[1])
+	}
 }

--- a/internal/project/store.go
+++ b/internal/project/store.go
@@ -105,6 +105,13 @@ func (s *Store) Create(input CreateInput) (Project, error) {
 			return Project{}, err
 		}
 	}
+	if err := s.appendSystemActivity(project.ID, ActivityAppendInput{
+		Kind:    ActivityKindProjectCreated,
+		Status:  project.Status,
+		Message: "Project created",
+	}); err != nil {
+		return Project{}, err
+	}
 	return s.Get(project.ID)
 }
 
@@ -186,6 +193,7 @@ func (s *Store) Update(id string, input UpdateInput) (Project, error) {
 	if err != nil {
 		return Project{}, err
 	}
+	before := item
 	if err := applyUpdateInput(&item, input); err != nil {
 		return Project{}, err
 	}
@@ -193,7 +201,27 @@ func (s *Store) Update(id string, input UpdateInput) (Project, error) {
 	if err := s.write(item); err != nil {
 		return Project{}, err
 	}
-	return s.Get(item.ID)
+	updated, err := s.Get(item.ID)
+	if err != nil {
+		return Project{}, err
+	}
+	if !projectActivityChanged(before, updated) {
+		return updated, nil
+	}
+	kind := ActivityKindProjectUpdated
+	message := "Project updated"
+	if before.Status != updated.Status && updated.Status == "archived" {
+		kind = ActivityKindProjectArchived
+		message = "Project archived"
+	}
+	if err := s.appendSystemActivity(updated.ID, ActivityAppendInput{
+		Kind:    kind,
+		Status:  updated.Status,
+		Message: message,
+	}); err != nil {
+		return Project{}, err
+	}
+	return updated, nil
 }
 
 func (s *Store) Archive(id string) (Project, error) {

--- a/internal/project/store_test.go
+++ b/internal/project/store_test.go
@@ -103,6 +103,23 @@ func TestStoreUpdateAndArchive(t *testing.T) {
 	if archived.Status != "archived" {
 		t.Fatalf("expected archived status, got %q", archived.Status)
 	}
+
+	activity, err := store.ListActivity(created.ID, 10)
+	if err != nil {
+		t.Fatalf("list activity: %v", err)
+	}
+	if len(activity) < 3 {
+		t.Fatalf("expected at least 3 activity items, got %d", len(activity))
+	}
+	if activity[0].Kind != ActivityKindProjectArchived {
+		t.Fatalf("expected newest archived activity, got %+v", activity[0])
+	}
+	if activity[1].Kind != ActivityKindProjectUpdated {
+		t.Fatalf("expected update activity second, got %+v", activity[1])
+	}
+	if activity[len(activity)-1].Kind != ActivityKindProjectCreated {
+		t.Fatalf("expected oldest created activity, got %+v", activity[len(activity)-1])
+	}
 }
 
 func TestStoreUpdatePreservesExistingCollectionsWhenInputSlicesAreEmpty(t *testing.T) {

--- a/internal/tarsserver/dashboard.go
+++ b/internal/tarsserver/dashboard.go
@@ -282,7 +282,7 @@ func newProjectDashboardHandler(store *project.Store, broker *projectDashboardBr
 		if current, err := store.GetState(route.ProjectID); err == nil {
 			state = &current
 		}
-		activity, err := store.ListActivity(route.ProjectID, 20)
+		activity, err := store.ListRecentActivity(route.ProjectID)
 		if err != nil {
 			logger.Error().Err(err).Str("project_id", route.ProjectID).Msg("list project activity for dashboard failed")
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "load dashboard failed"})

--- a/internal/tarsserver/handler_project.go
+++ b/internal/tarsserver/handler_project.go
@@ -173,6 +173,7 @@ func newProjectAPIHandler(store *project.Store, sessionStore *session.Store, mai
 				return
 			}
 			writeJSON(w, http.StatusOK, created)
+			dashboardBroker.publish(newProjectDashboardEvent(created.ID, "activity"))
 		default:
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		}
@@ -225,6 +226,7 @@ func newProjectAPIHandler(store *project.Store, sessionStore *session.Store, mai
 					writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "update project failed"})
 					return
 				}
+				dashboardBroker.publish(newProjectDashboardEvent(projectID, "activity"))
 				writeJSON(w, http.StatusOK, updated)
 			case http.MethodDelete:
 				if _, err := store.Archive(projectID); err != nil {
@@ -236,6 +238,7 @@ func newProjectAPIHandler(store *project.Store, sessionStore *session.Store, mai
 					writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "archive project failed"})
 					return
 				}
+				dashboardBroker.publish(newProjectDashboardEvent(projectID, "activity"))
 				w.WriteHeader(http.StatusNoContent)
 			default:
 				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -299,6 +302,7 @@ func newProjectAPIHandler(store *project.Store, sessionStore *session.Store, mai
 					writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "update project state failed"})
 					return
 				}
+				dashboardBroker.publish(newProjectDashboardEvent(projectID, "activity"))
 				writeJSON(w, http.StatusOK, updated)
 			default:
 				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)

--- a/internal/tarsserver/handler_project_test.go
+++ b/internal/tarsserver/handler_project_test.go
@@ -150,7 +150,8 @@ func TestProjectAPI_BriefFinalizeAndStateRoutes(t *testing.T) {
 	}
 
 	projectStore := project.NewStore(root, nil)
-	handler := newProjectAPIHandler(projectStore, store, mainSess.ID, nil, zerolog.New(io.Discard))
+	broker := newProjectDashboardBroker()
+	handler := newProjectAPIHandler(projectStore, store, mainSess.ID, broker, zerolog.New(io.Discard))
 
 	briefReq := httptest.NewRequest(http.MethodPatch, "/v1/project-briefs/"+mainSess.ID, strings.NewReader(`{
 		"title":"Orbit Hearts",
@@ -204,6 +205,30 @@ func TestProjectAPI_BriefFinalizeAndStateRoutes(t *testing.T) {
 	}
 	if !strings.Contains(statePatchRec.Body.String(), "Draft chapter one") {
 		t.Fatalf("expected next_action in state patch response, got %q", statePatchRec.Body.String())
+	}
+
+	events, unsubscribe := broker.subscribe()
+	defer unsubscribe()
+
+	statePatchReq2 := httptest.NewRequest(http.MethodPatch, "/v1/projects/"+payload.Project.ID+"/state", strings.NewReader(`{
+		"phase":"review",
+		"status":"paused",
+		"next_action":"Wait for feedback"
+	}`))
+	statePatchReq2.Header.Set("Content-Type", "application/json")
+	statePatchRec2 := httptest.NewRecorder()
+	handler.ServeHTTP(statePatchRec2, statePatchReq2)
+	if statePatchRec2.Code != http.StatusOK {
+		t.Fatalf("expected 200 for second state patch, got %d body=%q", statePatchRec2.Code, statePatchRec2.Body.String())
+	}
+
+	select {
+	case evt := <-events:
+		if evt.ProjectID != payload.Project.ID || evt.Kind != "activity" {
+			t.Fatalf("unexpected dashboard event: %+v", evt)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected dashboard event for state patch")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Append project activity automatically for lifecycle, state, and board-task changes instead of relying only on manual activity POSTs
- Standardize activity kind names for project, task, test, build, issue, and PR events so later orchestration code can write to a consistent timeline
- Closes #20

## Changes

- Main user-visible or developer-visible changes:
  - Add standardized project activity kind constants and a recent-activity read helper capped at 50 items
  - Automatically append activity for project create/update/archive, state updates, and board task create/update changes
  - Refresh dashboard consumers from the recent-activity read path and emit dashboard activity refresh signals on state and lifecycle API updates
- API, config, or compatibility changes:
  - No breaking API changes
  - No config changes

## Validation

- [x] `make test`
- [x] `make security-scan`
- [x] Additional manual verification, if needed
  - `go test ./internal/project ./internal/tarsserver`

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [ ] Docs and `CHANGELOG.md` updated when needed
- [ ] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [ ] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level: Medium-low. The change adds automatic timeline writes in the project store and extra dashboard refresh signals on project API routes.
- Rollback plan: Revert this PR to return to manual activity writes only.

## Notes

- `.docs/TODO.md` was updated locally to track progress, but `.docs/` is currently gitignored and is not part of this PR.