### PR TITLE
chore: prefer worktrees in tars-github-flow skill

### DIFF
--- a/.codex/skills/tars-github-flow/SKILL.md
+++ b/.codex/skills/tars-github-flow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tars-github-flow
-description: "Repository-specific GitHub Flow for the TARS project. Use when work in this repository should follow the full delivery lifecycle: plan the task, create a GitHub issue, create a feature branch, implement with TDD, update VERSION.txt plus CHANGELOG.md and README.md for shipped changes, commit and push, open a PR with the repository template, review CI/CD results, merge to main with squash, sync local main, and verify the automated tag and release flow."
+description: "Repository-specific GitHub Flow for the TARS project. Use when work in this repository should follow the full delivery lifecycle: plan the task, create a GitHub issue, create a dedicated worktree-backed feature branch, implement with TDD, update VERSION.txt plus CHANGELOG.md and README.md for shipped changes, commit and push, open a PR with the repository template, review CI/CD results, merge to main with squash, sync local main, and verify the automated tag and release flow."
 ---
 
 # TARS GitHub Flow
@@ -9,19 +9,19 @@ description: "Repository-specific GitHub Flow for the TARS project. Use when wor
 
 - Use this skill only for end-to-end repository work that should land through the standard TARS delivery path.
 - Prefer `gh` for issue, PR, review, merge, and release inspection work.
-- Default to a local feature branch workflow: commit locally, confirm `git status --short --branch` is clean on that feature branch, then push that same branch and open the PR.
+- Default to a dedicated git worktree per feature branch: create the worktree from `main`, do the implementation inside that worktree, confirm `git status --short --branch` is clean there, then push that branch and open the PR.
 - Read [references/repo-flow.md](references/repo-flow.md) before executing commands.
 
 ## Workflow
 
 1. Plan the task and decide whether it should ship as a public release.
 2. Create or update a GitHub issue before coding.
-3. Create a `feat/`, `fix/`, or `chore/` branch from `main`.
+3. Create a dedicated worktree for a `feat/`, `fix/`, or `chore/` branch from `main`.
 4. Add a failing test first when practical, then implement.
 5. Review the diff before committing and keep the change set focused.
 6. Update `VERSION.txt`, `CHANGELOG.md`, and `README.md` when the change is meant to ship publicly.
-7. Commit with conventional commits on the local feature branch, then confirm that branch is clean with `git status --short --branch`.
-8. Push that clean local feature branch and only then open a PR with the repository template.
+7. Commit with conventional commits inside the worktree-backed feature branch, then confirm that branch is clean with `git status --short --branch`.
+8. Push that clean worktree-backed feature branch and only then open a PR with the repository template.
 9. Wait for `security` and `test`, address review comments, and verify one approval.
 10. Merge with `squash`, delete the remote branch, sync local `main`, and confirm automated release results.
 
@@ -29,7 +29,7 @@ description: "Repository-specific GitHub Flow for the TARS project. Use when wor
 
 - Use `feat:`, `fix:`, or `chore:` commit prefixes.
 - Keep PRs small, test-proven, and easy to review.
-- Do not open a PR from uncommitted local work or from a dirty feature branch.
+- Do not open a PR from uncommitted local work or from a dirty feature branch worktree.
 - Treat `VERSION.txt` and `CHANGELOG.md` as a pair for release PRs.
 - Expect `main` protection to require a PR, one approval, resolved conversations, `security`, `test`, and squash merge only.
 - Do not manually create GitHub releases unless the automated `release-on-version-bump` workflow failed and the user asked for recovery.
@@ -37,7 +37,7 @@ description: "Repository-specific GitHub Flow for the TARS project. Use when wor
 ## Environment Notes
 
 - Remote-only GitHub API fallbacks are the exception, not the default.
-- Use a remote-only fallback only when local `.git` writes are truly blocked and the user understands that the normal requirement is still: local feature branch commit first, clean `git status`, then push and PR.
+- Use a remote-only fallback only when local `.git` writes are truly blocked and the user understands that the normal requirement is still: local worktree-backed feature branch commit first, clean `git status`, then push and PR.
 - When a remote-only fallback is unavoidable, tell the user exactly what did not happen locally and what local sync they still need to run in their own shell.
 
 ## References

--- a/.codex/skills/tars-github-flow/agents/openai.yaml
+++ b/.codex/skills/tars-github-flow/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "TARS GitHub Flow"
-  short_description: "TARS repo GitHub Flow from issue to release"
-  default_prompt: "Use $tars-github-flow to run the TARS repository workflow from planning and issue creation through PR, merge, and release verification."
+  short_description: "TARS repo GitHub Flow with worktree-based branch flow"
+  default_prompt: "Use $tars-github-flow to run the TARS repository workflow from planning and issue creation through a dedicated feature worktree, PR, merge, and release verification."

--- a/.codex/skills/tars-github-flow/references/repo-flow.md
+++ b/.codex/skills/tars-github-flow/references/repo-flow.md
@@ -26,12 +26,13 @@ gh issue create \
   --body $'## Summary\n- Add init/doctor/service flow\n\n## Acceptance Criteria\n- `tars init` creates starter files\n- `tars doctor --fix` repairs local setup\n- `tars service ...` manages launchd'
 ```
 
-## Phase 3: Create a Feature Branch
+## Phase 3: Create a Feature Worktree
 
-- Branch from `main`.
+- Branch from `main` into a dedicated worktree.
 - Use `feat/<name>`, `fix/<name>`, or `chore/<name>`.
 - Keep names lowercase kebab-case.
-- Do the work on that local feature branch, not on `main`.
+- Keep the worktree outside the repository root when possible, for example under `../tars-worktrees/`.
+- Do the work in that worktree-backed feature branch, not on `main`.
 
 Example:
 
@@ -39,15 +40,17 @@ Example:
 git fetch origin
 git switch main
 git pull --rebase
-git switch -c feat/onboarding-service-flow
+mkdir -p ../tars-worktrees
+git worktree add ../tars-worktrees/feat-onboarding-service-flow -b feat/onboarding-service-flow main
+cd ../tars-worktrees/feat-onboarding-service-flow
 ```
 
 Fallback when `.git` writes are blocked in the Codex environment:
 
-- This is an exception path only after you have clearly told the user that the normal path is local feature branch -> local commit -> clean `git status` -> push -> PR.
+- This is an exception path only after you have clearly told the user that the normal path is local worktree-backed feature branch -> local commit -> clean `git status` -> push -> PR.
 - Create the remote branch with `gh api repos/<owner>/<repo>/git/refs`.
 - Commit through the GitHub Git Data API only when local `.git` writes are truly blocked.
-- Tell the user that local branch creation and local main sync still need to happen in their own shell.
+- Tell the user that local worktree creation and local main sync still need to happen in their own shell.
 
 ## Phase 4: Develop With TDD
 
@@ -79,9 +82,9 @@ Current repository release rules:
 
 - Keep the commit subject imperative and under 72 characters.
 - Prefer one commit per logical unit when possible.
-- Commit on the local feature branch before any remote push.
-- Run `git status --short --branch` after committing and confirm the feature branch is clean.
-- If the feature branch is not clean, do not push and do not open a PR yet.
+- Commit on the local worktree-backed feature branch before any remote push.
+- Run `git status --short --branch` after committing and confirm the feature branch worktree is clean.
+- If the feature branch worktree is not clean, do not push and do not open a PR yet.
 
 Example:
 
@@ -97,7 +100,7 @@ git push -u origin feat/onboarding-service-flow
 - Use the repository PR template at `.github/pull_request_template.md`.
 - Fill all sections: `Summary`, `Changes`, `Validation`, `Checklist`, `Risks / Rollback`.
 - Explicitly document any local-only test failure that is unrelated to the change.
-- Open the PR only after the local feature branch commit exists and `git status --short --branch` is clean.
+- Open the PR only after the local feature branch commit exists in the worktree and `git status --short --branch` is clean there.
 
 Required checks and merge rules on `main`:
 
@@ -128,11 +131,13 @@ gh pr merge <number> --squash --delete-branch
 
 ## Phase 9: Sync Local Main
 
-- After merge, sync local `main`.
+- After merge, clean up the feature worktree and sync local `main`.
 
 Preferred:
 
 ```bash
+git worktree remove ../tars-worktrees/feat-onboarding-service-flow
+git worktree prune
 git fetch origin
 git switch main
 git pull --rebase


### PR DESCRIPTION
## Summary

- Update the repository-local `tars-github-flow` skill so feature work defaults to a dedicated git worktree instead of a plain branch in the main checkout
- Keep the rest of the delivery lifecycle the same while making the branch creation and cleanup steps match the preferred worktree workflow
- Close #47 by aligning the skill body, repo-flow reference, and UI metadata

## Changes

- Main user-visible or developer-visible changes:
  - `SKILL.md` now tells Codex to create a dedicated worktree from `main` before implementation
  - `references/repo-flow.md` now uses `git worktree add` in the branch creation phase and `git worktree remove` during cleanup
  - `agents/openai.yaml` now describes the worktree-based flow in the UI metadata
- API, config, or compatibility changes:
  - None

## Validation

- [ ] `make test`
- [ ] `make security-scan`
- [x] Additional manual verification, if needed
  - Ran `python3 /Users/changheonshin/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/tars-github-flow`

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [ ] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [ ] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [ ] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level: Low
- Rollback plan: Revert commit `72476b5` to restore the previous branch-oriented skill wording
