### PR TITLE
fix: robust stale session recovery and add chat panel scrolling

### DIFF
--- a/internal/tarsclient/app_model.go
+++ b/internal/tarsclient/app_model.go
@@ -106,6 +106,8 @@ type tarsAppModel struct {
 	inflightCanceled bool
 	assistantLine    int
 
+	chatScrollOffset int // 0 = bottom (latest), positive = lines scrolled up
+
 	asyncCh chan tea.Msg
 }
 
@@ -172,6 +174,7 @@ func (m *tarsAppModel) appendChatLine(line string) {
 	if len(m.chatLines) > maxChatLines {
 		m.chatLines = m.chatLines[len(m.chatLines)-maxChatLines:]
 	}
+	m.chatScrollOffset = 0 // snap to bottom on new message
 }
 
 func (m *tarsAppModel) appendChatBlock(block string) {
@@ -209,6 +212,7 @@ func (m *tarsAppModel) setAssistantLine() {
 			m.assistantLine = -1
 		}
 	}
+	m.chatScrollOffset = 0
 }
 
 func (m *tarsAppModel) appendAssistantChunk(chunk string) {
@@ -218,9 +222,11 @@ func (m *tarsAppModel) appendAssistantChunk(chunk string) {
 	if m.assistantLine < 0 || m.assistantLine >= len(m.chatLines) {
 		m.chatLines = append(m.chatLines, "TARS > "+chunk)
 		m.assistantLine = len(m.chatLines) - 1
+		m.chatScrollOffset = 0
 		return
 	}
 	m.chatLines[m.assistantLine] += chunk
+	m.chatScrollOffset = 0
 }
 
 func (m *tarsAppModel) pushHistory(value string) {

--- a/internal/tarsclient/app_update.go
+++ b/internal/tarsclient/app_update.go
@@ -54,10 +54,24 @@ func (m *tarsAppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.input.SetValue("")
 			return m, nil
+		case tea.KeyPgUp:
+			m.scrollChatUp(m.chatPanelPageSize())
+			return m, nil
+		case tea.KeyPgDown:
+			m.scrollChatDown(m.chatPanelPageSize())
+			return m, nil
 		case tea.KeyUp:
+			if typed.Alt {
+				m.scrollChatUp(1)
+				return m, nil
+			}
 			m.historyPrev()
 			return m, nil
 		case tea.KeyDown:
+			if typed.Alt {
+				m.scrollChatDown(1)
+				return m, nil
+			}
 			m.historyNext()
 			return m, nil
 		case tea.KeyTab:
@@ -302,6 +316,28 @@ func (m *tarsAppModel) cancelInFlight(reason string) {
 	m.inflightCanceled = true
 	m.appendStatusLine(reason)
 	m.inflightCancel()
+}
+
+func (m *tarsAppModel) scrollChatUp(lines int) {
+	m.chatScrollOffset += lines
+}
+
+func (m *tarsAppModel) scrollChatDown(lines int) {
+	m.chatScrollOffset -= lines
+	if m.chatScrollOffset < 0 {
+		m.chatScrollOffset = 0
+	}
+}
+
+func (m *tarsAppModel) chatPanelPageSize() int {
+	contentHeight := m.height - 5
+	if contentHeight < 9 {
+		contentHeight = 9
+	}
+	if m.width < 120 {
+		return maxInt(1, contentHeight/2-2)
+	}
+	return maxInt(1, contentHeight-2)
 }
 
 func maxInt(a, b int) int {

--- a/internal/tarsclient/app_view.go
+++ b/internal/tarsclient/app_view.go
@@ -97,13 +97,25 @@ func (m *tarsAppModel) View() string {
 
 func (m *tarsAppModel) renderChatPanel(width, height int) string {
 	contentWidth := innerPanelWidth(width)
-	content := renderPanelLines(m.chatLines, contentWidth, height-2, func(original, segment string) string {
+	limit := height - 2
+	content, totalVisual := renderPanelLinesWithScroll(m.chatLines, contentWidth, limit, m.chatScrollOffset, func(original, segment string) string {
 		return formatChatLine(original, segment)
 	})
+	// clamp scroll offset to valid range
+	maxOffset := totalVisual - limit
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	if m.chatScrollOffset > maxOffset {
+		m.chatScrollOffset = maxOffset
+	}
 	if strings.TrimSpace(content) == "" {
 		content = "(no chat yet)"
 	}
 	title := chatTitleStyle.Render("Chat")
+	if m.chatScrollOffset > 0 {
+		title += " " + lipgloss.NewStyle().Foreground(lipgloss.Color("#94A3B8")).Render(fmt.Sprintf("(↑%d)", m.chatScrollOffset))
+	}
 	return panelStyle.Width(width).Height(height).Render(title + "\n" + content)
 }
 
@@ -149,6 +161,11 @@ func innerPanelWidth(width int) int {
 }
 
 func renderPanelLines(lines []string, width, limit int, formatter func(original, segment string) string) string {
+	content, _ := renderPanelLinesWithScroll(lines, width, limit, 0, formatter)
+	return content
+}
+
+func renderPanelLinesWithScroll(lines []string, width, limit, scrollOffset int, formatter func(original, segment string) string) (string, int) {
 	if width <= 0 {
 		width = 1
 	}
@@ -156,7 +173,7 @@ func renderPanelLines(lines []string, width, limit int, formatter func(original,
 		limit = 1
 	}
 	if len(lines) == 0 {
-		return ""
+		return "", 0
 	}
 	visual := make([]string, 0, len(lines))
 	for _, line := range lines {
@@ -168,11 +185,23 @@ func renderPanelLines(lines []string, width, limit int, formatter func(original,
 			visual = append(visual, segment)
 		}
 	}
-	start := 0
-	if len(visual) > limit {
-		start = len(visual) - limit
+	total := len(visual)
+	// end is the last line index (exclusive) to show
+	end := total - scrollOffset
+	if end < 0 {
+		end = 0
 	}
-	return strings.Join(visual[start:], "\n")
+	if end > total {
+		end = total
+	}
+	start := end - limit
+	if start < 0 {
+		start = 0
+	}
+	if start >= end {
+		return "", total
+	}
+	return strings.Join(visual[start:end], "\n"), total
 }
 
 func wrapVisualLine(line string, width int) []string {

--- a/internal/tarsclient/chat.go
+++ b/internal/tarsclient/chat.go
@@ -36,7 +36,17 @@ func (c chatClient) stream(ctx context.Context, req chatRequest, onStatus func(c
 	}
 	retryReq := req
 	retryReq.SessionID = c.recoverChatSessionID(ctx, req.SessionID)
-	return c.client().StreamChat(ctx, retryReq, onStatus, onDelta)
+	result, err = c.client().StreamChat(ctx, retryReq, onStatus, onDelta)
+	if err == nil || retryReq.SessionID == "" {
+		return result, err
+	}
+	// Recovery session was also stale; final attempt with empty session
+	// so the server creates a fresh one.
+	if shouldRecoverMissingChatSession(retryReq.SessionID, err) {
+		retryReq.SessionID = ""
+		return c.client().StreamChat(ctx, retryReq, onStatus, onDelta)
+	}
+	return result, err
 }
 
 func shouldRecoverMissingChatSession(sessionID string, err error) bool {

--- a/internal/tarsclient/chat_test.go
+++ b/internal/tarsclient/chat_test.go
@@ -263,3 +263,68 @@ func TestChatClientStream_RetriesWithoutSessionWhenNoMainSessionExists(t *testin
 		t.Fatalf("expected second attempt without session, got %+v", attempts[1])
 	}
 }
+
+func TestChatClientStream_RetriesWithEmptySessionWhenRecoveredSessionAlsoStale(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		attempts []chatRequest
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/chat":
+			var req chatRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			mu.Lock()
+			attempts = append(attempts, req)
+			attempt := len(attempts)
+			mu.Unlock()
+			// First two attempts fail (stale session and stale main session).
+			if attempt <= 2 {
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"code":    "not_found",
+					"message": "session not found",
+				})
+				return
+			}
+			// Third attempt with empty session succeeds.
+			w.Header().Set("Content-Type", "text/event-stream")
+			fmt.Fprint(w, "data: {\"type\":\"delta\",\"text\":\"Hello\"}\n")
+			fmt.Fprint(w, "data: {\"type\":\"done\",\"session_id\":\"sess-fresh\"}\n")
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/status":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"workspace_dir":   "/tmp/ws",
+				"session_count":   1,
+				"main_session_id": "stale-main",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := chatClient{serverURL: server.URL}
+	res, err := client.stream(context.Background(), chatRequest{Message: "hi", SessionID: "stale-1"}, nil, nil)
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	if res.SessionID != "sess-fresh" {
+		t.Fatalf("expected session_id sess-fresh, got %q", res.SessionID)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(attempts) != 3 {
+		t.Fatalf("expected three chat attempts, got %d", len(attempts))
+	}
+	if attempts[0].SessionID != "stale-1" {
+		t.Fatalf("expected first attempt with stale-1, got %+v", attempts[0])
+	}
+	if attempts[1].SessionID != "stale-main" {
+		t.Fatalf("expected second attempt with stale-main, got %+v", attempts[1])
+	}
+	if attempts[2].SessionID != "" {
+		t.Fatalf("expected third attempt with empty session, got %+v", attempts[2])
+	}
+}

--- a/internal/tarsserver/handler_chat.go
+++ b/internal/tarsserver/handler_chat.go
@@ -27,21 +27,32 @@ func resolveChatSession(store *session.Store, sessionID string, mainSessionID st
 	if strings.TrimSpace(sessionID) == "" {
 		id := strings.TrimSpace(mainSessionID)
 		if id == "" {
-			sess, err := store.Create("chat")
-			if err != nil {
-				return "", err
-			}
-			return sess.ID, nil
+			return createFallbackChatSession(store)
 		}
 		if _, err := store.Get(id); err != nil {
-			return "", err
+			return createFallbackChatSession(store)
 		}
 		return id, nil
 	}
 	if _, err := store.Get(strings.TrimSpace(sessionID)); err != nil {
-		return "", err
+		// Requested session is stale; fall back to the main session
+		// or create a new one so the chat request is not rejected.
+		if id := strings.TrimSpace(mainSessionID); id != "" && id != strings.TrimSpace(sessionID) {
+			if _, mainErr := store.Get(id); mainErr == nil {
+				return id, nil
+			}
+		}
+		return createFallbackChatSession(store)
 	}
 	return strings.TrimSpace(sessionID), nil
+}
+
+func createFallbackChatSession(store *session.Store) (string, error) {
+	sess, err := store.Create("chat")
+	if err != nil {
+		return "", err
+	}
+	return sess.ID, nil
 }
 
 func prepareChatContext(workspaceDir, userMessage string) (systemPrompt string, toolChoice string, err error) {

--- a/internal/tarsserver/main_session_test.go
+++ b/internal/tarsserver/main_session_test.go
@@ -68,3 +68,56 @@ func TestResolveSession_MainSession_CreatesWhenNoSessions(t *testing.T) {
 		t.Fatalf("expected main session to exist: %v", err)
 	}
 }
+
+func TestResolveSession_StaleMainSession_CreatesNewSession(t *testing.T) {
+	store := session.NewStore(t.TempDir())
+	// Simulate a stale mainSessionID that no longer exists in the store.
+	resolved, err := resolveChatSession(store, "", "deleted-stale-id")
+	if err != nil {
+		t.Fatalf("expected fallback to new session, got error: %v", err)
+	}
+	if strings.TrimSpace(resolved) == "" {
+		t.Fatalf("expected non-empty session id")
+	}
+	if resolved == "deleted-stale-id" {
+		t.Fatalf("should not return the stale id")
+	}
+	// Verify the new session exists in the store.
+	if _, err := store.Get(resolved); err != nil {
+		t.Fatalf("new session should exist in store: %v", err)
+	}
+}
+
+func TestResolveSession_StaleExplicitSession_FallsBackToMain(t *testing.T) {
+	store := session.NewStore(t.TempDir())
+	mainSession, err := store.Create("main")
+	if err != nil {
+		t.Fatalf("create main session: %v", err)
+	}
+	// Explicit session ID is stale, should fall back to main session.
+	resolved, err := resolveChatSession(store, "stale-explicit-id", mainSession.ID)
+	if err != nil {
+		t.Fatalf("expected fallback, got error: %v", err)
+	}
+	if resolved != mainSession.ID {
+		t.Fatalf("expected main session %q, got %q", mainSession.ID, resolved)
+	}
+}
+
+func TestResolveSession_StaleExplicitAndMainSession_CreatesNew(t *testing.T) {
+	store := session.NewStore(t.TempDir())
+	// Both explicit and main session IDs are stale.
+	resolved, err := resolveChatSession(store, "stale-explicit", "stale-main")
+	if err != nil {
+		t.Fatalf("expected fallback to new session, got error: %v", err)
+	}
+	if strings.TrimSpace(resolved) == "" {
+		t.Fatalf("expected non-empty session id")
+	}
+	if resolved == "stale-explicit" || resolved == "stale-main" {
+		t.Fatalf("should not return stale ids, got %q", resolved)
+	}
+	if _, err := store.Get(resolved); err != nil {
+		t.Fatalf("new session should exist in store: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- `resolveChatSession`이 stale session ID에 대해 항상 새 세션으로 fallback하도록 수정하여 404 에러 제거
- 클라이언트 복구 로직에 3차 재시도(빈 session ID) 추가로 main session도 stale한 경우 대응
- TUI 채팅 패널에 스크롤 기능 추가 (PageUp/Down, Alt+↑/↓)

## Test plan
- [x] `TestResolveSession_StaleMainSession_CreatesNewSession` 통과
- [x] `TestResolveSession_StaleExplicitSession_FallsBackToMain` 통과
- [x] `TestResolveSession_StaleExplicitAndMainSession_CreatesNew` 통과
- [x] `TestChatClientStream_RetriesWithEmptySessionWhenRecoveredSessionAlsoStale` 통과
- [x] 기존 테스트 모두 통과
- [ ] TUI에서 PageUp/PageDown으로 이전 대화 확인 가능한지 수동 테스트