### PR TITLE
chore: centralize project state transitions

### DIFF
--- a/internal/project/brief_state.go
+++ b/internal/project/brief_state.go
@@ -196,7 +196,7 @@ func (s *Store) UpdateState(projectID string, input ProjectStateUpdateInput) (Pr
 		if _, getErr := s.Get(projectID); getErr != nil {
 			return ProjectState{}, getErr
 		}
-		item = ProjectState{ProjectID: projectID, Phase: "planning", Status: "active"}
+		item = DefaultWorkflowPolicy.DefaultProjectState(projectID)
 	}
 	before := item
 	applyProjectStateUpdateInput(&item, input)
@@ -257,14 +257,10 @@ func (s *Store) FinalizeBrief(id string, sessionStore *session.Store) (Project, 
 	if err != nil {
 		return Project{}, Brief{}, err
 	}
-	_, err = s.UpdateState(created.ID, ProjectStateUpdateInput{
-		Goal:           stringValuePtr(strings.TrimSpace(brief.Goal)),
-		Phase:          stringValuePtr("planning"),
-		Status:         stringValuePtr("active"),
-		NextAction:     stringValuePtr(defaultProjectNextAction(brief)),
-		RemainingTasks: append([]string(nil), brief.OpenQuestions...),
-		LastRunSummary: stringValuePtr("Project initialized from brief."),
-	})
+	initial := DefaultWorkflowPolicy.InitialProjectState(brief).stateInput()
+	initial.Goal = stringValuePtr(strings.TrimSpace(brief.Goal))
+	initial.RemainingTasks = append([]string(nil), brief.OpenQuestions...)
+	_, err = s.UpdateState(created.ID, initial)
 	if err != nil {
 		return Project{}, Brief{}, err
 	}
@@ -407,7 +403,9 @@ func parseProjectStateDocument(raw string) (ProjectState, error) {
 		return ProjectState{}, err
 	}
 	if !hasMeta {
-		return ProjectState{Phase: "planning", Status: "active", Body: strings.TrimSpace(raw)}, nil
+		item := DefaultWorkflowPolicy.DefaultProjectState("")
+		item.Body = strings.TrimSpace(raw)
+		return item, nil
 	}
 	parsed := map[string]any{}
 	if err := yaml.Unmarshal([]byte(metaRaw), &parsed); err != nil {

--- a/internal/project/project_runner.go
+++ b/internal/project/project_runner.go
@@ -243,7 +243,7 @@ func (m *AutopilotManager) run(ctx context.Context, projectID, runID string) {
 				item.Iterations = iteration
 				item.FinishedAt = ""
 			})
-			m.updateState(projectID, "planning", "active", "Dispatch seeded backlog", "PM seeded MVP backlog", "")
+			m.updateState(projectID, DefaultWorkflowPolicy.AutopilotSeededBacklogState())
 			m.publish(projectID)
 			immediateStreak++
 			continue
@@ -254,7 +254,9 @@ func (m *AutopilotManager) run(ctx context.Context, projectID, runID string) {
 				item.Iterations = iteration
 				item.FinishedAt = ""
 			})
-			m.updateState(projectID, "executing", "active", "Dispatch todo tasks", "Autopilot dispatching todo tasks", "")
+			if update, ok := DefaultWorkflowPolicy.AutopilotDispatchState("todo"); ok {
+				m.updateState(projectID, update)
+			}
 			if _, err := orch.DispatchTodo(context.Background(), projectID); err != nil {
 				recovered, recoverErr := m.autoRecover(projectID, iteration, "todo dispatch", err)
 				if recoverErr != nil {
@@ -282,7 +284,9 @@ func (m *AutopilotManager) run(ctx context.Context, projectID, runID string) {
 				item.Iterations = iteration
 				item.FinishedAt = ""
 			})
-			m.updateState(projectID, "reviewing", "active", "Dispatch review tasks", "Autopilot dispatching review tasks", "")
+			if update, ok := DefaultWorkflowPolicy.AutopilotDispatchState("review"); ok {
+				m.updateState(projectID, update)
+			}
 			if _, err := orch.DispatchReview(context.Background(), projectID); err != nil {
 				recovered, recoverErr := m.autoRecover(projectID, iteration, "review dispatch", err)
 				if recoverErr != nil {
@@ -328,7 +332,7 @@ func (m *AutopilotManager) run(ctx context.Context, projectID, runID string) {
 			continue
 		case allBoardTasksDone(board):
 			message := "Autopilot completed all project tasks"
-			m.updateState(projectID, "done", "done", "Project complete", message, "")
+			m.updateState(projectID, DefaultWorkflowPolicy.AutopilotCompletedState(message))
 			m.setRun(projectID, func(item *AutopilotRun) {
 				item.Status = AutopilotStatusDone
 				item.Message = message
@@ -355,7 +359,7 @@ func (m *AutopilotManager) run(ctx context.Context, projectID, runID string) {
 }
 
 func (m *AutopilotManager) fail(projectID, runID string, iteration int, message string) {
-	m.updateState(projectID, "blocked", "blocked", "Inspect autopilot failure", strings.TrimSpace(message), strings.TrimSpace(message))
+	m.updateState(projectID, DefaultWorkflowPolicy.AutopilotFailedState(message))
 	m.setRun(projectID, func(item *AutopilotRun) {
 		item.RunID = runID
 		item.Status = AutopilotStatusFailed
@@ -368,7 +372,7 @@ func (m *AutopilotManager) fail(projectID, runID string, iteration int, message 
 
 func (m *AutopilotManager) block(projectID, runID string, iteration int, message string) {
 	_ = m.appendPMActivity(projectID, ActivityKindBlocker, "blocked", strings.TrimSpace(message), nil)
-	m.updateState(projectID, "blocked", "blocked", "Review blocker and continue", strings.TrimSpace(message), strings.TrimSpace(message))
+	m.updateState(projectID, DefaultWorkflowPolicy.AutopilotBlockedState(message, "Review blocker and continue"))
 	m.setRun(projectID, func(item *AutopilotRun) {
 		item.RunID = runID
 		item.Status = AutopilotStatusBlocked
@@ -382,10 +386,7 @@ func (m *AutopilotManager) block(projectID, runID string, iteration int, message
 func (m *AutopilotManager) noteBlocked(projectID, runID string, iteration int, message string, nextAction string) {
 	message = strings.TrimSpace(message)
 	nextAction = strings.TrimSpace(nextAction)
-	if nextAction == "" {
-		nextAction = "Autopilot will retry after the loop interval"
-	}
-	m.updateState(projectID, "blocked", "blocked", nextAction, message, message)
+	m.updateState(projectID, DefaultWorkflowPolicy.AutopilotBlockedState(message, nextAction))
 	m.setRun(projectID, func(item *AutopilotRun) {
 		item.RunID = runID
 		item.Status = AutopilotStatusRunning
@@ -411,30 +412,13 @@ func (m *AutopilotManager) setRun(projectID string, mutate func(*AutopilotRun)) 
 	m.runs[projectID] = item
 }
 
-func (m *AutopilotManager) updateState(projectID, phase, status, nextAction, summary, stopReason string) {
+func (m *AutopilotManager) updateState(projectID string, update workflowStateUpdate) {
 	if m == nil || m.store == nil {
 		return
 	}
-	phaseValue := phase
-	statusValue := status
-	next := nextAction
-	lastRunSummary := summary
-	stop := stopReason
 	lastRunAt := m.store.nowFn().UTC().Format(time.RFC3339)
-	input := ProjectStateUpdateInput{
-		Phase:          &phaseValue,
-		Status:         &statusValue,
-		NextAction:     &next,
-		LastRunSummary: &lastRunSummary,
-		LastRunAt:      &lastRunAt,
-	}
-	if strings.TrimSpace(stopReason) != "" {
-		input.StopReason = &stop
-	}
-	if strings.EqualFold(status, "done") {
-		completionSummary := summary
-		input.CompletionSummary = &completionSummary
-	}
+	input := update.stateInput()
+	input.LastRunAt = &lastRunAt
 	_, _ = m.store.UpdateState(projectID, input)
 }
 
@@ -539,16 +523,8 @@ func (m *AutopilotManager) autoRecover(projectID string, iteration int, reason e
 	if !boardHasStatus(board, "in_progress") {
 		return false, nil
 	}
-	tasks := make([]BoardTask, 0, len(board.Tasks))
-	recoveredIDs := make([]string, 0)
-	for _, task := range board.Tasks {
-		if task.Status == "in_progress" {
-			task.Status = "todo"
-			recoveredIDs = append(recoveredIDs, task.ID)
-		}
-		tasks = append(tasks, task)
-	}
-	if len(recoveredIDs) == 0 {
+	tasks, recoveredIDs, ok := DefaultWorkflowPolicy.RecoverStalledTasks(board.Tasks)
+	if !ok {
 		return false, nil
 	}
 	if _, err := m.store.UpdateBoard(projectID, BoardUpdateInput{
@@ -570,7 +546,7 @@ func (m *AutopilotManager) autoRecover(projectID string, iteration int, reason e
 	}
 	_ = m.appendPMActivity(projectID, ActivityKindDecision, "auto_retry", "PM diagnosed the blocker and retried the implementation loop without user input", meta)
 	_ = m.appendPMActivity(projectID, ActivityKindReplan, "applied", message, meta)
-	m.updateState(projectID, "executing", "active", "Retry recovered tasks", message, "")
+	m.updateState(projectID, DefaultWorkflowPolicy.AutopilotRecoveredState(message))
 	return true, nil
 }
 

--- a/internal/project/workflow_policy.go
+++ b/internal/project/workflow_policy.go
@@ -6,6 +6,38 @@ type WorkflowPolicy struct{}
 
 var DefaultWorkflowPolicy WorkflowPolicy
 
+type workflowStateUpdate struct {
+	Phase             string
+	Status            string
+	NextAction        string
+	LastRunSummary    string
+	StopReason        string
+	CompletionSummary string
+}
+
+func (u workflowStateUpdate) stateInput() ProjectStateUpdateInput {
+	input := ProjectStateUpdateInput{}
+	if trimmed := strings.TrimSpace(u.Phase); trimmed != "" {
+		input.Phase = stringValuePtr(trimmed)
+	}
+	if trimmed := strings.TrimSpace(u.Status); trimmed != "" {
+		input.Status = stringValuePtr(trimmed)
+	}
+	if trimmed := strings.TrimSpace(u.NextAction); trimmed != "" {
+		input.NextAction = stringValuePtr(trimmed)
+	}
+	if trimmed := strings.TrimSpace(u.LastRunSummary); trimmed != "" {
+		input.LastRunSummary = stringValuePtr(trimmed)
+	}
+	if trimmed := strings.TrimSpace(u.StopReason); trimmed != "" {
+		input.StopReason = stringValuePtr(trimmed)
+	}
+	if trimmed := strings.TrimSpace(u.CompletionSummary); trimmed != "" {
+		input.CompletionSummary = stringValuePtr(trimmed)
+	}
+	return input
+}
+
 func (WorkflowPolicy) NormalizeBriefStatus(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "collecting", "ready", "finalized":
@@ -52,6 +84,42 @@ func (p WorkflowPolicy) DefaultProjectNextAction(brief Brief) string {
 	return "Review project instructions and define the first executable milestone in STATE.md."
 }
 
+func (p WorkflowPolicy) DefaultProjectState(projectID string) ProjectState {
+	return ProjectState{
+		ProjectID: strings.TrimSpace(projectID),
+		Phase:     p.NormalizeProjectStatePhase(""),
+		Status:    p.NormalizeProjectStateStatus(""),
+	}
+}
+
+func (p WorkflowPolicy) InitialProjectState(brief Brief) workflowStateUpdate {
+	return workflowStateUpdate{
+		Phase:          "planning",
+		Status:         "active",
+		NextAction:     p.DefaultProjectNextAction(brief),
+		LastRunSummary: "Project initialized from brief.",
+	}
+}
+
+func (p WorkflowPolicy) ProjectStateSummary(item Project, state *ProjectState) (status, phase, nextAction string) {
+	status = strings.TrimSpace(item.Status)
+	if status == "" {
+		status = p.NormalizeProjectStateStatus("")
+	}
+	phase = p.NormalizeProjectStatePhase("")
+	if state == nil {
+		return status, phase, ""
+	}
+	if current := strings.TrimSpace(state.Status); current != "" {
+		status = p.NormalizeProjectStateStatus(current)
+	}
+	if current := strings.TrimSpace(state.Phase); current != "" {
+		phase = p.NormalizeProjectStatePhase(current)
+	}
+	nextAction = strings.TrimSpace(state.NextAction)
+	return status, phase, nextAction
+}
+
 func (WorkflowPolicy) IsKickoffMessage(message string) bool {
 	lower := strings.ToLower(strings.TrimSpace(message))
 	if lower == "" || strings.HasPrefix(lower, "/") {
@@ -86,6 +154,98 @@ func (WorkflowPolicy) NormalizeDispatchStage(raw string) (string, bool) {
 	default:
 		return "", false
 	}
+}
+
+func (WorkflowPolicy) AutopilotSeededBacklogState() workflowStateUpdate {
+	return workflowStateUpdate{
+		Phase:          "planning",
+		Status:         "active",
+		NextAction:     "Dispatch seeded backlog",
+		LastRunSummary: "PM seeded MVP backlog",
+	}
+}
+
+func (WorkflowPolicy) AutopilotDispatchState(stage string) (workflowStateUpdate, bool) {
+	switch strings.ToLower(strings.TrimSpace(stage)) {
+	case "todo":
+		return workflowStateUpdate{
+			Phase:          "executing",
+			Status:         "active",
+			NextAction:     "Dispatch todo tasks",
+			LastRunSummary: "Autopilot dispatching todo tasks",
+		}, true
+	case "review":
+		return workflowStateUpdate{
+			Phase:          "reviewing",
+			Status:         "active",
+			NextAction:     "Dispatch review tasks",
+			LastRunSummary: "Autopilot dispatching review tasks",
+		}, true
+	default:
+		return workflowStateUpdate{}, false
+	}
+}
+
+func (WorkflowPolicy) AutopilotRecoveredState(message string) workflowStateUpdate {
+	return workflowStateUpdate{
+		Phase:          "executing",
+		Status:         "active",
+		NextAction:     "Retry recovered tasks",
+		LastRunSummary: strings.TrimSpace(message),
+	}
+}
+
+func (WorkflowPolicy) AutopilotBlockedState(message string, nextAction string) workflowStateUpdate {
+	trimmedMessage := strings.TrimSpace(message)
+	trimmedNext := strings.TrimSpace(nextAction)
+	if trimmedNext == "" {
+		trimmedNext = "Autopilot will retry after the loop interval"
+	}
+	return workflowStateUpdate{
+		Phase:          "blocked",
+		Status:         "blocked",
+		NextAction:     trimmedNext,
+		LastRunSummary: trimmedMessage,
+		StopReason:     trimmedMessage,
+	}
+}
+
+func (WorkflowPolicy) AutopilotFailedState(message string) workflowStateUpdate {
+	trimmed := strings.TrimSpace(message)
+	return workflowStateUpdate{
+		Phase:          "blocked",
+		Status:         "blocked",
+		NextAction:     "Inspect autopilot failure",
+		LastRunSummary: trimmed,
+		StopReason:     trimmed,
+	}
+}
+
+func (WorkflowPolicy) AutopilotCompletedState(message string) workflowStateUpdate {
+	trimmed := strings.TrimSpace(message)
+	return workflowStateUpdate{
+		Phase:             "done",
+		Status:            "done",
+		NextAction:        "Project complete",
+		LastRunSummary:    trimmed,
+		CompletionSummary: trimmed,
+	}
+}
+
+func (WorkflowPolicy) RecoverStalledTasks(tasks []BoardTask) ([]BoardTask, []string, bool) {
+	recovered := make([]BoardTask, 0, len(tasks))
+	recoveredIDs := make([]string, 0)
+	for _, task := range tasks {
+		if strings.TrimSpace(task.Status) == "in_progress" {
+			task.Status = "todo"
+			recoveredIDs = append(recoveredIDs, task.ID)
+		}
+		recovered = append(recovered, task)
+	}
+	if len(recoveredIDs) == 0 {
+		return nil, nil, false
+	}
+	return recovered, recoveredIDs, true
 }
 
 func (WorkflowPolicy) FilterDispatchableTasks(status string, tasks []BoardTask) []BoardTask {

--- a/internal/project/workflow_policy_test.go
+++ b/internal/project/workflow_policy_test.go
@@ -94,3 +94,98 @@ func TestWorkflowPolicyDispatchAndAutopilotHelpers(t *testing.T) {
 		t.Fatalf("expected done project state to stop autopilot")
 	}
 }
+
+func TestWorkflowPolicyProjectStateDefaultsAndSummary(t *testing.T) {
+	policy := DefaultWorkflowPolicy
+
+	defaultState := policy.DefaultProjectState("project-1")
+	if defaultState.ProjectID != "project-1" {
+		t.Fatalf("expected project id to round-trip, got %+v", defaultState)
+	}
+	if defaultState.Phase != "planning" || defaultState.Status != "active" {
+		t.Fatalf("expected default planning/active state, got %+v", defaultState)
+	}
+
+	initial := policy.InitialProjectState(Brief{
+		Goal:          "Ship dashboard",
+		OpenQuestions: []string{"Who owns the first release?"},
+	})
+	if initial.Phase != "planning" || initial.Status != "active" {
+		t.Fatalf("expected brief init state to start planning/active, got %+v", initial)
+	}
+	if initial.NextAction != "Who owns the first release?" {
+		t.Fatalf("expected brief next action from open question, got %+v", initial)
+	}
+	if initial.LastRunSummary != "Project initialized from brief." {
+		t.Fatalf("expected brief init summary, got %+v", initial)
+	}
+
+	status, phase, nextAction := policy.ProjectStateSummary(Project{Status: "active"}, nil)
+	if status != "active" || phase != "planning" || nextAction != "" {
+		t.Fatalf("expected dashboard fallback summary, got status=%q phase=%q next=%q", status, phase, nextAction)
+	}
+
+	status, phase, nextAction = policy.ProjectStateSummary(Project{Status: "archived"}, &ProjectState{
+		Status:     "blocked",
+		Phase:      "reviewing",
+		NextAction: "Review blocker",
+	})
+	if status != "blocked" || phase != "reviewing" || nextAction != "Review blocker" {
+		t.Fatalf("expected state summary to prefer normalized project state, got status=%q phase=%q next=%q", status, phase, nextAction)
+	}
+}
+
+func TestWorkflowPolicyAutopilotStateUpdates(t *testing.T) {
+	policy := DefaultWorkflowPolicy
+
+	seeded := policy.AutopilotSeededBacklogState()
+	if seeded.Phase != "planning" || seeded.Status != "active" || seeded.NextAction != "Dispatch seeded backlog" {
+		t.Fatalf("unexpected seeded backlog state: %+v", seeded)
+	}
+
+	todo, ok := policy.AutopilotDispatchState("todo")
+	if !ok || todo.Phase != "executing" || todo.Status != "active" || todo.NextAction != "Dispatch todo tasks" {
+		t.Fatalf("unexpected todo dispatch state: ok=%v state=%+v", ok, todo)
+	}
+	review, ok := policy.AutopilotDispatchState("review")
+	if !ok || review.Phase != "reviewing" || review.Status != "active" || review.NextAction != "Dispatch review tasks" {
+		t.Fatalf("unexpected review dispatch state: ok=%v state=%+v", ok, review)
+	}
+	if _, ok := policy.AutopilotDispatchState("unknown"); ok {
+		t.Fatalf("expected unknown dispatch stage to be rejected")
+	}
+
+	recovered := policy.AutopilotRecoveredState("PM auto-requeued stalled task: task-1")
+	if recovered.Phase != "executing" || recovered.Status != "active" || recovered.NextAction != "Retry recovered tasks" {
+		t.Fatalf("unexpected recovered state: %+v", recovered)
+	}
+
+	blocked := policy.AutopilotBlockedState("Autopilot waiting on task: task-1", "")
+	if blocked.Phase != "blocked" || blocked.Status != "blocked" || blocked.NextAction != "Autopilot will retry after the loop interval" {
+		t.Fatalf("unexpected blocked state: %+v", blocked)
+	}
+
+	failed := policy.AutopilotFailedState("runner crashed")
+	if failed.Phase != "blocked" || failed.Status != "blocked" || failed.NextAction != "Inspect autopilot failure" || failed.StopReason != "runner crashed" {
+		t.Fatalf("unexpected failure state: %+v", failed)
+	}
+
+	done := policy.AutopilotCompletedState("Autopilot completed all project tasks")
+	if done.Phase != "done" || done.Status != "done" || done.NextAction != "Project complete" || done.CompletionSummary != "Autopilot completed all project tasks" {
+		t.Fatalf("unexpected completed state: %+v", done)
+	}
+
+	recoveredTasks, recoveredIDs, ok := policy.RecoverStalledTasks([]BoardTask{
+		{ID: "task-1", Status: "in_progress"},
+		{ID: "task-2", Status: "done"},
+	})
+	if !ok {
+		t.Fatalf("expected stalled task recovery to be detected")
+	}
+	if len(recoveredIDs) != 1 || recoveredIDs[0] != "task-1" {
+		t.Fatalf("unexpected recovered ids: %v", recoveredIDs)
+	}
+	if recoveredTasks[0].Status != "todo" || recoveredTasks[1].Status != "done" {
+		t.Fatalf("unexpected recovered tasks: %+v", recoveredTasks)
+	}
+}

--- a/internal/tarsserver/dashboard.go
+++ b/internal/tarsserver/dashboard.go
@@ -16,6 +16,9 @@ import (
 type projectDashboardPageData struct {
 	Project    project.Project
 	State      *project.ProjectState
+	Status     string
+	Phase      string
+	NextAction string
 	Autopilot  *project.AutopilotRun
 	Activity   []project.Activity
 	Board      project.Board
@@ -284,15 +287,15 @@ var projectDashboardTemplate = template.Must(template.New("project-dashboard").P
       </article>
       <article class="card">
         <div class="label">Status</div>
-        <div class="value">{{if .State}}{{.State.Status}}{{else}}{{.Project.Status}}{{end}}</div>
+        <div class="value">{{.Status}}</div>
       </article>
       <article class="card">
         <div class="label">Phase</div>
-        <div class="value">{{if .State}}{{.State.Phase}}{{else}}planning{{end}}</div>
+        <div class="value">{{.Phase}}</div>
       </article>
       <article class="card">
         <div class="label">Next Action</div>
-        <div class="value">{{if and .State .State.NextAction}}{{.State.NextAction}}{{else}}-{{end}}</div>
+        <div class="value">{{if .NextAction}}{{.NextAction}}{{else}}-{{end}}</div>
       </article>
     </section>
 
@@ -686,23 +689,20 @@ func buildProjectDashboardList(store *project.Store, autopilot projectAutopilotS
 	}
 	rows := make([]projectDashboardListItem, 0, len(projects))
 	for _, item := range projects {
+		var state *project.ProjectState
+		if current, err := store.GetState(item.ID); err == nil {
+			state = &current
+		}
+		status, phase, nextAction := project.DefaultWorkflowPolicy.ProjectStateSummary(item, state)
 		row := projectDashboardListItem{
 			ID:            strings.TrimSpace(item.ID),
 			Name:          strings.TrimSpace(item.Name),
 			Objective:     strings.TrimSpace(item.Objective),
-			Status:        strings.TrimSpace(item.Status),
-			Phase:         "planning",
+			Status:        status,
+			Phase:         phase,
+			NextAction:    nextAction,
 			UpdatedAt:     strings.TrimSpace(item.UpdatedAt),
 			DashboardPath: fmt.Sprintf("/ui/projects/%s", strings.TrimSpace(item.ID)),
-		}
-		if current, err := store.GetState(item.ID); err == nil {
-			if status := strings.TrimSpace(current.Status); status != "" {
-				row.Status = status
-			}
-			if phase := strings.TrimSpace(current.Phase); phase != "" {
-				row.Phase = phase
-			}
-			row.NextAction = strings.TrimSpace(current.NextAction)
 		}
 		if autopilot != nil {
 			if current, ok := autopilot.Status(item.ID); ok {
@@ -738,9 +738,13 @@ func buildProjectDashboardPageData(
 	activity []project.Activity,
 	board project.Board,
 ) projectDashboardPageData {
+	status, phase, nextAction := project.DefaultWorkflowPolicy.ProjectStateSummary(item, state)
 	data := projectDashboardPageData{
 		Project:    item,
 		State:      state,
+		Status:     status,
+		Phase:      phase,
+		NextAction: nextAction,
 		Autopilot:  autopilotRun,
 		Activity:   activity,
 		Board:      board,


### PR DESCRIPTION
## Summary

- Centralize project state defaults, initial brief state, dashboard summary, and autopilot state updates in `internal/project/workflow_policy.go`
- Replace duplicated autopilot and dashboard state interpretation with shared workflow policy helpers
- Add workflow policy tests covering project-state defaults, autopilot state payloads, and stalled-task recovery

Why this approach is correct:
The existing kickoff and dispatch policy extraction already centralized state normalization and stage gates, but the actual state payloads were still duplicated across `brief_state.go`, `project_runner.go`, and the dashboard. Moving those payloads into the same workflow policy keeps behavior unchanged while making new phase or retry-rule edits local to one place.

Closes #73

## Changes

- Main user-visible or developer-visible changes:
  - Dashboard list/detail pages now render status, phase, and next action from the shared workflow summary helper
  - Brief finalization and autopilot recovery/blocked/done transitions now reuse workflow policy state builders
- API, config, or compatibility changes:
  - None

## Validation

- [x] `make test`
- [x] `make security-scan`
- [x] Additional manual verification, if needed
  - `go test ./internal/project -run 'TestStoreUpdateBriefAndFinalize|TestStoreStateRoundtripAndNormalization|TestStoreStatePreservesDraftingPhase|TestAutopilotManager_'`
  - `go test ./internal/tarsserver -run 'TestProjectDashboardHandler_'`

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [ ] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [ ] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level:
  - Low. This is a behavior-preserving refactor around project workflow state plumbing.
- Rollback plan:
  - Revert the squash merge commit for this PR to restore the previous inline state updates.
