### PR TITLE
feat: add project review gate

### DIFF
--- a/internal/project/activity.go
+++ b/internal/project/activity.go
@@ -29,6 +29,7 @@ const (
 	ActivityKindStateChanged     = "state_changed"
 	ActivityKindBoardTaskCreated = "board_task_created"
 	ActivityKindBoardTaskUpdated = "board_task_updated"
+	ActivityKindReviewStatus     = "review_status"
 	ActivityKindTestStatus       = "test_status"
 	ActivityKindBuildStatus      = "build_status"
 	ActivityKindIssueStatus      = "issue_status"

--- a/internal/project/activity_auto.go
+++ b/internal/project/activity_auto.go
@@ -52,6 +52,7 @@ func boardTaskActivityChanged(before, after BoardTask) bool {
 		before.Assignee != after.Assignee ||
 		before.Role != after.Role ||
 		before.WorkerKind != after.WorkerKind ||
+		before.ReviewApprovedBy != after.ReviewApprovedBy ||
 		before.ReviewRequired != after.ReviewRequired ||
 		before.TestCommand != after.TestCommand ||
 		before.BuildCommand != after.BuildCommand

--- a/internal/project/kanban.go
+++ b/internal/project/kanban.go
@@ -15,15 +15,16 @@ const projectBoardDocumentName = "KANBAN.md"
 var defaultBoardColumns = []string{"todo", "in_progress", "review", "done"}
 
 type BoardTask struct {
-	ID             string `json:"id" yaml:"id"`
-	Title          string `json:"title" yaml:"title"`
-	Status         string `json:"status" yaml:"status"`
-	Assignee       string `json:"assignee,omitempty" yaml:"assignee,omitempty"`
-	Role           string `json:"role,omitempty" yaml:"role,omitempty"`
-	WorkerKind     string `json:"worker_kind,omitempty" yaml:"worker_kind,omitempty"`
-	ReviewRequired bool   `json:"review_required,omitempty" yaml:"review_required,omitempty"`
-	TestCommand    string `json:"test_command,omitempty" yaml:"test_command,omitempty"`
-	BuildCommand   string `json:"build_command,omitempty" yaml:"build_command,omitempty"`
+	ID               string `json:"id" yaml:"id"`
+	Title            string `json:"title" yaml:"title"`
+	Status           string `json:"status" yaml:"status"`
+	Assignee         string `json:"assignee,omitempty" yaml:"assignee,omitempty"`
+	Role             string `json:"role,omitempty" yaml:"role,omitempty"`
+	WorkerKind       string `json:"worker_kind,omitempty" yaml:"worker_kind,omitempty"`
+	ReviewApprovedBy string `json:"review_approved_by,omitempty" yaml:"review_approved_by,omitempty"`
+	ReviewRequired   bool   `json:"review_required,omitempty" yaml:"review_required,omitempty"`
+	TestCommand      string `json:"test_command,omitempty" yaml:"test_command,omitempty"`
+	BuildCommand     string `json:"build_command,omitempty" yaml:"build_command,omitempty"`
 }
 
 type Board struct {
@@ -249,15 +250,16 @@ func normalizeBoardTasks(raw []BoardTask, columns []string) []BoardTask {
 	out := make([]BoardTask, 0, len(raw))
 	for _, task := range raw {
 		item := BoardTask{
-			ID:             strings.TrimSpace(task.ID),
-			Title:          strings.TrimSpace(task.Title),
-			Status:         strings.ToLower(strings.TrimSpace(task.Status)),
-			Assignee:       strings.TrimSpace(task.Assignee),
-			Role:           strings.TrimSpace(task.Role),
-			WorkerKind:     strings.ToLower(strings.TrimSpace(task.WorkerKind)),
-			ReviewRequired: task.ReviewRequired,
-			TestCommand:    strings.TrimSpace(task.TestCommand),
-			BuildCommand:   strings.TrimSpace(task.BuildCommand),
+			ID:               strings.TrimSpace(task.ID),
+			Title:            strings.TrimSpace(task.Title),
+			Status:           strings.ToLower(strings.TrimSpace(task.Status)),
+			Assignee:         strings.TrimSpace(task.Assignee),
+			Role:             strings.TrimSpace(task.Role),
+			WorkerKind:       strings.ToLower(strings.TrimSpace(task.WorkerKind)),
+			ReviewApprovedBy: strings.TrimSpace(task.ReviewApprovedBy),
+			ReviewRequired:   task.ReviewRequired,
+			TestCommand:      strings.TrimSpace(task.TestCommand),
+			BuildCommand:     strings.TrimSpace(task.BuildCommand),
 		}
 		if _, ok := allowedStatus[item.Status]; !ok {
 			item.Status = normalizedColumns[0]

--- a/internal/project/kanban_test.go
+++ b/internal/project/kanban_test.go
@@ -56,15 +56,16 @@ func TestStoreBoardRoundtrip(t *testing.T) {
 	updated, err := store.UpdateBoard(created.ID, BoardUpdateInput{
 		Tasks: []BoardTask{
 			{
-				ID:             "task-1",
-				Title:          "Build activity feed",
-				Status:         "in_progress",
-				Assignee:       "dev-1",
-				Role:           "developer",
-				WorkerKind:     WorkerKindCodexCLI,
-				ReviewRequired: true,
-				TestCommand:    "go test ./internal/project",
-				BuildCommand:   "go test ./internal/tarsserver",
+				ID:               "task-1",
+				Title:            "Build activity feed",
+				Status:           "in_progress",
+				Assignee:         "dev-1",
+				Role:             "developer",
+				WorkerKind:       WorkerKindCodexCLI,
+				ReviewApprovedBy: "review-bot",
+				ReviewRequired:   true,
+				TestCommand:      "go test ./internal/project",
+				BuildCommand:     "go test ./internal/tarsserver",
 			},
 		},
 	})
@@ -87,6 +88,9 @@ func TestStoreBoardRoundtrip(t *testing.T) {
 	}
 	if loaded.Tasks[0].WorkerKind != WorkerKindCodexCLI {
 		t.Fatalf("expected worker kind %q, got %+v", WorkerKindCodexCLI, loaded.Tasks[0])
+	}
+	if loaded.Tasks[0].ReviewApprovedBy != "review-bot" {
+		t.Fatalf("expected review approver to round-trip, got %+v", loaded.Tasks[0])
 	}
 
 	second, err := store.UpdateBoard(created.ID, BoardUpdateInput{

--- a/internal/project/orchestrator.go
+++ b/internal/project/orchestrator.go
@@ -61,6 +61,19 @@ func NewOrchestrator(store *Store, runner TaskRunner) *Orchestrator {
 }
 
 func (o *Orchestrator) DispatchTodo(ctx context.Context, projectID string) (DispatchReport, error) {
+	return o.dispatchTasksByStatus(ctx, projectID, "todo", o.dispatchTask)
+}
+
+func (o *Orchestrator) DispatchReview(ctx context.Context, projectID string) (DispatchReport, error) {
+	return o.dispatchTasksByStatus(ctx, projectID, "review", o.dispatchReviewTask)
+}
+
+func (o *Orchestrator) dispatchTasksByStatus(
+	ctx context.Context,
+	projectID string,
+	status string,
+	dispatchFn func(context.Context, string, BoardTask) (TaskRun, error),
+) (DispatchReport, error) {
 	if o == nil || o.store == nil {
 		return DispatchReport{}, fmt.Errorf("project orchestrator store is not configured")
 	}
@@ -73,7 +86,7 @@ func (o *Orchestrator) DispatchTodo(ctx context.Context, projectID string) (Disp
 	}
 	tasks := make([]BoardTask, 0, len(board.Tasks))
 	for _, task := range board.Tasks {
-		if task.Status == "todo" {
+		if task.Status == strings.TrimSpace(status) {
 			tasks = append(tasks, task)
 		}
 	}
@@ -94,7 +107,7 @@ func (o *Orchestrator) DispatchTodo(ctx context.Context, projectID string) (Disp
 		wg.Add(1)
 		go func(index int, task BoardTask) {
 			defer wg.Done()
-			run, runErr := o.dispatchTask(ctx, projectID, task)
+			run, runErr := dispatchFn(ctx, projectID, task)
 			report.Runs[index] = run
 			if runErr != nil {
 				errMu.Lock()
@@ -212,6 +225,87 @@ func (o *Orchestrator) dispatchTask(ctx context.Context, projectID string, task 
 			"agent":       firstNonEmpty(strings.TrimSpace(finished.Agent), strings.TrimSpace(task.Assignee)),
 			"assignee":    strings.TrimSpace(task.Assignee),
 			"worker_kind": firstNonEmpty(strings.TrimSpace(finished.WorkerKind), profile.Kind),
+		},
+	}); err != nil {
+		return finished, err
+	}
+	return finished, nil
+}
+
+func (o *Orchestrator) dispatchReviewTask(ctx context.Context, projectID string, task BoardTask) (TaskRun, error) {
+	reviewTask := task
+	reviewTask.Role = "reviewer"
+	reviewTask.WorkerKind = ""
+
+	profile, err := ResolveWorkerProfile(reviewTask)
+	if err != nil {
+		return TaskRun{}, err
+	}
+	prompt := BuildTaskPrompt(reviewTask, projectID, profile) +
+		"\n\nCurrent task status: review" +
+		"\nImplementation worker_kind: " + strings.TrimSpace(task.WorkerKind)
+
+	run, err := o.runner.Start(ctx, TaskRunRequest{
+		ProjectID:  strings.TrimSpace(projectID),
+		TaskID:     task.ID,
+		Title:      task.Title,
+		Prompt:     prompt,
+		Agent:      firstNonEmpty(strings.TrimSpace(task.Assignee), "reviewer"),
+		Role:       "reviewer",
+		WorkerKind: profile.Kind,
+	})
+	if err != nil {
+		return TaskRun{}, err
+	}
+
+	finished, err := o.runner.Wait(ctx, run.ID)
+	if err != nil {
+		_ = o.store.appendSystemActivity(projectID, ActivityAppendInput{
+			TaskID:  task.ID,
+			Kind:    ActivityKindReviewStatus,
+			Status:  "blocked",
+			Message: "Review run failed",
+			Meta: map[string]string{
+				"run_id":      run.ID,
+				"worker_kind": profile.Kind,
+			},
+		})
+		return run, err
+	}
+
+	report := ParseTaskReport(finished.Response)
+	reviewStatus := strings.ToLower(strings.TrimSpace(report.Status))
+	nextStatus := "review"
+	approvedBy := ""
+	message := "Review blocked"
+	switch reviewStatus {
+	case "approved":
+		nextStatus = "done"
+		approvedBy = firstNonEmpty(strings.TrimSpace(finished.Agent), profile.Kind)
+		message = "Review approved"
+	case "rejected":
+		nextStatus = "in_progress"
+		message = "Review rejected"
+	default:
+		reviewStatus = "blocked"
+	}
+
+	if err := o.updateBoardTask(projectID, task.ID, func(item *BoardTask) {
+		item.Status = nextStatus
+		item.ReviewApprovedBy = approvedBy
+	}); err != nil {
+		return finished, err
+	}
+
+	if err := o.store.appendSystemActivity(projectID, ActivityAppendInput{
+		TaskID:  task.ID,
+		Kind:    ActivityKindReviewStatus,
+		Status:  reviewStatus,
+		Message: message,
+		Meta: map[string]string{
+			"run_id":      run.ID,
+			"worker_kind": profile.Kind,
+			"reviewer":    firstNonEmpty(strings.TrimSpace(finished.Agent), profile.Kind),
 		},
 	}); err != nil {
 		return finished, err

--- a/internal/project/review_gate_test.go
+++ b/internal/project/review_gate_test.go
@@ -1,0 +1,191 @@
+package project
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestParseTaskReport(t *testing.T) {
+	report := ParseTaskReport(`
+noise
+<task-report>
+status: approved
+summary: looks good
+tests: go test ./...
+build: go test ./...
+notes: ship it
+</task-report>
+`)
+	if report.Status != "approved" {
+		t.Fatalf("expected approved status, got %+v", report)
+	}
+	if report.Summary != "looks good" {
+		t.Fatalf("expected summary to be parsed, got %+v", report)
+	}
+}
+
+func TestOrchestratorDispatchReviewApprovesTaskToDone(t *testing.T) {
+	store := NewStore(t.TempDir(), func() time.Time {
+		return time.Date(2026, 3, 14, 15, 0, 0, 0, time.UTC)
+	})
+	created, err := store.Create(CreateInput{Name: "Review Project"})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	if _, err := store.UpdateBoard(created.ID, BoardUpdateInput{
+		Tasks: []BoardTask{
+			{
+				ID:             "task-1",
+				Title:          "Review orchestrator output",
+				Status:         "review",
+				Assignee:       "dev-1",
+				Role:           "developer",
+				WorkerKind:     WorkerKindCodexCLI,
+				ReviewRequired: true,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("seed board: %v", err)
+	}
+
+	runner := newStubTaskRunner()
+	runner.results["run-task-1"] = TaskRun{
+		ID:         "run-task-1",
+		TaskID:     "task-1",
+		Agent:      WorkerKindClaudeCode,
+		WorkerKind: WorkerKindClaudeCode,
+		Status:     TaskRunStatusCompleted,
+		Response: `<task-report>
+status: approved
+summary: ok
+tests: go test ./internal/project
+build: go test ./internal/gateway
+notes: approved
+</task-report>`,
+	}
+	orchestrator := NewOrchestrator(store, runner)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, runErr := orchestrator.DispatchReview(context.Background(), created.ID)
+		errCh <- runErr
+	}()
+
+	select {
+	case <-runner.startedCh:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected review run to start")
+	}
+	close(runner.waitGate)
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("dispatch review: %v", err)
+	}
+
+	board, err := store.GetBoard(created.ID)
+	if err != nil {
+		t.Fatalf("get board: %v", err)
+	}
+	if len(board.Tasks) != 1 || board.Tasks[0].Status != "done" {
+		t.Fatalf("expected approved task to move to done, got %+v", board.Tasks)
+	}
+	if board.Tasks[0].ReviewApprovedBy != WorkerKindClaudeCode {
+		t.Fatalf("expected reviewer %q, got %+v", WorkerKindClaudeCode, board.Tasks[0])
+	}
+
+	activity, err := store.ListActivity(created.ID, 20)
+	if err != nil {
+		t.Fatalf("list activity: %v", err)
+	}
+	if !hasActivityKindStatus(activity, ActivityKindReviewStatus, "approved") {
+		t.Fatalf("expected approved review activity, got %+v", activity)
+	}
+}
+
+func TestOrchestratorDispatchReviewRejectsTaskBackToInProgress(t *testing.T) {
+	store := NewStore(t.TempDir(), func() time.Time {
+		return time.Date(2026, 3, 14, 15, 0, 0, 0, time.UTC)
+	})
+	created, err := store.Create(CreateInput{Name: "Reject Project"})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	if _, err := store.UpdateBoard(created.ID, BoardUpdateInput{
+		Tasks: []BoardTask{
+			{
+				ID:             "task-1",
+				Title:          "Review orchestrator output",
+				Status:         "review",
+				Assignee:       "dev-1",
+				Role:           "developer",
+				WorkerKind:     WorkerKindCodexCLI,
+				ReviewRequired: true,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("seed board: %v", err)
+	}
+
+	runner := newStubTaskRunner()
+	runner.results["run-task-1"] = TaskRun{
+		ID:         "run-task-1",
+		TaskID:     "task-1",
+		Agent:      WorkerKindClaudeCode,
+		WorkerKind: WorkerKindClaudeCode,
+		Status:     TaskRunStatusCompleted,
+		Response: `<task-report>
+status: rejected
+summary: not ready
+tests: go test ./internal/project
+build: go test ./internal/gateway
+notes: fix the failing case
+</task-report>`,
+	}
+	orchestrator := NewOrchestrator(store, runner)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, runErr := orchestrator.DispatchReview(context.Background(), created.ID)
+		errCh <- runErr
+	}()
+
+	select {
+	case <-runner.startedCh:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected review run to start")
+	}
+	close(runner.waitGate)
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("dispatch review: %v", err)
+	}
+
+	board, err := store.GetBoard(created.ID)
+	if err != nil {
+		t.Fatalf("get board: %v", err)
+	}
+	if len(board.Tasks) != 1 || board.Tasks[0].Status != "in_progress" {
+		t.Fatalf("expected rejected task to move to in_progress, got %+v", board.Tasks)
+	}
+	if board.Tasks[0].ReviewApprovedBy != "" {
+		t.Fatalf("expected review approver to be cleared, got %+v", board.Tasks[0])
+	}
+
+	activity, err := store.ListActivity(created.ID, 20)
+	if err != nil {
+		t.Fatalf("list activity: %v", err)
+	}
+	if !hasActivityKindStatus(activity, ActivityKindReviewStatus, "rejected") {
+		t.Fatalf("expected rejected review activity, got %+v", activity)
+	}
+}
+
+func hasActivityKindStatus(items []Activity, kind, status string) bool {
+	for _, item := range items {
+		if item.Kind == kind && item.Status == status {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/project/task_report.go
+++ b/internal/project/task_report.go
@@ -1,0 +1,51 @@
+package project
+
+import (
+	"bufio"
+	"strings"
+)
+
+type TaskReport struct {
+	Status  string
+	Summary string
+	Tests   string
+	Build   string
+	Notes   string
+}
+
+func ParseTaskReport(raw string) TaskReport {
+	report := TaskReport{}
+	body := strings.TrimSpace(raw)
+	start := strings.Index(body, "<task-report>")
+	end := strings.Index(body, "</task-report>")
+	if start != -1 && end != -1 && end > start {
+		body = body[start+len("<task-report>") : end]
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(body))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		trimmedKey := strings.ToLower(strings.TrimSpace(key))
+		trimmedValue := strings.TrimSpace(value)
+		switch trimmedKey {
+		case "status":
+			report.Status = strings.ToLower(trimmedValue)
+		case "summary":
+			report.Summary = trimmedValue
+		case "tests":
+			report.Tests = trimmedValue
+		case "build":
+			report.Build = trimmedValue
+		case "notes":
+			report.Notes = trimmedValue
+		}
+	}
+	return report
+}


### PR DESCRIPTION
## Summary

- Add a review gate for project tasks so reviewer approval is required before `done`.
- Parse the fixed task report format to drive approved/rejected review outcomes.
- Persist review approval metadata on board tasks and emit review activity events.

## Changes

- Add `review_status` activity kind and `review_approved_by` board task metadata.
- Add `project.ParseTaskReport` for the `<task-report>` response contract.
- Add `Orchestrator.DispatchReview` to run reviewer workers for tasks in `review` and move them to `done` or back to `in_progress`.
- Extend board normalization/activity change detection for review approval metadata.
- Add tests covering report parsing, review approval, review rejection, and board round-tripping.
- API, config, or compatibility changes: board task documents now support an optional `review_approved_by` field.

## Validation

- [x] `make test`
- [x] `make security-scan`
- [x] Additional manual verification, if needed: `go test ./internal/project ./internal/tarsserver -count=1`

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [x] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [x] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level: medium. This changes task completion semantics for review-required work.
- Rollback plan: revert this PR to remove the review dispatch path and restore the pre-gate task lifecycle.

## Notes

- Closes #26
- `.docs/TODO.md` was updated locally for milestone tracking but is gitignored and not part of this PR.
