### PR TITLE
fix: warn on browser relay query tokens

### DIFF
--- a/internal/browserrelay/server.go
+++ b/internal/browserrelay/server.go
@@ -337,6 +337,7 @@ func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
 	payload := map[string]any{
 		"Browser": "Tars Relay",
 	}
+	s.addQueryTokenStatus(payload)
 	if s.hasExtension() {
 		payload["webSocketDebuggerUrl"] = s.CDPWebSocketURL()
 	}
@@ -532,10 +533,20 @@ func (s *Server) handleExtensionStatus(w http.ResponseWriter, r *http.Request) {
 	if !s.authorizeRelayRequest(w, r) {
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{
+	payload := map[string]any{
 		"connected":     s.hasExtension(),
 		"attached_tabs": s.AttachedTabs(),
-	})
+	}
+	s.addQueryTokenStatus(payload)
+	writeJSON(w, http.StatusOK, payload)
+}
+
+func (s *Server) addQueryTokenStatus(payload map[string]any) {
+	if payload == nil || s == nil || !s.opts.AllowQueryToken {
+		return
+	}
+	payload["query_token_enabled"] = true
+	payload["query_token_warning"] = "query token auth is enabled and may leak through browser history or logs"
 }
 
 func (s *Server) forwardExtensionToCDP(conn *websocket.Conn) {

--- a/internal/browserrelay/server_test.go
+++ b/internal/browserrelay/server_test.go
@@ -741,6 +741,47 @@ func TestRelayExtensionStatusRequiresToken(t *testing.T) {
 	}
 }
 
+func TestRelayExtensionStatusWarnsWhenQueryTokensAreEnabled(t *testing.T) {
+	srv, err := New(Options{
+		Addr:            "127.0.0.1:0",
+		RelayToken:      "relay-token",
+		AllowQueryToken: true,
+		OriginAllowlist: []string{"chrome-extension://*"},
+	})
+	if err != nil {
+		t.Fatalf("new relay: %v", err)
+	}
+	if err := srv.Start(context.Background()); err != nil {
+		t.Fatalf("start relay: %v", err)
+	}
+	t.Cleanup(func() { _ = srv.Close(context.Background()) })
+
+	req, err := http.NewRequest(http.MethodGet, "http://"+srv.Addr()+"/extension/status", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Tars-Relay-Token", "relay-token")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("get extension status: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 for /extension/status with token, got %d", res.StatusCode)
+	}
+
+	var payload map[string]any
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode extension status: %v", err)
+	}
+	if enabled, ok := payload["query_token_enabled"].(bool); !ok || !enabled {
+		t.Fatalf("expected query_token_enabled=true, got %+v", payload["query_token_enabled"])
+	}
+	if got := strings.TrimSpace(asString(payload["query_token_warning"])); got == "" {
+		t.Fatalf("expected query_token_warning to be populated, got %+v", payload)
+	}
+}
+
 func TestRelayJSONActivateAndCloseWithToken(t *testing.T) {
 	srv, err := New(Options{
 		Addr:            "127.0.0.1:0",


### PR DESCRIPTION
## Summary
- close #67 by making query-token relay mode advertise its risk through relay status responses
- keep the default header-only relay auth path unchanged while adding explicit warning metadata when query tokens are enabled

## Changes
- add query-token warning fields to browser relay status/version payloads when `AllowQueryToken` is enabled
- add regression coverage for the new warning signal on `/extension/status`
- API, config, or compatibility changes: none for default setups; instances that already opt into query-token auth now expose warning metadata in relay responses

## Validation
- [x] `go test ./internal/browserrelay`
- [x] `go test ./...`
- [x] Additional manual verification, if needed: inspected response payload changes and verified default query-token rejection remains covered by existing tests

## Checklist
- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [x] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [x] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback
- Risk level: low, because the change only adds warning metadata for an already opt-in mode
- Rollback plan: revert commit `a0f24cc` or the PR squash commit if any relay client depends on the exact old payload shape