### PR TITLE
feat: add project github flow gates

### DIFF
--- a/internal/project/activity.go
+++ b/internal/project/activity.go
@@ -29,6 +29,7 @@ const (
 	ActivityKindStateChanged     = "state_changed"
 	ActivityKindBoardTaskCreated = "board_task_created"
 	ActivityKindBoardTaskUpdated = "board_task_updated"
+	ActivityKindBranchStatus     = "branch_status"
 	ActivityKindReviewStatus     = "review_status"
 	ActivityKindTestStatus       = "test_status"
 	ActivityKindBuildStatus      = "build_status"

--- a/internal/project/activity_auto.go
+++ b/internal/project/activity_auto.go
@@ -52,6 +52,9 @@ func boardTaskActivityChanged(before, after BoardTask) bool {
 		before.Assignee != after.Assignee ||
 		before.Role != after.Role ||
 		before.WorkerKind != after.WorkerKind ||
+		before.Issue != after.Issue ||
+		before.Branch != after.Branch ||
+		before.PR != after.PR ||
 		before.ReviewApprovedBy != after.ReviewApprovedBy ||
 		before.ReviewRequired != after.ReviewRequired ||
 		before.TestCommand != after.TestCommand ||

--- a/internal/project/github_flow.go
+++ b/internal/project/github_flow.go
@@ -1,0 +1,37 @@
+package project
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type GitHubAuthChecker func(context.Context) error
+
+func defaultGitHubAuthChecker(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, "gh", "auth", "status")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			message = strings.TrimSpace(err.Error())
+		}
+		return fmt.Errorf("github auth precondition failed: gh auth status: %s", message)
+	}
+	return nil
+}
+
+func verificationStatus(raw string) string {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	switch {
+	case value == "":
+		return "blocked"
+	case strings.Contains(value, "fail"), strings.Contains(value, "error"), strings.Contains(value, "blocked"):
+		return "failed"
+	case strings.Contains(value, "pass"), strings.Contains(value, "ok"), strings.Contains(value, "success"):
+		return "passed"
+	default:
+		return "blocked"
+	}
+}

--- a/internal/project/github_flow_test.go
+++ b/internal/project/github_flow_test.go
@@ -1,0 +1,148 @@
+package project
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestOrchestratorDispatchTodoBlocksReviewWhenVerificationFails(t *testing.T) {
+	store := NewStore(t.TempDir(), func() time.Time {
+		return time.Date(2026, 3, 14, 16, 0, 0, 0, time.UTC)
+	})
+	created, err := store.Create(CreateInput{Name: "Verification Project"})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	if _, err := store.UpdateBoard(created.ID, BoardUpdateInput{
+		Tasks: []BoardTask{
+			{
+				ID:             "task-1",
+				Title:          "Implement verification gate",
+				Status:         "todo",
+				Assignee:       "dev-1",
+				Role:           "developer",
+				ReviewRequired: true,
+				TestCommand:    "go test ./internal/project",
+				BuildCommand:   "go test ./internal/gateway",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("seed board: %v", err)
+	}
+
+	runner := newStubTaskRunner()
+	runner.results["run-task-1"] = TaskRun{
+		ID:         "run-task-1",
+		TaskID:     "task-1",
+		Agent:      WorkerKindCodexCLI,
+		WorkerKind: WorkerKindCodexCLI,
+		Status:     TaskRunStatusCompleted,
+		Response: `<task-report>
+status: completed
+summary: implemented
+tests: failed
+build: passed
+issue: https://github.com/devlikebear/tars/issues/201
+branch: feat/task-1
+pr: https://github.com/devlikebear/tars/pull/301
+notes: test still failing
+</task-report>`,
+	}
+	orchestrator := NewOrchestratorWithGitHubAuthChecker(store, runner, func(context.Context) error { return nil })
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, runErr := orchestrator.DispatchTodo(context.Background(), created.ID)
+		errCh <- runErr
+	}()
+
+	select {
+	case <-runner.startedCh:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected task run to start")
+	}
+	close(runner.waitGate)
+
+	if err := <-errCh; err == nil {
+		t.Fatal("expected verification gate error")
+	}
+
+	board, err := store.GetBoard(created.ID)
+	if err != nil {
+		t.Fatalf("get board: %v", err)
+	}
+	if len(board.Tasks) != 1 || board.Tasks[0].Status != "in_progress" {
+		t.Fatalf("expected verification failure to hold task in progress, got %+v", board.Tasks)
+	}
+	if board.Tasks[0].Issue == "" || board.Tasks[0].Branch == "" || board.Tasks[0].PR == "" {
+		t.Fatalf("expected github flow metadata from report, got %+v", board.Tasks[0])
+	}
+
+	activity, err := store.ListActivity(created.ID, 30)
+	if err != nil {
+		t.Fatalf("list activity: %v", err)
+	}
+	if !hasActivityKindStatus(activity, ActivityKindTestStatus, "failed") {
+		t.Fatalf("expected failed test activity, got %+v", activity)
+	}
+	if !hasActivityKindStatus(activity, ActivityKindBuildStatus, "passed") {
+		t.Fatalf("expected passed build activity, got %+v", activity)
+	}
+}
+
+func TestOrchestratorDispatchTodoFailsWhenGitHubAuthMissing(t *testing.T) {
+	store := NewStore(t.TempDir(), func() time.Time {
+		return time.Date(2026, 3, 14, 16, 0, 0, 0, time.UTC)
+	})
+	created, err := store.Create(CreateInput{Name: "Auth Project"})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	if _, err := store.UpdateBoard(created.ID, BoardUpdateInput{
+		Tasks: []BoardTask{
+			{
+				ID:             "task-1",
+				Title:          "Implement auth gate",
+				Status:         "todo",
+				Assignee:       "dev-1",
+				Role:           "developer",
+				ReviewRequired: true,
+				TestCommand:    "go test ./internal/project",
+				BuildCommand:   "go test ./internal/gateway",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("seed board: %v", err)
+	}
+
+	runner := newStubTaskRunner()
+	orchestrator := NewOrchestratorWithGitHubAuthChecker(store, runner, func(context.Context) error {
+		return context.DeadlineExceeded
+	})
+
+	_, err = orchestrator.DispatchTodo(context.Background(), created.ID)
+	if err == nil {
+		t.Fatal("expected github auth error")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "github") && !strings.Contains(strings.ToLower(err.Error()), "gh auth") {
+		t.Fatalf("expected github auth error, got %v", err)
+	}
+
+	board, err := store.GetBoard(created.ID)
+	if err != nil {
+		t.Fatalf("get board: %v", err)
+	}
+	if len(board.Tasks) != 1 || board.Tasks[0].Status != "todo" {
+		t.Fatalf("expected auth failure to leave task in todo, got %+v", board.Tasks)
+	}
+
+	activity, err := store.ListActivity(created.ID, 20)
+	if err != nil {
+		t.Fatalf("list activity: %v", err)
+	}
+	if !hasActivityKindStatus(activity, ActivityKindIssueStatus, "blocked") {
+		t.Fatalf("expected blocked issue status activity, got %+v", activity)
+	}
+}

--- a/internal/project/kanban.go
+++ b/internal/project/kanban.go
@@ -21,6 +21,9 @@ type BoardTask struct {
 	Assignee         string `json:"assignee,omitempty" yaml:"assignee,omitempty"`
 	Role             string `json:"role,omitempty" yaml:"role,omitempty"`
 	WorkerKind       string `json:"worker_kind,omitempty" yaml:"worker_kind,omitempty"`
+	Issue            string `json:"issue,omitempty" yaml:"issue,omitempty"`
+	Branch           string `json:"branch,omitempty" yaml:"branch,omitempty"`
+	PR               string `json:"pr,omitempty" yaml:"pr,omitempty"`
 	ReviewApprovedBy string `json:"review_approved_by,omitempty" yaml:"review_approved_by,omitempty"`
 	ReviewRequired   bool   `json:"review_required,omitempty" yaml:"review_required,omitempty"`
 	TestCommand      string `json:"test_command,omitempty" yaml:"test_command,omitempty"`
@@ -256,6 +259,9 @@ func normalizeBoardTasks(raw []BoardTask, columns []string) []BoardTask {
 			Assignee:         strings.TrimSpace(task.Assignee),
 			Role:             strings.TrimSpace(task.Role),
 			WorkerKind:       strings.ToLower(strings.TrimSpace(task.WorkerKind)),
+			Issue:            strings.TrimSpace(task.Issue),
+			Branch:           strings.TrimSpace(task.Branch),
+			PR:               strings.TrimSpace(task.PR),
 			ReviewApprovedBy: strings.TrimSpace(task.ReviewApprovedBy),
 			ReviewRequired:   task.ReviewRequired,
 			TestCommand:      strings.TrimSpace(task.TestCommand),

--- a/internal/project/kanban_test.go
+++ b/internal/project/kanban_test.go
@@ -62,6 +62,9 @@ func TestStoreBoardRoundtrip(t *testing.T) {
 				Assignee:         "dev-1",
 				Role:             "developer",
 				WorkerKind:       WorkerKindCodexCLI,
+				Issue:            "https://github.com/devlikebear/tars/issues/99",
+				Branch:           "feat/task-1",
+				PR:               "https://github.com/devlikebear/tars/pull/199",
 				ReviewApprovedBy: "review-bot",
 				ReviewRequired:   true,
 				TestCommand:      "go test ./internal/project",
@@ -88,6 +91,9 @@ func TestStoreBoardRoundtrip(t *testing.T) {
 	}
 	if loaded.Tasks[0].WorkerKind != WorkerKindCodexCLI {
 		t.Fatalf("expected worker kind %q, got %+v", WorkerKindCodexCLI, loaded.Tasks[0])
+	}
+	if loaded.Tasks[0].Issue == "" || loaded.Tasks[0].Branch == "" || loaded.Tasks[0].PR == "" {
+		t.Fatalf("expected github flow metadata to round-trip, got %+v", loaded.Tasks[0])
 	}
 	if loaded.Tasks[0].ReviewApprovedBy != "review-bot" {
 		t.Fatalf("expected review approver to round-trip, got %+v", loaded.Tasks[0])

--- a/internal/project/orchestrator.go
+++ b/internal/project/orchestrator.go
@@ -48,15 +48,21 @@ type DispatchReport struct {
 }
 
 type Orchestrator struct {
-	store  *Store
-	runner TaskRunner
-	mu     sync.Mutex
+	store             *Store
+	runner            TaskRunner
+	githubAuthChecker GitHubAuthChecker
+	mu                sync.Mutex
 }
 
 func NewOrchestrator(store *Store, runner TaskRunner) *Orchestrator {
+	return NewOrchestratorWithGitHubAuthChecker(store, runner, defaultGitHubAuthChecker)
+}
+
+func NewOrchestratorWithGitHubAuthChecker(store *Store, runner TaskRunner, checker GitHubAuthChecker) *Orchestrator {
 	return &Orchestrator{
-		store:  store,
-		runner: runner,
+		store:             store,
+		runner:            runner,
+		githubAuthChecker: checker,
 	}
 }
 
@@ -130,6 +136,18 @@ func (o *Orchestrator) dispatchTask(ctx context.Context, projectID string, task 
 	if err != nil {
 		return TaskRun{}, err
 	}
+	if o.githubAuthChecker != nil {
+		if err := o.githubAuthChecker(ctx); err != nil {
+			wrapped := fmt.Errorf("github auth precondition failed: %w", err)
+			_ = o.store.appendSystemActivity(projectID, ActivityAppendInput{
+				TaskID:  task.ID,
+				Kind:    ActivityKindIssueStatus,
+				Status:  "blocked",
+				Message: strings.TrimSpace(wrapped.Error()),
+			})
+			return TaskRun{}, wrapped
+		}
+	}
 	if err := o.updateBoardTask(projectID, task.ID, func(item *BoardTask) {
 		item.Status = "in_progress"
 		item.WorkerKind = profile.Kind
@@ -202,9 +220,88 @@ func (o *Orchestrator) dispatchTask(ctx context.Context, projectID string, task 
 	if finished.Status == TaskRunStatusFailed || finished.Status == TaskRunStatusCanceled {
 		finalStatus = "todo"
 	}
+	report := ParseTaskReport(finished.Response)
+	testStatus := verificationStatus(report.Tests)
+	buildStatus := verificationStatus(report.Build)
+	issueRef := firstNonEmpty(strings.TrimSpace(report.Issue), strings.TrimSpace(task.Issue))
+	branchRef := firstNonEmpty(strings.TrimSpace(report.Branch), strings.TrimSpace(task.Branch))
+	prRef := firstNonEmpty(strings.TrimSpace(report.PR), strings.TrimSpace(task.PR))
+
+	if strings.TrimSpace(task.TestCommand) != "" {
+		_ = o.store.appendSystemActivity(projectID, ActivityAppendInput{
+			TaskID:  task.ID,
+			Kind:    ActivityKindTestStatus,
+			Status:  testStatus,
+			Message: "Task test verification reported",
+			Meta: map[string]string{
+				"command": task.TestCommand,
+			},
+		})
+	}
+	if strings.TrimSpace(task.BuildCommand) != "" {
+		_ = o.store.appendSystemActivity(projectID, ActivityAppendInput{
+			TaskID:  task.ID,
+			Kind:    ActivityKindBuildStatus,
+			Status:  buildStatus,
+			Message: "Task build verification reported",
+			Meta: map[string]string{
+				"command": task.BuildCommand,
+			},
+		})
+	}
+	_ = o.store.appendSystemActivity(projectID, ActivityAppendInput{
+		TaskID:  task.ID,
+		Kind:    ActivityKindIssueStatus,
+		Status:  ternaryStatus(issueRef != "", "ready", "blocked"),
+		Message: "Task issue metadata recorded",
+		Meta: map[string]string{
+			"issue": issueRef,
+		},
+	})
+	_ = o.store.appendSystemActivity(projectID, ActivityAppendInput{
+		TaskID:  task.ID,
+		Kind:    ActivityKindBranchStatus,
+		Status:  ternaryStatus(branchRef != "", "ready", "blocked"),
+		Message: "Task branch metadata recorded",
+		Meta: map[string]string{
+			"branch": branchRef,
+		},
+	})
+	_ = o.store.appendSystemActivity(projectID, ActivityAppendInput{
+		TaskID:  task.ID,
+		Kind:    ActivityKindPRStatus,
+		Status:  ternaryStatus(prRef != "", "ready", "blocked"),
+		Message: "Task pull request metadata recorded",
+		Meta: map[string]string{
+			"pr": prRef,
+		},
+	})
+
+	gateErrs := []string{}
+	if strings.TrimSpace(task.TestCommand) != "" && testStatus != "passed" {
+		gateErrs = append(gateErrs, "tests not passed")
+	}
+	if strings.TrimSpace(task.BuildCommand) != "" && buildStatus != "passed" {
+		gateErrs = append(gateErrs, "build not passed")
+	}
+	if strings.TrimSpace(issueRef) == "" {
+		gateErrs = append(gateErrs, "issue missing")
+	}
+	if strings.TrimSpace(branchRef) == "" {
+		gateErrs = append(gateErrs, "branch missing")
+	}
+	if strings.TrimSpace(prRef) == "" {
+		gateErrs = append(gateErrs, "pr missing")
+	}
+	if len(gateErrs) > 0 && finished.Status != TaskRunStatusFailed && finished.Status != TaskRunStatusCanceled {
+		finalStatus = "in_progress"
+	}
 	if err := o.updateBoardTask(projectID, task.ID, func(item *BoardTask) {
 		item.Status = finalStatus
 		item.WorkerKind = firstNonEmpty(strings.TrimSpace(finished.WorkerKind), profile.Kind)
+		item.Issue = issueRef
+		item.Branch = branchRef
+		item.PR = prRef
 	}); err != nil {
 		return finished, err
 	}
@@ -214,6 +311,9 @@ func (o *Orchestrator) dispatchTask(ctx context.Context, projectID string, task 
 	if finished.Status == TaskRunStatusFailed || finished.Status == TaskRunStatusCanceled {
 		activityStatus = "failed"
 		message = "Task run failed"
+	} else if len(gateErrs) > 0 {
+		activityStatus = "in_progress"
+		message = "Task run blocked by verification or GitHub Flow gate"
 	}
 	if err := o.store.appendSystemActivity(projectID, ActivityAppendInput{
 		TaskID:  task.ID,
@@ -228,6 +328,9 @@ func (o *Orchestrator) dispatchTask(ctx context.Context, projectID string, task 
 		},
 	}); err != nil {
 		return finished, err
+	}
+	if len(gateErrs) > 0 && finished.Status != TaskRunStatusFailed && finished.Status != TaskRunStatusCanceled {
+		return finished, fmt.Errorf("task gate failed: %s", strings.Join(gateErrs, ", "))
 	}
 	return finished, nil
 }
@@ -347,4 +450,11 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func ternaryStatus(ok bool, whenTrue, whenFalse string) string {
+	if ok {
+		return whenTrue
+	}
+	return whenFalse
 }

--- a/internal/project/orchestrator_test.go
+++ b/internal/project/orchestrator_test.go
@@ -31,11 +31,21 @@ func (s *stubTaskRunner) Start(_ context.Context, req TaskRunRequest) (TaskRun, 
 	runID := fmt.Sprintf("run-%s", req.TaskID)
 	if _, ok := s.results[runID]; !ok {
 		s.results[runID] = TaskRun{
-			ID:       runID,
-			TaskID:   req.TaskID,
-			Agent:    req.Agent,
-			Status:   TaskRunStatusCompleted,
-			Response: "ok",
+			ID:         runID,
+			TaskID:     req.TaskID,
+			Agent:      req.Agent,
+			WorkerKind: req.WorkerKind,
+			Status:     TaskRunStatusCompleted,
+			Response: `<task-report>
+status: completed
+summary: ok
+tests: passed
+build: passed
+issue: https://github.com/devlikebear/tars/issues/1
+branch: feat/` + req.TaskID + `
+pr: https://github.com/devlikebear/tars/pull/1
+notes: ok
+</task-report>`,
 		}
 	}
 	s.startedCh <- struct{}{}
@@ -72,7 +82,7 @@ func TestOrchestratorDispatchTodoRunsTasksInParallel(t *testing.T) {
 	}
 
 	runner := newStubTaskRunner()
-	orchestrator := NewOrchestrator(store, runner)
+	orchestrator := NewOrchestratorWithGitHubAuthChecker(store, runner, func(context.Context) error { return nil })
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -142,7 +152,7 @@ func TestOrchestratorDispatchTodoRestoresFailedTaskToTodo(t *testing.T) {
 		Status: TaskRunStatusFailed,
 		Error:  "boom",
 	}
-	orchestrator := NewOrchestrator(store, runner)
+	orchestrator := NewOrchestratorWithGitHubAuthChecker(store, runner, func(context.Context) error { return nil })
 
 	errCh := make(chan error, 1)
 	go func() {

--- a/internal/project/review_gate_test.go
+++ b/internal/project/review_gate_test.go
@@ -64,7 +64,7 @@ build: go test ./internal/gateway
 notes: approved
 </task-report>`,
 	}
-	orchestrator := NewOrchestrator(store, runner)
+	orchestrator := NewOrchestratorWithGitHubAuthChecker(store, runner, func(context.Context) error { return nil })
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -142,7 +142,7 @@ build: go test ./internal/gateway
 notes: fix the failing case
 </task-report>`,
 	}
-	orchestrator := NewOrchestrator(store, runner)
+	orchestrator := NewOrchestratorWithGitHubAuthChecker(store, runner, func(context.Context) error { return nil })
 
 	errCh := make(chan error, 1)
 	go func() {

--- a/internal/project/task_report.go
+++ b/internal/project/task_report.go
@@ -10,6 +10,9 @@ type TaskReport struct {
 	Summary string
 	Tests   string
 	Build   string
+	Issue   string
+	Branch  string
+	PR      string
 	Notes   string
 }
 
@@ -43,6 +46,12 @@ func ParseTaskReport(raw string) TaskReport {
 			report.Tests = trimmedValue
 		case "build":
 			report.Build = trimmedValue
+		case "issue":
+			report.Issue = trimmedValue
+		case "branch":
+			report.Branch = trimmedValue
+		case "pr":
+			report.PR = trimmedValue
 		case "notes":
 			report.Notes = trimmedValue
 		}

--- a/internal/project/worker_profiles.go
+++ b/internal/project/worker_profiles.go
@@ -98,6 +98,9 @@ func BuildTaskPrompt(task BoardTask, projectID string, profile WorkerProfile) st
 		builder.WriteString("summary: <short result summary>\n")
 		builder.WriteString("tests: <what ran and what passed/failed>\n")
 		builder.WriteString("build: <what ran and what passed/failed>\n")
+		builder.WriteString("issue: <linked issue url or id>\n")
+		builder.WriteString("branch: <branch name used for the task>\n")
+		builder.WriteString("pr: <pull request url or id>\n")
 		builder.WriteString("notes: <review findings or follow-up>\n")
 		builder.WriteString("</task-report>")
 	default:
@@ -108,6 +111,9 @@ func BuildTaskPrompt(task BoardTask, projectID string, profile WorkerProfile) st
 		builder.WriteString("summary: <short result summary>\n")
 		builder.WriteString("tests: <what ran and what passed/failed>\n")
 		builder.WriteString("build: <what ran and what passed/failed>\n")
+		builder.WriteString("issue: <linked issue url or id>\n")
+		builder.WriteString("branch: <branch name used for the task>\n")
+		builder.WriteString("pr: <pull request url or id>\n")
 		builder.WriteString("notes: <important details, blockers, or follow-up>\n")
 		builder.WriteString("</task-report>")
 	}

--- a/internal/tarsserver/dashboard.go
+++ b/internal/tarsserver/dashboard.go
@@ -19,6 +19,7 @@ type projectDashboardPageData struct {
 	Activity   []project.Activity
 	Board      project.Board
 	BoardStats []projectDashboardBoardStat
+	GitHubFlow []projectDashboardGitHubFlowRow
 	PagePath   string
 	StreamPath string
 }
@@ -26,6 +27,19 @@ type projectDashboardPageData struct {
 type projectDashboardBoardStat struct {
 	Status string
 	Count  int
+}
+
+type projectDashboardGitHubFlowRow struct {
+	Task             string
+	Issue            string
+	Branch           string
+	PR               string
+	ReviewApprovedBy string
+	TestStatus       string
+	BuildStatus      string
+	IssueStatus      string
+	BranchStatus     string
+	PRStatus         string
 }
 
 type projectDashboardRoute struct {
@@ -204,6 +218,40 @@ var projectDashboardTemplate = template.Must(template.New("project-dashboard").P
       <p class="muted">No activity recorded yet.</p>
       {{end}}
     </section>
+
+    <section id="github-flow-section" class="card">
+      <h2>GitHub Flow</h2>
+      {{if .GitHubFlow}}
+      <table>
+        <thead>
+          <tr>
+            <th>Task</th>
+            <th>Issue</th>
+            <th>Branch</th>
+            <th>PR</th>
+            <th>Review</th>
+            <th>Test</th>
+            <th>Build</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{range .GitHubFlow}}
+          <tr>
+            <td><strong>{{.Task}}</strong></td>
+            <td>{{if .Issue}}{{.Issue}}{{else}}-{{end}}{{if .IssueStatus}}<div class="muted">{{.IssueStatus}}</div>{{end}}</td>
+            <td>{{if .Branch}}{{.Branch}}{{else}}-{{end}}{{if .BranchStatus}}<div class="muted">{{.BranchStatus}}</div>{{end}}</td>
+            <td>{{if .PR}}{{.PR}}{{else}}-{{end}}{{if .PRStatus}}<div class="muted">{{.PRStatus}}</div>{{end}}</td>
+            <td>{{if .ReviewApprovedBy}}{{.ReviewApprovedBy}}{{else}}-{{end}}</td>
+            <td>{{if .TestStatus}}<code>{{.TestStatus}}</code>{{else}}-{{end}}</td>
+            <td>{{if .BuildStatus}}<code>{{.BuildStatus}}</code>{{else}}-{{end}}</td>
+          </tr>
+          {{end}}
+        </tbody>
+      </table>
+      {{else}}
+      <p class="muted">No GitHub Flow metadata recorded yet.</p>
+      {{end}}
+    </section>
   </main>
   <script>
     (() => {
@@ -225,7 +273,7 @@ var projectDashboardTemplate = template.Must(template.New("project-dashboard").P
           }
           const html = await response.text();
           const doc = new DOMParser().parseFromString(html, "text/html");
-          for (const id of ["board-section", "activity-section"]) {
+          for (const id of ["board-section", "activity-section", "github-flow-section"]) {
             const next = doc.getElementById(id);
             const current = document.getElementById(id);
             if (next && current) {
@@ -301,6 +349,7 @@ func newProjectDashboardHandler(store *project.Store, broker *projectDashboardBr
 			Activity:   activity,
 			Board:      board,
 			BoardStats: buildProjectDashboardBoardStats(board),
+			GitHubFlow: buildProjectDashboardGitHubFlow(board, activity),
 			PagePath:   fmt.Sprintf("/ui/projects/%s", route.ProjectID),
 			StreamPath: fmt.Sprintf("/ui/projects/%s/stream", route.ProjectID),
 		}); err != nil {
@@ -322,6 +371,41 @@ func buildProjectDashboardBoardStats(board project.Board) []projectDashboardBoar
 		})
 	}
 	return stats
+}
+
+func buildProjectDashboardGitHubFlow(board project.Board, activity []project.Activity) []projectDashboardGitHubFlowRow {
+	rows := make([]projectDashboardGitHubFlowRow, 0, len(board.Tasks))
+	statusByTaskAndKind := map[string]map[string]string{}
+	for _, item := range activity {
+		if strings.TrimSpace(item.TaskID) == "" || strings.TrimSpace(item.Kind) == "" {
+			continue
+		}
+		kindMap, ok := statusByTaskAndKind[item.TaskID]
+		if !ok {
+			kindMap = map[string]string{}
+			statusByTaskAndKind[item.TaskID] = kindMap
+		}
+		if _, exists := kindMap[item.Kind]; exists {
+			continue
+		}
+		kindMap[item.Kind] = strings.TrimSpace(item.Status)
+	}
+	for _, task := range board.Tasks {
+		kindMap := statusByTaskAndKind[task.ID]
+		rows = append(rows, projectDashboardGitHubFlowRow{
+			Task:             task.Title,
+			Issue:            task.Issue,
+			Branch:           task.Branch,
+			PR:               task.PR,
+			ReviewApprovedBy: task.ReviewApprovedBy,
+			TestStatus:       kindMap[project.ActivityKindTestStatus],
+			BuildStatus:      kindMap[project.ActivityKindBuildStatus],
+			IssueStatus:      kindMap[project.ActivityKindIssueStatus],
+			BranchStatus:     kindMap[project.ActivityKindBranchStatus],
+			PRStatus:         kindMap[project.ActivityKindPRStatus],
+		})
+	}
+	return rows
 }
 
 func serveProjectDashboardStream(w http.ResponseWriter, r *http.Request, projectID string, broker *projectDashboardBroker, logger zerolog.Logger) {

--- a/internal/tarsserver/dashboard_test.go
+++ b/internal/tarsserver/dashboard_test.go
@@ -59,10 +59,16 @@ func TestProjectDashboardHandler_RendersProjectOverviewAndActivity(t *testing.T)
 	if _, err := store.UpdateBoard(created.ID, project.BoardUpdateInput{
 		Tasks: []project.BoardTask{
 			{
-				ID:       "task-1",
-				Title:    "Build dashboard view",
-				Status:   "in_progress",
-				Assignee: "dev-1",
+				ID:               "task-1",
+				Title:            "Build dashboard view",
+				Status:           "in_progress",
+				Assignee:         "dev-1",
+				Issue:            "https://github.com/devlikebear/tars/issues/42",
+				Branch:           "feat/dashboard-view",
+				PR:               "https://github.com/devlikebear/tars/pull/42",
+				ReviewApprovedBy: "review-bot",
+				TestCommand:      "go test ./internal/tarsserver",
+				BuildCommand:     "go test ./internal/project",
 			},
 			{
 				ID:       "task-2",
@@ -73,6 +79,24 @@ func TestProjectDashboardHandler_RendersProjectOverviewAndActivity(t *testing.T)
 		},
 	}); err != nil {
 		t.Fatalf("update board: %v", err)
+	}
+	if _, err := store.AppendActivity(created.ID, project.ActivityAppendInput{
+		Source:  "system",
+		TaskID:  "task-1",
+		Kind:    project.ActivityKindTestStatus,
+		Status:  "passed",
+		Message: "Task tests passed",
+	}); err != nil {
+		t.Fatalf("append test status: %v", err)
+	}
+	if _, err := store.AppendActivity(created.ID, project.ActivityAppendInput{
+		Source:  "system",
+		TaskID:  "task-1",
+		Kind:    project.ActivityKindBuildStatus,
+		Status:  "passed",
+		Message: "Task build passed",
+	}); err != nil {
+		t.Fatalf("append build status: %v", err)
 	}
 
 	handler := newProjectDashboardHandler(store, newProjectDashboardBroker(), zerolog.New(io.Discard))
@@ -97,6 +121,12 @@ func TestProjectDashboardHandler_RendersProjectOverviewAndActivity(t *testing.T)
 		"Board",
 		"Build dashboard view",
 		"Prepare review notes",
+		"GitHub Flow",
+		"https://github.com/devlikebear/tars/issues/42",
+		"feat/dashboard-view",
+		"https://github.com/devlikebear/tars/pull/42",
+		"review-bot",
+		"passed",
 		"in_progress",
 		"review",
 		"todo",
@@ -105,6 +135,7 @@ func TestProjectDashboardHandler_RendersProjectOverviewAndActivity(t *testing.T)
 		"/ui/projects/" + created.ID + "/stream",
 		"board-section",
 		"activity-section",
+		"github-flow-section",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("expected dashboard body to contain %q, got %q", want, body)


### PR DESCRIPTION
## Summary

- Persist GitHub Flow metadata on project board tasks and render it in the dashboard.
- Enforce test/build and GitHub Flow gates before developer tasks can advance to `review` or `done`.
- Surface `gh auth status` failures as explicit task activity and orchestration errors.

## Changes

- Add `issue`, `branch`, and `pr` task metadata plus `branch_status` activity tracking.
- Extend task reports and worker prompt contracts to carry issue/branch/PR metadata.
- Add a GitHub auth checker and developer-run gate logic for test/build plus GitHub Flow metadata.
- Extend the dashboard with a `GitHub Flow` section that shows task metadata and latest verification state.
- Add tests for auth failures, verification gating, metadata round-tripping, and dashboard rendering.
- API, config, or compatibility changes: board task documents now support optional `issue`, `branch`, and `pr` fields.

## Validation

- [x] `make test`
- [x] `make security-scan`
- [x] Additional manual verification, if needed: `go test ./internal/project ./internal/tarsserver -count=1`

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [x] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [x] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level: medium. This tightens developer task advancement rules and expands the board document schema.
- Rollback plan: revert this PR to remove GitHub Flow metadata persistence and the new verification gates.

## Notes

- Closes #28
- `.docs/TODO.md` was updated locally for milestone tracking but is gitignored and not part of this PR.
