### PR TITLE
feat: add project task orchestrator

### DIFF
--- a/internal/project/orchestrator.go
+++ b/internal/project/orchestrator.go
@@ -1,0 +1,251 @@
+package project
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+type TaskRunStatus string
+
+const (
+	TaskRunStatusAccepted  TaskRunStatus = "accepted"
+	TaskRunStatusRunning   TaskRunStatus = "running"
+	TaskRunStatusCompleted TaskRunStatus = "completed"
+	TaskRunStatusFailed    TaskRunStatus = "failed"
+	TaskRunStatusCanceled  TaskRunStatus = "canceled"
+)
+
+type TaskRunRequest struct {
+	ProjectID string
+	TaskID    string
+	Title     string
+	Prompt    string
+	Agent     string
+	Role      string
+}
+
+type TaskRun struct {
+	ID       string
+	TaskID   string
+	Agent    string
+	Status   TaskRunStatus
+	Response string
+	Error    string
+}
+
+type TaskRunner interface {
+	Start(ctx context.Context, req TaskRunRequest) (TaskRun, error)
+	Wait(ctx context.Context, runID string) (TaskRun, error)
+}
+
+type DispatchReport struct {
+	ProjectID string
+	Runs      []TaskRun
+}
+
+type Orchestrator struct {
+	store  *Store
+	runner TaskRunner
+	mu     sync.Mutex
+}
+
+func NewOrchestrator(store *Store, runner TaskRunner) *Orchestrator {
+	return &Orchestrator{
+		store:  store,
+		runner: runner,
+	}
+}
+
+func (o *Orchestrator) DispatchTodo(ctx context.Context, projectID string) (DispatchReport, error) {
+	if o == nil || o.store == nil {
+		return DispatchReport{}, fmt.Errorf("project orchestrator store is not configured")
+	}
+	if o.runner == nil {
+		return DispatchReport{}, fmt.Errorf("project orchestrator runner is not configured")
+	}
+	board, err := o.store.GetBoard(projectID)
+	if err != nil {
+		return DispatchReport{}, err
+	}
+	tasks := make([]BoardTask, 0, len(board.Tasks))
+	for _, task := range board.Tasks {
+		if task.Status == "todo" {
+			tasks = append(tasks, task)
+		}
+	}
+	report := DispatchReport{
+		ProjectID: strings.TrimSpace(projectID),
+		Runs:      make([]TaskRun, len(tasks)),
+	}
+	if len(tasks) == 0 {
+		return report, nil
+	}
+
+	var (
+		wg       sync.WaitGroup
+		firstErr error
+		errMu    sync.Mutex
+	)
+	for i, task := range tasks {
+		wg.Add(1)
+		go func(index int, task BoardTask) {
+			defer wg.Done()
+			run, runErr := o.dispatchTask(ctx, projectID, task)
+			report.Runs[index] = run
+			if runErr != nil {
+				errMu.Lock()
+				if firstErr == nil {
+					firstErr = runErr
+				}
+				errMu.Unlock()
+			}
+		}(i, task)
+	}
+	wg.Wait()
+	if firstErr != nil {
+		return report, firstErr
+	}
+	return report, nil
+}
+
+func (o *Orchestrator) dispatchTask(ctx context.Context, projectID string, task BoardTask) (TaskRun, error) {
+	if err := o.setBoardTaskStatus(projectID, task.ID, "in_progress"); err != nil {
+		return TaskRun{}, err
+	}
+	if err := o.store.appendSystemActivity(projectID, ActivityAppendInput{
+		TaskID:  task.ID,
+		Kind:    ActivityKindTaskStatus,
+		Status:  "in_progress",
+		Message: "Task dispatched to worker",
+		Meta: map[string]string{
+			"assignee": task.Assignee,
+			"role":     task.Role,
+		},
+	}); err != nil {
+		return TaskRun{}, err
+	}
+
+	run, err := o.runner.Start(ctx, TaskRunRequest{
+		ProjectID: strings.TrimSpace(projectID),
+		TaskID:    task.ID,
+		Title:     task.Title,
+		Prompt:    buildTaskPrompt(task, projectID),
+		Agent:     task.Assignee,
+		Role:      task.Role,
+	})
+	if err != nil {
+		_ = o.setBoardTaskStatus(projectID, task.ID, "todo")
+		_ = o.store.appendSystemActivity(projectID, ActivityAppendInput{
+			TaskID:  task.ID,
+			Kind:    ActivityKindTaskStatus,
+			Status:  "failed",
+			Message: "Task dispatch failed",
+		})
+		return TaskRun{}, err
+	}
+
+	finished, err := o.runner.Wait(ctx, run.ID)
+	if err != nil {
+		_ = o.setBoardTaskStatus(projectID, task.ID, "todo")
+		_ = o.store.appendSystemActivity(projectID, ActivityAppendInput{
+			TaskID:  task.ID,
+			Kind:    ActivityKindTaskStatus,
+			Status:  "failed",
+			Message: "Task run failed",
+			Meta: map[string]string{
+				"run_id": run.ID,
+			},
+		})
+		return run, err
+	}
+
+	finalStatus := "done"
+	if task.ReviewRequired {
+		finalStatus = "review"
+	}
+	if finished.Status == TaskRunStatusFailed || finished.Status == TaskRunStatusCanceled {
+		finalStatus = "todo"
+	}
+	if err := o.setBoardTaskStatus(projectID, task.ID, finalStatus); err != nil {
+		return finished, err
+	}
+
+	activityStatus := finalStatus
+	message := "Task run completed"
+	if finished.Status == TaskRunStatusFailed || finished.Status == TaskRunStatusCanceled {
+		activityStatus = "failed"
+		message = "Task run failed"
+	}
+	if err := o.store.appendSystemActivity(projectID, ActivityAppendInput{
+		TaskID:  task.ID,
+		Kind:    ActivityKindTaskStatus,
+		Status:  activityStatus,
+		Message: message,
+		Meta: map[string]string{
+			"run_id": run.ID,
+			"agent":  firstNonEmpty(strings.TrimSpace(finished.Agent), strings.TrimSpace(task.Assignee)),
+		},
+	}); err != nil {
+		return finished, err
+	}
+	return finished, nil
+}
+
+func (o *Orchestrator) setBoardTaskStatus(projectID, taskID, status string) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	board, err := o.store.GetBoard(projectID)
+	if err != nil {
+		return err
+	}
+	updated := false
+	tasks := make([]BoardTask, 0, len(board.Tasks))
+	for _, task := range board.Tasks {
+		if task.ID == strings.TrimSpace(taskID) {
+			task.Status = strings.TrimSpace(status)
+			updated = true
+		}
+		tasks = append(tasks, task)
+	}
+	if !updated {
+		return fmt.Errorf("task not found: %s", strings.TrimSpace(taskID))
+	}
+	_, err = o.store.UpdateBoard(projectID, BoardUpdateInput{
+		Columns: board.Columns,
+		Tasks:   tasks,
+	})
+	return err
+}
+
+func buildTaskPrompt(task BoardTask, projectID string) string {
+	var builder strings.Builder
+	builder.WriteString("Project ID: ")
+	builder.WriteString(strings.TrimSpace(projectID))
+	builder.WriteString("\nTask: ")
+	builder.WriteString(strings.TrimSpace(task.Title))
+	if role := strings.TrimSpace(task.Role); role != "" {
+		builder.WriteString("\nRole: ")
+		builder.WriteString(role)
+	}
+	if testCmd := strings.TrimSpace(task.TestCommand); testCmd != "" {
+		builder.WriteString("\nTest command: ")
+		builder.WriteString(testCmd)
+	}
+	if buildCmd := strings.TrimSpace(task.BuildCommand); buildCmd != "" {
+		builder.WriteString("\nBuild command: ")
+		builder.WriteString(buildCmd)
+	}
+	return builder.String()
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/internal/project/orchestrator_test.go
+++ b/internal/project/orchestrator_test.go
@@ -1,0 +1,182 @@
+package project
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+type stubTaskRunner struct {
+	mu        sync.Mutex
+	started   []TaskRunRequest
+	startedCh chan struct{}
+	waitGate  chan struct{}
+	results   map[string]TaskRun
+}
+
+func newStubTaskRunner() *stubTaskRunner {
+	return &stubTaskRunner{
+		startedCh: make(chan struct{}, 8),
+		waitGate:  make(chan struct{}),
+		results:   map[string]TaskRun{},
+	}
+}
+
+func (s *stubTaskRunner) Start(_ context.Context, req TaskRunRequest) (TaskRun, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.started = append(s.started, req)
+	runID := fmt.Sprintf("run-%s", req.TaskID)
+	if _, ok := s.results[runID]; !ok {
+		s.results[runID] = TaskRun{
+			ID:       runID,
+			TaskID:   req.TaskID,
+			Agent:    req.Agent,
+			Status:   TaskRunStatusCompleted,
+			Response: "ok",
+		}
+	}
+	s.startedCh <- struct{}{}
+	return TaskRun{
+		ID:     runID,
+		TaskID: req.TaskID,
+		Agent:  req.Agent,
+		Status: TaskRunStatusAccepted,
+	}, nil
+}
+
+func (s *stubTaskRunner) Wait(_ context.Context, runID string) (TaskRun, error) {
+	<-s.waitGate
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.results[runID], nil
+}
+
+func TestOrchestratorDispatchTodoRunsTasksInParallel(t *testing.T) {
+	store := NewStore(t.TempDir(), func() time.Time {
+		return time.Date(2026, 3, 14, 13, 0, 0, 0, time.UTC)
+	})
+	created, err := store.Create(CreateInput{Name: "Parallel Project"})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	if _, err := store.UpdateBoard(created.ID, BoardUpdateInput{
+		Tasks: []BoardTask{
+			{ID: "task-1", Title: "Build dashboard", Status: "todo", Assignee: "dev-1", Role: "developer", ReviewRequired: true},
+			{ID: "task-2", Title: "Wire activity log", Status: "todo", Assignee: "dev-2", Role: "developer", ReviewRequired: true},
+		},
+	}); err != nil {
+		t.Fatalf("seed board: %v", err)
+	}
+
+	runner := newStubTaskRunner()
+	orchestrator := NewOrchestrator(store, runner)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, runErr := orchestrator.DispatchTodo(context.Background(), created.ID)
+		errCh <- runErr
+	}()
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-runner.startedCh:
+		case <-time.After(200 * time.Millisecond):
+			t.Fatal("expected both task runs to start before waits unblock")
+		}
+	}
+	close(runner.waitGate)
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("dispatch todo: %v", err)
+	}
+
+	board, err := store.GetBoard(created.ID)
+	if err != nil {
+		t.Fatalf("get board: %v", err)
+	}
+	for _, task := range board.Tasks {
+		if task.Status != "review" {
+			t.Fatalf("expected task %s to move to review, got %+v", task.ID, task)
+		}
+	}
+
+	activity, err := store.ListActivity(created.ID, 20)
+	if err != nil {
+		t.Fatalf("list activity: %v", err)
+	}
+	if !hasTaskStatusActivity(activity, "task-1", "review") || !hasTaskStatusActivity(activity, "task-2", "review") {
+		t.Fatalf("expected completion activity for both tasks, got %+v", activity)
+	}
+}
+
+func TestOrchestratorDispatchTodoRestoresFailedTaskToTodo(t *testing.T) {
+	store := NewStore(t.TempDir(), func() time.Time {
+		return time.Date(2026, 3, 14, 13, 0, 0, 0, time.UTC)
+	})
+	created, err := store.Create(CreateInput{Name: "Failure Project"})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	if _, err := store.UpdateBoard(created.ID, BoardUpdateInput{
+		Tasks: []BoardTask{
+			{ID: "task-1", Title: "Handle failure", Status: "todo", Assignee: "dev-1", Role: "developer"},
+		},
+	}); err != nil {
+		t.Fatalf("seed board: %v", err)
+	}
+
+	runner := newStubTaskRunner()
+	runner.results["run-task-1"] = TaskRun{
+		ID:     "run-task-1",
+		TaskID: "task-1",
+		Agent:  "dev-1",
+		Status: TaskRunStatusFailed,
+		Error:  "boom",
+	}
+	orchestrator := NewOrchestrator(store, runner)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, runErr := orchestrator.DispatchTodo(context.Background(), created.ID)
+		errCh <- runErr
+	}()
+
+	select {
+	case <-runner.startedCh:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected failed task run to start")
+	}
+	close(runner.waitGate)
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("dispatch todo: %v", err)
+	}
+
+	board, err := store.GetBoard(created.ID)
+	if err != nil {
+		t.Fatalf("get board: %v", err)
+	}
+	if len(board.Tasks) != 1 || board.Tasks[0].Status != "todo" {
+		t.Fatalf("expected failed task to return to todo, got %+v", board.Tasks)
+	}
+
+	activity, err := store.ListActivity(created.ID, 20)
+	if err != nil {
+		t.Fatalf("list activity: %v", err)
+	}
+	if !hasTaskStatusActivity(activity, "task-1", "failed") {
+		t.Fatalf("expected failed task activity, got %+v", activity)
+	}
+}
+
+func hasTaskStatusActivity(items []Activity, taskID, status string) bool {
+	for _, item := range items {
+		if item.TaskID == taskID && item.Kind == ActivityKindTaskStatus && item.Status == status {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- Add a minimal project orchestrator that dispatches `todo` board tasks to agent runs in parallel.
- Update board status and activity timeline when task runs start, complete, or fail.
- Keep the runner interface gateway-agnostic so the next slice can plug in Codex and Claude Code workers.

## Changes

- Add `internal/project.Orchestrator`, `TaskRunner`, and dispatch/report types.
- Dispatch all `todo` tasks concurrently and persist `in_progress`, `review`, `done`, or failure fallback status changes.
- Record task run lifecycle events in project activity for dashboard monitoring.
- Add tests covering parallel dispatch and failed-run rollback to `todo`.
- API, config, or compatibility changes: none in this slice. This is an internal project-domain surface for the next worker-integration milestone.

## Validation

- [x] `make test`
- [x] `make security-scan`
- [x] Additional manual verification, if needed: `go test ./internal/project -run 'TestOrchestratorDispatchTodo' -count=1`

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [x] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [x] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level: low to medium. This adds a new domain orchestrator but does not yet wire external workers.
- Rollback plan: revert this PR to remove the orchestrator types and restore the pre-dispatch project domain behavior.

## Notes

- `Closes #22`
- `.docs/TODO.md` was updated locally for milestone tracking but is gitignored and not part of this PR.
