### PR TITLE
feat: add project worker profiles

### DIFF
--- a/internal/gateway/project_task_runner.go
+++ b/internal/gateway/project_task_runner.go
@@ -1,0 +1,89 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/devlikebear/tars/internal/project"
+)
+
+type projectTaskRuntime interface {
+	Spawn(ctx context.Context, req SpawnRequest) (Run, error)
+	Wait(ctx context.Context, runID string) (Run, error)
+}
+
+type ProjectTaskRunner struct {
+	runtime     projectTaskRuntime
+	workspaceID string
+}
+
+func NewProjectTaskRunner(runtime projectTaskRuntime, workspaceID string) *ProjectTaskRunner {
+	return &ProjectTaskRunner{
+		runtime:     runtime,
+		workspaceID: strings.TrimSpace(workspaceID),
+	}
+}
+
+func (r *ProjectTaskRunner) Start(ctx context.Context, req project.TaskRunRequest) (project.TaskRun, error) {
+	if r == nil || r.runtime == nil {
+		return project.TaskRun{}, fmt.Errorf("gateway project task runner is not configured")
+	}
+	workerKind := strings.ToLower(strings.TrimSpace(req.WorkerKind))
+	if workerKind == "" {
+		return project.TaskRun{}, fmt.Errorf("worker kind is required")
+	}
+
+	run, err := r.runtime.Spawn(ctx, SpawnRequest{
+		WorkspaceID: r.workspaceID,
+		ProjectID:   strings.TrimSpace(req.ProjectID),
+		Title:       strings.TrimSpace(req.Title),
+		Prompt:      strings.TrimSpace(req.Prompt),
+		Agent:       workerKind,
+	})
+	if err != nil {
+		return project.TaskRun{}, err
+	}
+	return project.TaskRun{
+		ID:         run.ID,
+		TaskID:     strings.TrimSpace(req.TaskID),
+		Agent:      run.Agent,
+		WorkerKind: workerKind,
+		Status:     mapProjectTaskRunStatus(run.Status),
+		Response:   run.Response,
+		Error:      run.Error,
+	}, nil
+}
+
+func (r *ProjectTaskRunner) Wait(ctx context.Context, runID string) (project.TaskRun, error) {
+	if r == nil || r.runtime == nil {
+		return project.TaskRun{}, fmt.Errorf("gateway project task runner is not configured")
+	}
+	run, err := r.runtime.Wait(ctx, runID)
+	if err != nil {
+		return project.TaskRun{}, err
+	}
+	return project.TaskRun{
+		ID:         run.ID,
+		Agent:      run.Agent,
+		WorkerKind: strings.ToLower(strings.TrimSpace(run.Agent)),
+		Status:     mapProjectTaskRunStatus(run.Status),
+		Response:   run.Response,
+		Error:      run.Error,
+	}, nil
+}
+
+func mapProjectTaskRunStatus(status RunStatus) project.TaskRunStatus {
+	switch status {
+	case RunStatusAccepted:
+		return project.TaskRunStatusAccepted
+	case RunStatusRunning:
+		return project.TaskRunStatusRunning
+	case RunStatusFailed:
+		return project.TaskRunStatusFailed
+	case RunStatusCanceled:
+		return project.TaskRunStatusCanceled
+	default:
+		return project.TaskRunStatusCompleted
+	}
+}

--- a/internal/gateway/project_task_runner_test.go
+++ b/internal/gateway/project_task_runner_test.go
@@ -1,0 +1,72 @@
+package gateway
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/devlikebear/tars/internal/project"
+	"github.com/devlikebear/tars/internal/session"
+)
+
+func TestProjectTaskRunner_StartAndWaitUsesSelectedWorkerKind(t *testing.T) {
+	codexExecutor, err := NewPromptExecutorWithOptions(PromptExecutorOptions{
+		Name: "codex-cli",
+		RunPrompt: func(_ context.Context, _ string, prompt string, _ []string) (string, error) {
+			return "codex:" + prompt, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("new codex executor: %v", err)
+	}
+	claudeExecutor, err := NewPromptExecutorWithOptions(PromptExecutorOptions{
+		Name: "claude-code",
+		RunPrompt: func(_ context.Context, _ string, prompt string, _ []string) (string, error) {
+			return "claude:" + prompt, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("new claude executor: %v", err)
+	}
+
+	runtime := NewRuntime(RuntimeOptions{
+		Enabled:      true,
+		SessionStore: session.NewStore(t.TempDir()),
+		Executors:    []AgentExecutor{codexExecutor, claudeExecutor},
+		DefaultAgent: "codex-cli",
+		Now: func() time.Time {
+			return time.Date(2026, 3, 14, 14, 0, 0, 0, time.UTC)
+		},
+	})
+	t.Cleanup(func() { closeGatewayRuntime(t, runtime) })
+
+	runner := NewProjectTaskRunner(runtime, "")
+	run, err := runner.Start(context.Background(), project.TaskRunRequest{
+		ProjectID:  "proj_demo",
+		TaskID:     "task-1",
+		Title:      "Implement worker integration",
+		Prompt:     "do the task",
+		Role:       "developer",
+		WorkerKind: project.WorkerKindCodexCLI,
+	})
+	if err != nil {
+		t.Fatalf("start task run: %v", err)
+	}
+	if run.WorkerKind != project.WorkerKindCodexCLI {
+		t.Fatalf("expected worker kind %q, got %+v", project.WorkerKindCodexCLI, run)
+	}
+
+	final, err := runner.Wait(context.Background(), run.ID)
+	if err != nil {
+		t.Fatalf("wait task run: %v", err)
+	}
+	if final.Status != project.TaskRunStatusCompleted {
+		t.Fatalf("expected completed status, got %+v", final)
+	}
+	if final.WorkerKind != project.WorkerKindCodexCLI {
+		t.Fatalf("expected worker kind %q after wait, got %+v", project.WorkerKindCodexCLI, final)
+	}
+	if final.Agent != project.WorkerKindCodexCLI {
+		t.Fatalf("expected gateway agent name %q, got %+v", project.WorkerKindCodexCLI, final)
+	}
+}

--- a/internal/project/activity_auto.go
+++ b/internal/project/activity_auto.go
@@ -51,6 +51,7 @@ func boardTaskActivityChanged(before, after BoardTask) bool {
 		before.Status != after.Status ||
 		before.Assignee != after.Assignee ||
 		before.Role != after.Role ||
+		before.WorkerKind != after.WorkerKind ||
 		before.ReviewRequired != after.ReviewRequired ||
 		before.TestCommand != after.TestCommand ||
 		before.BuildCommand != after.BuildCommand

--- a/internal/project/kanban.go
+++ b/internal/project/kanban.go
@@ -20,6 +20,7 @@ type BoardTask struct {
 	Status         string `json:"status" yaml:"status"`
 	Assignee       string `json:"assignee,omitempty" yaml:"assignee,omitempty"`
 	Role           string `json:"role,omitempty" yaml:"role,omitempty"`
+	WorkerKind     string `json:"worker_kind,omitempty" yaml:"worker_kind,omitempty"`
 	ReviewRequired bool   `json:"review_required,omitempty" yaml:"review_required,omitempty"`
 	TestCommand    string `json:"test_command,omitempty" yaml:"test_command,omitempty"`
 	BuildCommand   string `json:"build_command,omitempty" yaml:"build_command,omitempty"`
@@ -253,6 +254,7 @@ func normalizeBoardTasks(raw []BoardTask, columns []string) []BoardTask {
 			Status:         strings.ToLower(strings.TrimSpace(task.Status)),
 			Assignee:       strings.TrimSpace(task.Assignee),
 			Role:           strings.TrimSpace(task.Role),
+			WorkerKind:     strings.ToLower(strings.TrimSpace(task.WorkerKind)),
 			ReviewRequired: task.ReviewRequired,
 			TestCommand:    strings.TrimSpace(task.TestCommand),
 			BuildCommand:   strings.TrimSpace(task.BuildCommand),

--- a/internal/project/kanban_test.go
+++ b/internal/project/kanban_test.go
@@ -61,6 +61,7 @@ func TestStoreBoardRoundtrip(t *testing.T) {
 				Status:         "in_progress",
 				Assignee:       "dev-1",
 				Role:           "developer",
+				WorkerKind:     WorkerKindCodexCLI,
 				ReviewRequired: true,
 				TestCommand:    "go test ./internal/project",
 				BuildCommand:   "go test ./internal/tarsserver",
@@ -83,6 +84,9 @@ func TestStoreBoardRoundtrip(t *testing.T) {
 	}
 	if len(loaded.Tasks) != 1 || loaded.Tasks[0].Assignee != "dev-1" {
 		t.Fatalf("unexpected loaded tasks: %+v", loaded.Tasks)
+	}
+	if loaded.Tasks[0].WorkerKind != WorkerKindCodexCLI {
+		t.Fatalf("expected worker kind %q, got %+v", WorkerKindCodexCLI, loaded.Tasks[0])
 	}
 
 	second, err := store.UpdateBoard(created.ID, BoardUpdateInput{

--- a/internal/project/orchestrator.go
+++ b/internal/project/orchestrator.go
@@ -18,21 +18,23 @@ const (
 )
 
 type TaskRunRequest struct {
-	ProjectID string
-	TaskID    string
-	Title     string
-	Prompt    string
-	Agent     string
-	Role      string
+	ProjectID  string
+	TaskID     string
+	Title      string
+	Prompt     string
+	Agent      string
+	Role       string
+	WorkerKind string
 }
 
 type TaskRun struct {
-	ID       string
-	TaskID   string
-	Agent    string
-	Status   TaskRunStatus
-	Response string
-	Error    string
+	ID         string
+	TaskID     string
+	Agent      string
+	WorkerKind string
+	Status     TaskRunStatus
+	Response   string
+	Error      string
 }
 
 type TaskRunner interface {
@@ -111,7 +113,14 @@ func (o *Orchestrator) DispatchTodo(ctx context.Context, projectID string) (Disp
 }
 
 func (o *Orchestrator) dispatchTask(ctx context.Context, projectID string, task BoardTask) (TaskRun, error) {
-	if err := o.setBoardTaskStatus(projectID, task.ID, "in_progress"); err != nil {
+	profile, err := ResolveWorkerProfile(task)
+	if err != nil {
+		return TaskRun{}, err
+	}
+	if err := o.updateBoardTask(projectID, task.ID, func(item *BoardTask) {
+		item.Status = "in_progress"
+		item.WorkerKind = profile.Kind
+	}); err != nil {
 		return TaskRun{}, err
 	}
 	if err := o.store.appendSystemActivity(projectID, ActivityAppendInput{
@@ -120,42 +129,54 @@ func (o *Orchestrator) dispatchTask(ctx context.Context, projectID string, task 
 		Status:  "in_progress",
 		Message: "Task dispatched to worker",
 		Meta: map[string]string{
-			"assignee": task.Assignee,
-			"role":     task.Role,
+			"assignee":    task.Assignee,
+			"role":        task.Role,
+			"worker_kind": profile.Kind,
 		},
 	}); err != nil {
 		return TaskRun{}, err
 	}
 
 	run, err := o.runner.Start(ctx, TaskRunRequest{
-		ProjectID: strings.TrimSpace(projectID),
-		TaskID:    task.ID,
-		Title:     task.Title,
-		Prompt:    buildTaskPrompt(task, projectID),
-		Agent:     task.Assignee,
-		Role:      task.Role,
+		ProjectID:  strings.TrimSpace(projectID),
+		TaskID:     task.ID,
+		Title:      task.Title,
+		Prompt:     BuildTaskPrompt(task, projectID, profile),
+		Agent:      task.Assignee,
+		Role:       task.Role,
+		WorkerKind: profile.Kind,
 	})
 	if err != nil {
-		_ = o.setBoardTaskStatus(projectID, task.ID, "todo")
+		_ = o.updateBoardTask(projectID, task.ID, func(item *BoardTask) {
+			item.Status = "todo"
+			item.WorkerKind = profile.Kind
+		})
 		_ = o.store.appendSystemActivity(projectID, ActivityAppendInput{
 			TaskID:  task.ID,
 			Kind:    ActivityKindTaskStatus,
 			Status:  "failed",
 			Message: "Task dispatch failed",
+			Meta: map[string]string{
+				"worker_kind": profile.Kind,
+			},
 		})
 		return TaskRun{}, err
 	}
 
 	finished, err := o.runner.Wait(ctx, run.ID)
 	if err != nil {
-		_ = o.setBoardTaskStatus(projectID, task.ID, "todo")
+		_ = o.updateBoardTask(projectID, task.ID, func(item *BoardTask) {
+			item.Status = "todo"
+			item.WorkerKind = profile.Kind
+		})
 		_ = o.store.appendSystemActivity(projectID, ActivityAppendInput{
 			TaskID:  task.ID,
 			Kind:    ActivityKindTaskStatus,
 			Status:  "failed",
 			Message: "Task run failed",
 			Meta: map[string]string{
-				"run_id": run.ID,
+				"run_id":      run.ID,
+				"worker_kind": profile.Kind,
 			},
 		})
 		return run, err
@@ -168,7 +189,10 @@ func (o *Orchestrator) dispatchTask(ctx context.Context, projectID string, task 
 	if finished.Status == TaskRunStatusFailed || finished.Status == TaskRunStatusCanceled {
 		finalStatus = "todo"
 	}
-	if err := o.setBoardTaskStatus(projectID, task.ID, finalStatus); err != nil {
+	if err := o.updateBoardTask(projectID, task.ID, func(item *BoardTask) {
+		item.Status = finalStatus
+		item.WorkerKind = firstNonEmpty(strings.TrimSpace(finished.WorkerKind), profile.Kind)
+	}); err != nil {
 		return finished, err
 	}
 
@@ -184,8 +208,10 @@ func (o *Orchestrator) dispatchTask(ctx context.Context, projectID string, task 
 		Status:  activityStatus,
 		Message: message,
 		Meta: map[string]string{
-			"run_id": run.ID,
-			"agent":  firstNonEmpty(strings.TrimSpace(finished.Agent), strings.TrimSpace(task.Assignee)),
+			"run_id":      run.ID,
+			"agent":       firstNonEmpty(strings.TrimSpace(finished.Agent), strings.TrimSpace(task.Assignee)),
+			"assignee":    strings.TrimSpace(task.Assignee),
+			"worker_kind": firstNonEmpty(strings.TrimSpace(finished.WorkerKind), profile.Kind),
 		},
 	}); err != nil {
 		return finished, err
@@ -193,7 +219,7 @@ func (o *Orchestrator) dispatchTask(ctx context.Context, projectID string, task 
 	return finished, nil
 }
 
-func (o *Orchestrator) setBoardTaskStatus(projectID, taskID, status string) error {
+func (o *Orchestrator) updateBoardTask(projectID, taskID string, mutate func(*BoardTask)) error {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
@@ -205,7 +231,7 @@ func (o *Orchestrator) setBoardTaskStatus(projectID, taskID, status string) erro
 	tasks := make([]BoardTask, 0, len(board.Tasks))
 	for _, task := range board.Tasks {
 		if task.ID == strings.TrimSpace(taskID) {
-			task.Status = strings.TrimSpace(status)
+			mutate(&task)
 			updated = true
 		}
 		tasks = append(tasks, task)
@@ -218,27 +244,6 @@ func (o *Orchestrator) setBoardTaskStatus(projectID, taskID, status string) erro
 		Tasks:   tasks,
 	})
 	return err
-}
-
-func buildTaskPrompt(task BoardTask, projectID string) string {
-	var builder strings.Builder
-	builder.WriteString("Project ID: ")
-	builder.WriteString(strings.TrimSpace(projectID))
-	builder.WriteString("\nTask: ")
-	builder.WriteString(strings.TrimSpace(task.Title))
-	if role := strings.TrimSpace(task.Role); role != "" {
-		builder.WriteString("\nRole: ")
-		builder.WriteString(role)
-	}
-	if testCmd := strings.TrimSpace(task.TestCommand); testCmd != "" {
-		builder.WriteString("\nTest command: ")
-		builder.WriteString(testCmd)
-	}
-	if buildCmd := strings.TrimSpace(task.BuildCommand); buildCmd != "" {
-		builder.WriteString("\nBuild command: ")
-		builder.WriteString(buildCmd)
-	}
-	return builder.String()
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/project/orchestrator_test.go
+++ b/internal/project/orchestrator_test.go
@@ -101,6 +101,9 @@ func TestOrchestratorDispatchTodoRunsTasksInParallel(t *testing.T) {
 		if task.Status != "review" {
 			t.Fatalf("expected task %s to move to review, got %+v", task.ID, task)
 		}
+		if task.WorkerKind != WorkerKindCodexCLI {
+			t.Fatalf("expected task %s worker kind %q, got %+v", task.ID, WorkerKindCodexCLI, task)
+		}
 	}
 
 	activity, err := store.ListActivity(created.ID, 20)
@@ -109,6 +112,9 @@ func TestOrchestratorDispatchTodoRunsTasksInParallel(t *testing.T) {
 	}
 	if !hasTaskStatusActivity(activity, "task-1", "review") || !hasTaskStatusActivity(activity, "task-2", "review") {
 		t.Fatalf("expected completion activity for both tasks, got %+v", activity)
+	}
+	if !hasTaskStatusMeta(activity, "task-1", "worker_kind", WorkerKindCodexCLI) {
+		t.Fatalf("expected task-1 worker kind activity meta, got %+v", activity)
 	}
 }
 
@@ -175,6 +181,18 @@ func TestOrchestratorDispatchTodoRestoresFailedTaskToTodo(t *testing.T) {
 func hasTaskStatusActivity(items []Activity, taskID, status string) bool {
 	for _, item := range items {
 		if item.TaskID == taskID && item.Kind == ActivityKindTaskStatus && item.Status == status {
+			return true
+		}
+	}
+	return false
+}
+
+func hasTaskStatusMeta(items []Activity, taskID, key, want string) bool {
+	for _, item := range items {
+		if item.TaskID != taskID || item.Kind != ActivityKindTaskStatus {
+			continue
+		}
+		if item.Meta[key] == want {
 			return true
 		}
 	}

--- a/internal/project/worker_profiles.go
+++ b/internal/project/worker_profiles.go
@@ -1,0 +1,115 @@
+package project
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	WorkerKindCodexCLI   = "codex-cli"
+	WorkerKindClaudeCode = "claude-code"
+)
+
+type WorkerProfile struct {
+	Kind         string
+	ExecutorName string
+	Command      string
+	Args         []string
+	Description  string
+}
+
+func BuiltinWorkerProfiles() map[string]WorkerProfile {
+	return map[string]WorkerProfile{
+		WorkerKindCodexCLI: {
+			Kind:         WorkerKindCodexCLI,
+			ExecutorName: WorkerKindCodexCLI,
+			Command:      "codex",
+			Args:         []string{"exec", "--skip-git-repo-check", "--full-auto", "-"},
+			Description:  "Codex CLI non-interactive worker for implementation tasks",
+		},
+		WorkerKindClaudeCode: {
+			Kind:         WorkerKindClaudeCode,
+			ExecutorName: WorkerKindClaudeCode,
+			Command:      "claude",
+			Args:         []string{"-p", "--output-format", "text", "--permission-mode", "auto"},
+			Description:  "Claude Code CLI non-interactive worker for review and coordination tasks",
+		},
+	}
+}
+
+func ResolveWorkerProfile(task BoardTask) (WorkerProfile, error) {
+	profiles := BuiltinWorkerProfiles()
+	workerKind := strings.ToLower(strings.TrimSpace(task.WorkerKind))
+	if workerKind == "" {
+		switch strings.ToLower(strings.TrimSpace(task.Role)) {
+		case "reviewer", "review", "pm", "manager":
+			workerKind = WorkerKindClaudeCode
+		default:
+			workerKind = WorkerKindCodexCLI
+		}
+	}
+	profile, ok := profiles[workerKind]
+	if !ok {
+		return WorkerProfile{}, fmt.Errorf("unknown worker kind %q", workerKind)
+	}
+	return profile, nil
+}
+
+func BuildTaskPrompt(task BoardTask, projectID string, profile WorkerProfile) string {
+	var builder strings.Builder
+	workerKind := firstNonEmpty(strings.TrimSpace(task.WorkerKind), profile.Kind)
+	role := firstNonEmpty(strings.TrimSpace(task.Role), "developer")
+
+	builder.WriteString("You are a TARS project worker.\n")
+	builder.WriteString("Follow repository instructions from AGENTS.md and use relevant local skills when they apply.\n")
+	builder.WriteString("Use TDD: write or update failing tests first, implement the smallest fix, rerun verification, and summarize results.\n")
+	builder.WriteString("\nProject ID: ")
+	builder.WriteString(strings.TrimSpace(projectID))
+	builder.WriteString("\nTask ID: ")
+	builder.WriteString(strings.TrimSpace(task.ID))
+	builder.WriteString("\nTask: ")
+	builder.WriteString(strings.TrimSpace(task.Title))
+	builder.WriteString("\nRole: ")
+	builder.WriteString(role)
+	builder.WriteString("\nworker_kind: ")
+	builder.WriteString(workerKind)
+	builder.WriteString("\nexecutor: ")
+	builder.WriteString(strings.TrimSpace(profile.ExecutorName))
+	if assignee := strings.TrimSpace(task.Assignee); assignee != "" {
+		builder.WriteString("\nAssignee: ")
+		builder.WriteString(assignee)
+	}
+	if testCmd := strings.TrimSpace(task.TestCommand); testCmd != "" {
+		builder.WriteString("\nTest command: ")
+		builder.WriteString(testCmd)
+	}
+	if buildCmd := strings.TrimSpace(task.BuildCommand); buildCmd != "" {
+		builder.WriteString("\nBuild command: ")
+		builder.WriteString(buildCmd)
+	}
+
+	builder.WriteString("\n\n")
+	switch strings.ToLower(role) {
+	case "reviewer", "review":
+		builder.WriteString("Review the task outcome, rerun the relevant verification when needed, and decide whether the work should be approved.\n")
+		builder.WriteString("Return the final result using this exact format:\n")
+		builder.WriteString("<task-report>\n")
+		builder.WriteString("status: approved|rejected|blocked\n")
+		builder.WriteString("summary: <short result summary>\n")
+		builder.WriteString("tests: <what ran and what passed/failed>\n")
+		builder.WriteString("build: <what ran and what passed/failed>\n")
+		builder.WriteString("notes: <review findings or follow-up>\n")
+		builder.WriteString("</task-report>")
+	default:
+		builder.WriteString("Implement the task and stop at a review-ready state when review is required.\n")
+		builder.WriteString("Return the final result using this exact format:\n")
+		builder.WriteString("<task-report>\n")
+		builder.WriteString("status: completed|blocked|needs_review\n")
+		builder.WriteString("summary: <short result summary>\n")
+		builder.WriteString("tests: <what ran and what passed/failed>\n")
+		builder.WriteString("build: <what ran and what passed/failed>\n")
+		builder.WriteString("notes: <important details, blockers, or follow-up>\n")
+		builder.WriteString("</task-report>")
+	}
+	return builder.String()
+}

--- a/internal/project/worker_profiles_test.go
+++ b/internal/project/worker_profiles_test.go
@@ -1,0 +1,80 @@
+package project
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveWorkerProfile_UsesExplicitWorkerAndRoleDefaults(t *testing.T) {
+	t.Run("developer defaults to codex", func(t *testing.T) {
+		profile, err := ResolveWorkerProfile(BoardTask{Role: "developer"})
+		if err != nil {
+			t.Fatalf("resolve worker profile: %v", err)
+		}
+		if profile.Kind != WorkerKindCodexCLI {
+			t.Fatalf("expected %q, got %+v", WorkerKindCodexCLI, profile)
+		}
+	})
+
+	t.Run("reviewer defaults to claude", func(t *testing.T) {
+		profile, err := ResolveWorkerProfile(BoardTask{Role: "reviewer"})
+		if err != nil {
+			t.Fatalf("resolve worker profile: %v", err)
+		}
+		if profile.Kind != WorkerKindClaudeCode {
+			t.Fatalf("expected %q, got %+v", WorkerKindClaudeCode, profile)
+		}
+	})
+
+	t.Run("explicit worker kind wins", func(t *testing.T) {
+		profile, err := ResolveWorkerProfile(BoardTask{
+			Role:       "developer",
+			WorkerKind: WorkerKindClaudeCode,
+		})
+		if err != nil {
+			t.Fatalf("resolve worker profile: %v", err)
+		}
+		if profile.Kind != WorkerKindClaudeCode {
+			t.Fatalf("expected explicit worker kind %q, got %+v", WorkerKindClaudeCode, profile)
+		}
+	})
+
+	t.Run("unknown worker kind fails", func(t *testing.T) {
+		if _, err := ResolveWorkerProfile(BoardTask{WorkerKind: "unknown-cli"}); err == nil {
+			t.Fatal("expected unknown worker kind error")
+		}
+	})
+}
+
+func TestBuildTaskPrompt_UsesFixedReportContract(t *testing.T) {
+	profile, err := ResolveWorkerProfile(BoardTask{Role: "developer"})
+	if err != nil {
+		t.Fatalf("resolve worker profile: %v", err)
+	}
+
+	prompt := BuildTaskPrompt(BoardTask{
+		ID:           "task-1",
+		Title:        "Implement board sync",
+		Role:         "developer",
+		WorkerKind:   WorkerKindCodexCLI,
+		TestCommand:  "go test ./internal/project",
+		BuildCommand: "go test ./internal/tarsserver",
+	}, "proj_demo", profile)
+
+	want := []string{
+		"Project ID: proj_demo",
+		"Task ID: task-1",
+		"worker_kind: codex-cli",
+		"Return the final result using this exact format:",
+		"<task-report>",
+		"status: completed|blocked|needs_review",
+		"tests: <what ran and what passed/failed>",
+		"build: <what ran and what passed/failed>",
+		"</task-report>",
+	}
+	for _, item := range want {
+		if !strings.Contains(prompt, item) {
+			t.Fatalf("expected prompt to contain %q, got:\n%s", item, prompt)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add built-in project worker profiles for `codex-cli` and `claude-code`.
- Persist the selected `worker_kind` on board tasks and in task status activity metadata.
- Standardize the task prompt/report contract and add a gateway-backed project task runner.

## Changes

- Add `project.WorkerProfile`, `ResolveWorkerProfile`, and `BuildTaskPrompt` with role-based defaults.
- Add `worker_kind` to board task metadata and include it in orchestrator activity updates.
- Add `gateway.ProjectTaskRunner` so project task runs can spawn and wait through the gateway runtime.
- Add tests for worker profile resolution, prompt contract, board round-tripping, orchestrator metadata, and gateway-backed task runs.
- API, config, or compatibility changes: board task documents now support an optional `worker_kind` field.

## Validation

- [x] `make test`
- [x] `make security-scan`
- [x] Additional manual verification, if needed: `go test ./internal/project ./internal/gateway -count=1`

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [x] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [x] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level: medium. This extends board task metadata and threads worker selection through the orchestrator/runtime boundary.
- Rollback plan: revert this PR to remove `worker_kind`, worker profile resolution, and the gateway task runner.

## Notes

- Closes #24
- `.docs/TODO.md` was updated locally for milestone tracking but is gitignored and not part of this PR.
