### PR TITLE
fix: guard dashboard auth off exposure

### DIFF
--- a/internal/serverauth/middleware.go
+++ b/internal/serverauth/middleware.go
@@ -33,6 +33,7 @@ type Options struct {
 	UserWorkspaceAllowlist        []string
 	AdminWorkspaceAllowlist       []string
 	SkipPaths                     []string
+	LoopbackSkipPaths             []string
 	AdminPaths                    []string
 }
 
@@ -45,6 +46,7 @@ type compiledOptions struct {
 	mode                          string
 	workspaceHeader               string
 	skipPaths                     pathMatcher
+	loopbackSkipPaths             pathMatcher
 	adminPaths                    pathMatcher
 	requireWorkspaceForAuthorized bool
 	userWorkspaceAllowlist        map[string]struct{}
@@ -151,6 +153,7 @@ func compileOptions(opts Options, logOut io.Writer) compiledOptions {
 		mode:                          NormalizeMode(opts.Mode),
 		workspaceHeader:               workspaceHeader,
 		skipPaths:                     newPathMatcher(opts.SkipPaths),
+		loopbackSkipPaths:             newPathMatcher(opts.LoopbackSkipPaths),
 		adminPaths:                    newPathMatcher(opts.AdminPaths),
 		requireWorkspaceForAuthorized: opts.RequireWorkspaceForAuthorized,
 		userWorkspaceAllowlist:        toWorkspaceAllowlist(opts.UserWorkspaceAllowlist),
@@ -262,6 +265,9 @@ func (c compiledOptions) requirementForRequest(r *http.Request) requestRequireme
 		return requestRequirement{}
 	}
 	if c.skipPaths.match(r.URL.Path) {
+		return requestRequirement{skip: true}
+	}
+	if c.loopbackSkipPaths.match(r.URL.Path) && isLoopbackRemoteAddr(r.RemoteAddr) {
 		return requestRequirement{skip: true}
 	}
 	requireToken := c.mode == ModeRequired

--- a/internal/serverauth/middleware_test.go
+++ b/internal/serverauth/middleware_test.go
@@ -115,6 +115,33 @@ func TestMiddleware_Off_AllowsAnyRequest(t *testing.T) {
 	}
 }
 
+func TestMiddleware_LoopbackSkipPaths_SkipOnlyAppliesToLoopbackRequests(t *testing.T) {
+	mw := NewMiddleware(Options{
+		Mode:              ModeRequired,
+		BearerToken:       "dev-token",
+		LoopbackSkipPaths: []string{"/dashboards", "/ui/projects/*"},
+	}, io.Discard)
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(r.URL.Path))
+	}))
+
+	loopbackReq := httptest.NewRequest(http.MethodGet, "/ui/projects/demo", nil)
+	loopbackReq.RemoteAddr = "127.0.0.1:1234"
+	loopbackRec := httptest.NewRecorder()
+	h.ServeHTTP(loopbackRec, loopbackReq)
+	if loopbackRec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for loopback skip path, got %d body=%q", loopbackRec.Code, loopbackRec.Body.String())
+	}
+
+	externalReq := httptest.NewRequest(http.MethodGet, "/ui/projects/demo", nil)
+	externalReq.RemoteAddr = "192.0.2.44:5555"
+	externalRec := httptest.NewRecorder()
+	h.ServeHTTP(externalRec, externalReq)
+	if externalRec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for external request on loopback-only skip path, got %d body=%q", externalRec.Code, externalRec.Body.String())
+	}
+}
+
 func TestMiddleware_SetsWorkspaceIDFromHeader(t *testing.T) {
 	mw := NewMiddleware(Options{
 		Mode:            ModeOff,

--- a/internal/tarsserver/handler_session.go
+++ b/internal/tarsserver/handler_session.go
@@ -311,7 +311,7 @@ func newStatusAPIHandler(workspaceDir string, store *session.Store, mainSessionI
 	})
 }
 
-func newHealthzAPIHandler(nowFn func() time.Time) http.Handler {
+func newHealthzAPIHandler(nowFn func() time.Time, dashboardAuthStatus map[string]any) http.Handler {
 	if nowFn == nil {
 		nowFn = time.Now
 	}
@@ -319,11 +319,15 @@ func newHealthzAPIHandler(nowFn func() time.Time) http.Handler {
 		if !requireMethod(w, r, http.MethodGet) {
 			return
 		}
-		writeJSON(w, http.StatusOK, map[string]any{
+		body := map[string]any{
 			"ok":        true,
 			"component": "tars",
 			"time":      nowFn().UTC().Format(time.RFC3339),
-		})
+		}
+		if dashboardAuthStatus != nil {
+			body["dashboard_auth"] = dashboardAuthStatus
+		}
+		writeJSON(w, http.StatusOK, body)
 	})
 }
 

--- a/internal/tarsserver/main_serve_api.go
+++ b/internal/tarsserver/main_serve_api.go
@@ -415,7 +415,7 @@ func buildAPIMux(
 	opsHandler := newOpsAPIHandler(opsManager, logger, dispatcher.Emit)
 	statusHandler := newStatusAPIHandler(cfg.WorkspaceDir, sessionStore, mainSessionID, logger)
 	authHandler := newAuthAPIHandler(cfg.APIAuthMode)
-	healthzHandler := newHealthzAPIHandler(nowFn)
+	healthzHandler := newHealthzAPIHandler(nowFn, dashboardAuthHealthzStatus(cfg))
 	providersModelsHandler := newProvidersModelsAPIHandler(providerModelsService, logger)
 	compactHandler := newCompactAPIHandler(cfg.WorkspaceDir, sessionStore, deps.llmClient, logger)
 	cronHandler := newCronAPIHandlerWithRunnerAndResolver(cronStoreResolver, cronRunner, logger)

--- a/internal/tarsserver/main_test.go
+++ b/internal/tarsserver/main_test.go
@@ -2144,7 +2144,7 @@ func TestStatusAPI(t *testing.T) {
 
 func TestHealthzAPI(t *testing.T) {
 	now := time.Date(2026, 2, 18, 8, 0, 0, 0, time.UTC)
-	handler := newHealthzAPIHandler(func() time.Time { return now })
+	handler := newHealthzAPIHandler(func() time.Time { return now }, nil)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/v1/healthz", nil)
@@ -2176,6 +2176,34 @@ func TestHealthzAPI(t *testing.T) {
 	handler.ServeHTTP(methodRec, methodReq)
 	if methodRec.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("expected 405, got %d body=%q", methodRec.Code, methodRec.Body.String())
+	}
+}
+
+func TestHealthzAPI_IncludesDashboardAuthWarning(t *testing.T) {
+	now := time.Date(2026, 2, 18, 8, 0, 0, 0, time.UTC)
+	handler := newHealthzAPIHandler(func() time.Time { return now }, map[string]any{
+		"mode":          "off",
+		"public_access": "loopback-only",
+		"warning":       "dashboard auth off is restricted to loopback requests",
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/healthz", nil)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%q", rec.Code, rec.Body.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode healthz response: %v", err)
+	}
+	dashboardAuth, ok := payload["dashboard_auth"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected dashboard_auth object, got %+v", payload["dashboard_auth"])
+	}
+	if got := strings.TrimSpace(asString(dashboardAuth["public_access"])); got != "loopback-only" {
+		t.Fatalf("expected public_access loopback-only, got %q", got)
 	}
 }
 

--- a/internal/tarsserver/middleware.go
+++ b/internal/tarsserver/middleware.go
@@ -11,6 +11,12 @@ import (
 )
 
 func applyAPIMiddleware(cfg config.Config, logger zerolog.Logger, next http.Handler, authLog io.Writer) http.Handler {
+	if dashboardAuthIsLoopbackOnly(cfg) {
+		logger.Warn().
+			Str("dashboard_auth_mode", "off").
+			Str("public_access", "loopback-only").
+			Msg("dashboard auth off is restricted to loopback requests")
+	}
 	auth := serverauth.NewMiddleware(serverauth.Options{
 		Mode:                          cfg.APIAuthMode,
 		BearerToken:                   cfg.APIAuthToken,
@@ -18,19 +24,14 @@ func applyAPIMiddleware(cfg config.Config, logger zerolog.Logger, next http.Hand
 		AdminToken:                    cfg.APIAdminToken,
 		RequireWorkspaceForAuthorized: false,
 		SkipPaths:                     apiAuthSkipPaths(cfg),
+		LoopbackSkipPaths:             dashboardLoopbackSkipPaths(cfg),
 		AdminPaths:                    apiAdminPaths(),
 	}, authLog)
 	return requestDebugMiddleware(logger, auth(withDefaultWorkspaceBinding(next)))
 }
 
 func apiAuthSkipPaths(cfg config.Config) []string {
-	paths := []string{
-		"/v1/healthz",
-	}
-	if strings.TrimSpace(strings.ToLower(cfg.DashboardAuthMode)) == "off" {
-		paths = append(paths, "/dashboards", "/dashboards/", "/ui/projects/*")
-	}
-	return paths
+	return []string{"/v1/healthz"}
 }
 
 func apiAdminPaths() []string {
@@ -58,4 +59,26 @@ func withDefaultWorkspaceBinding(next http.Handler) http.Handler {
 		req := r.WithContext(serverauth.WithWorkspaceID(r.Context(), defaultWorkspaceID))
 		next.ServeHTTP(w, req)
 	})
+}
+
+func dashboardLoopbackSkipPaths(cfg config.Config) []string {
+	if !dashboardAuthIsLoopbackOnly(cfg) {
+		return nil
+	}
+	return []string{"/dashboards", "/dashboards/", "/ui/projects/*"}
+}
+
+func dashboardAuthHealthzStatus(cfg config.Config) map[string]any {
+	if !dashboardAuthIsLoopbackOnly(cfg) {
+		return nil
+	}
+	return map[string]any{
+		"mode":          "off",
+		"public_access": "loopback-only",
+		"warning":       "dashboard auth off is restricted to loopback requests",
+	}
+}
+
+func dashboardAuthIsLoopbackOnly(cfg config.Config) bool {
+	return strings.TrimSpace(strings.ToLower(cfg.DashboardAuthMode)) == "off"
 }

--- a/internal/tarsserver/middleware_test.go
+++ b/internal/tarsserver/middleware_test.go
@@ -88,7 +88,7 @@ func TestApplyAPIMiddleware_AdminPathRequiresAdminRole(t *testing.T) {
 	}
 }
 
-func TestApplyAPIMiddleware_AllowsDashboardRoutesWithoutAuthWhenDashboardAuthIsOff(t *testing.T) {
+func TestApplyAPIMiddleware_DashboardRoutesWithoutAuthAreLoopbackOnlyWhenDashboardAuthIsOff(t *testing.T) {
 	cfg := config.Config{
 		APIAuthMode:       "required",
 		APIUserToken:      "user-token",
@@ -98,19 +98,29 @@ func TestApplyAPIMiddleware_AllowsDashboardRoutesWithoutAuthWhenDashboardAuthIsO
 	h := applyAPIMiddleware(cfg, zerolog.New(io.Discard), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(r.URL.Path))
 	}), io.Discard)
-
 	for _, path := range []string{"/dashboards", "/ui/projects/demo"} {
-		t.Run(path, func(t *testing.T) {
+		t.Run("loopback "+path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.RemoteAddr = "127.0.0.1:5555"
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200 for loopback dashboard path %q, got %d body=%q", path, rec.Code, rec.Body.String())
+			}
+			if got := strings.TrimSpace(rec.Body.String()); got != path {
+				t.Fatalf("expected dashboard path body %q, got %q", path, got)
+			}
+		})
+
+		t.Run("external "+path, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, path, nil)
 			req.RemoteAddr = "192.0.2.10:5555"
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, req)
 
-			if rec.Code != http.StatusOK {
-				t.Fatalf("expected 200 for dashboard path %q, got %d body=%q", path, rec.Code, rec.Body.String())
-			}
-			if got := strings.TrimSpace(rec.Body.String()); got != path {
-				t.Fatalf("expected dashboard path body %q, got %q", path, got)
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("expected 401 for external dashboard path %q, got %d body=%q", path, rec.Code, rec.Body.String())
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- close #65 by preventing `dashboard_auth_mode=off` from exposing dashboard routes to non-loopback requests
- publish the effective dashboard exposure mode through `/v1/healthz` and emit a startup warning when auth-off mode is active

## Changes
- add loopback-only skip path support to `internal/serverauth` so selected routes can bypass auth only for local requests
- switch dashboard auth-off handling to use loopback-only skips instead of global unauthenticated skips
- include dashboard auth exposure status in `healthz` output and add regression coverage for loopback/external behavior
- API, config, or compatibility changes: external unauthenticated dashboard access is no longer allowed when `dashboard_auth_mode=off`; loopback access remains open

## Validation
- [x] `go test ./internal/serverauth ./internal/tarsserver`
- [x] `go test ./...`
- [x] Additional manual verification, if needed: inspected middleware diff and exercised loopback/external dashboard auth paths in tests

## Checklist
- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [x] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [x] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback
- Risk level: medium-low, because the change tightens one auth bypass path but keeps authenticated and loopback paths covered by tests
- Rollback plan: revert commit `4cc62c2` or the PR squash commit if dashboard auth behavior needs to be restored temporarily