### PR TITLE
fix: reduce llm duplication and harden Telegram redaction

### DIFF
--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -25,14 +25,14 @@ type AnthropicClient struct {
 
 func NewAnthropicClient(baseURL, apiKey, model string, maxTokens int) (*AnthropicClient, error) {
 	config := DefaultClientConfig()
-	if strings.TrimSpace(baseURL) == "" {
-		return nil, fmt.Errorf("anthropic base url is required")
+	if _, err := requireConfiguredValue("anthropic", "base url", baseURL); err != nil {
+		return nil, err
 	}
-	if strings.TrimSpace(apiKey) == "" {
-		return nil, fmt.Errorf("anthropic api key is required")
+	if _, err := requireConfiguredValue("anthropic", "api key", apiKey); err != nil {
+		return nil, err
 	}
-	if strings.TrimSpace(model) == "" {
-		return nil, fmt.Errorf("anthropic model is required")
+	if _, err := requireConfiguredValue("anthropic", "model", model); err != nil {
+		return nil, err
 	}
 
 	if maxTokens <= 0 {
@@ -94,16 +94,7 @@ func (c *AnthropicClient) Chat(ctx context.Context, messages []ChatMessage, opts
 }
 
 func (c *AnthropicClient) Ask(ctx context.Context, prompt string) (string, error) {
-	resp, err := c.Chat(ctx, []ChatMessage{
-		{
-			Role:    "user",
-			Content: prompt,
-		},
-	}, ChatOptions{})
-	if err != nil {
-		return "", err
-	}
-	return resp.Message.Content, nil
+	return askFromSinglePrompt(ctx, c.Chat, prompt)
 }
 
 func (c *AnthropicClient) buildChatRequest(messages []ChatMessage, opts ChatOptions, streaming bool) map[string]any {

--- a/internal/llm/ask.go
+++ b/internal/llm/ask.go
@@ -1,0 +1,20 @@
+package llm
+
+import "context"
+
+func askFromSinglePrompt(
+	ctx context.Context,
+	chat func(context.Context, []ChatMessage, ChatOptions) (ChatResponse, error),
+	prompt string,
+	normalizers ...func(string) string,
+) (string, error) {
+	resp, err := chat(ctx, []ChatMessage{{Role: "user", Content: prompt}}, ChatOptions{})
+	if err != nil {
+		return "", err
+	}
+	content := resp.Message.Content
+	if len(normalizers) > 0 && normalizers[0] != nil {
+		content = normalizers[0](content)
+	}
+	return content, nil
+}

--- a/internal/llm/ask_test.go
+++ b/internal/llm/ask_test.go
@@ -1,0 +1,82 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestAskFromSinglePrompt_ReturnsAssistantContent(t *testing.T) {
+	t.Parallel()
+
+	var gotMessages []ChatMessage
+	got, err := askFromSinglePrompt(
+		context.Background(),
+		func(_ context.Context, messages []ChatMessage, opts ChatOptions) (ChatResponse, error) {
+			gotMessages = messages
+			if !reflect.DeepEqual(opts, ChatOptions{}) {
+				t.Fatalf("expected empty chat options, got %+v", opts)
+			}
+			return ChatResponse{
+				Message: ChatMessage{
+					Role:    "assistant",
+					Content: "hello",
+				},
+			}, nil
+		},
+		"ping",
+	)
+	if err != nil {
+		t.Fatalf("ask from single prompt: %v", err)
+	}
+	if got != "hello" {
+		t.Fatalf("expected assistant content hello, got %q", got)
+	}
+	wantMessages := []ChatMessage{{Role: "user", Content: "ping"}}
+	if !reflect.DeepEqual(gotMessages, wantMessages) {
+		t.Fatalf("expected messages %+v, got %+v", wantMessages, gotMessages)
+	}
+}
+
+func TestAskFromSinglePrompt_WithNormalizer_TransformsAssistantContent(t *testing.T) {
+	t.Parallel()
+
+	got, err := askFromSinglePrompt(
+		context.Background(),
+		func(_ context.Context, _ []ChatMessage, _ ChatOptions) (ChatResponse, error) {
+			return ChatResponse{
+				Message: ChatMessage{
+					Role:    "assistant",
+					Content: "  hello  \n",
+				},
+			}, nil
+		},
+		"ping",
+		func(content string) string {
+			return "trimmed:" + content[2:7]
+		},
+	)
+	if err != nil {
+		t.Fatalf("ask from single prompt: %v", err)
+	}
+	if got != "trimmed:hello" {
+		t.Fatalf("expected normalized content, got %q", got)
+	}
+}
+
+func TestAskFromSinglePrompt_PropagatesChatError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("boom")
+	_, err := askFromSinglePrompt(
+		context.Background(),
+		func(_ context.Context, _ []ChatMessage, _ ChatOptions) (ChatResponse, error) {
+			return ChatResponse{}, wantErr
+		},
+		"ping",
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected error %v, got %v", wantErr, err)
+	}
+}

--- a/internal/llm/claude_code_cli.go
+++ b/internal/llm/claude_code_cli.go
@@ -60,11 +60,7 @@ func NewClaudeCodeCLIClient(workDir, model string) (*ClaudeCodeCLIClient, error)
 }
 
 func (c *ClaudeCodeCLIClient) Ask(ctx context.Context, prompt string) (string, error) {
-	resp, err := c.Chat(ctx, []ChatMessage{{Role: "user", Content: prompt}}, ChatOptions{})
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(resp.Message.Content), nil
+	return askFromSinglePrompt(ctx, c.Chat, prompt, strings.TrimSpace)
 }
 
 func (c *ClaudeCodeCLIClient) Chat(ctx context.Context, messages []ChatMessage, opts ChatOptions) (ChatResponse, error) {

--- a/internal/llm/client_config_test.go
+++ b/internal/llm/client_config_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -16,6 +17,26 @@ func TestDefaultClientConfig(t *testing.T) {
 	}
 	if cfg.MaxTokens != 0 {
 		t.Fatalf("expected MaxTokens 0, got %d", cfg.MaxTokens)
+	}
+}
+
+func TestRequireConfiguredValue(t *testing.T) {
+	t.Parallel()
+
+	got, err := requireConfiguredValue("openai", "model", "  gpt-4o-mini  ")
+	if err != nil {
+		t.Fatalf("require configured value: %v", err)
+	}
+	if got != "gpt-4o-mini" {
+		t.Fatalf("expected trimmed value, got %q", got)
+	}
+
+	_, err = requireConfiguredValue("anthropic", "api key", " \t ")
+	if err == nil {
+		t.Fatal("expected error for blank configured value")
+	}
+	if !strings.Contains(err.Error(), "anthropic api key is required") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/llm/gemini_native.go
+++ b/internal/llm/gemini_native.go
@@ -76,11 +76,7 @@ func newGeminiNativeClientWithConfig(baseURL, apiKey, model string, config Clien
 }
 
 func (c *GeminiNativeClient) Ask(ctx context.Context, prompt string) (string, error) {
-	resp, err := c.Chat(ctx, []ChatMessage{{Role: "user", Content: prompt}}, ChatOptions{})
-	if err != nil {
-		return "", err
-	}
-	return resp.Message.Content, nil
+	return askFromSinglePrompt(ctx, c.Chat, prompt)
 }
 
 func (c *GeminiNativeClient) Chat(ctx context.Context, messages []ChatMessage, opts ChatOptions) (ChatResponse, error) {

--- a/internal/llm/openai_codex_client.go
+++ b/internal/llm/openai_codex_client.go
@@ -92,11 +92,11 @@ func newOpenAICodexClientWithConfig(
 	resolver codexCredentialResolver,
 	refresher codexCredentialRefresher,
 ) (*OpenAICodexClient, error) {
-	if strings.TrimSpace(baseURL) == "" {
-		return nil, fmt.Errorf("%s base url is required", openAICodexProviderLabel)
+	if _, err := requireConfiguredValue(openAICodexProviderLabel, "base url", baseURL); err != nil {
+		return nil, err
 	}
-	if strings.TrimSpace(model) == "" {
-		return nil, fmt.Errorf("%s model is required", openAICodexProviderLabel)
+	if _, err := requireConfiguredValue(openAICodexProviderLabel, "model", model); err != nil {
+		return nil, err
 	}
 
 	mode := strings.TrimSpace(strings.ToLower(authMode))
@@ -141,11 +141,7 @@ func newOpenAICodexClientWithConfig(
 }
 
 func (c *OpenAICodexClient) Ask(ctx context.Context, prompt string) (string, error) {
-	resp, err := c.Chat(ctx, []ChatMessage{{Role: "user", Content: prompt}}, ChatOptions{})
-	if err != nil {
-		return "", err
-	}
-	return resp.Message.Content, nil
+	return askFromSinglePrompt(ctx, c.Chat, prompt)
 }
 
 func (c *OpenAICodexClient) Chat(ctx context.Context, messages []ChatMessage, opts ChatOptions) (ChatResponse, error) {

--- a/internal/llm/openai_compat_client.go
+++ b/internal/llm/openai_compat_client.go
@@ -26,14 +26,14 @@ type OpenAICompatibleClient struct {
 type openAICompatibleResponseContextKey struct{}
 
 func newOpenAICompatibleClientWithConfig(label, baseURL, apiKey, model string, config ClientConfig) (*OpenAICompatibleClient, error) {
-	if strings.TrimSpace(baseURL) == "" {
-		return nil, fmt.Errorf("%s base url is required", label)
+	if _, err := requireConfiguredValue(label, "base url", baseURL); err != nil {
+		return nil, err
 	}
-	if strings.TrimSpace(apiKey) == "" {
-		return nil, fmt.Errorf("%s api key is required", label)
+	if _, err := requireConfiguredValue(label, "api key", apiKey); err != nil {
+		return nil, err
 	}
-	if strings.TrimSpace(model) == "" {
-		return nil, fmt.Errorf("%s model is required", label)
+	if _, err := requireConfiguredValue(label, "model", model); err != nil {
+		return nil, err
 	}
 
 	return &OpenAICompatibleClient{
@@ -287,11 +287,7 @@ func (c *OpenAICompatibleClient) chatNonStreaming(ctx context.Context, req *http
 }
 
 func (c *OpenAICompatibleClient) Ask(ctx context.Context, prompt string) (string, error) {
-	resp, err := c.Chat(ctx, []ChatMessage{{Role: "user", Content: prompt}}, ChatOptions{})
-	if err != nil {
-		return "", err
-	}
-	return resp.Message.Content, nil
+	return askFromSinglePrompt(ctx, c.Chat, prompt)
 }
 
 func orderedToolCalls(m map[int]ToolCall) []ToolCall {

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -193,19 +193,19 @@ func providerClientConfig(opts ProviderOptions) ClientConfig {
 func providerAuthConfig(opts ProviderOptions) auth.ProviderAuthConfig {
 	config := opts.AuthConfig
 	if strings.TrimSpace(config.Provider) == "" {
-		config.Provider = strings.TrimSpace(strings.ToLower(opts.Provider))
+		config.Provider = normalizeLowerTrimmed(opts.Provider)
 	}
 	if strings.TrimSpace(config.AuthMode) == "" {
-		config.AuthMode = strings.TrimSpace(strings.ToLower(opts.AuthMode))
+		config.AuthMode = normalizeLowerTrimmed(opts.AuthMode)
 	}
 	if strings.TrimSpace(config.OAuthProvider) == "" {
-		config.OAuthProvider = strings.TrimSpace(strings.ToLower(opts.OAuthProvider))
+		config.OAuthProvider = normalizeLowerTrimmed(opts.OAuthProvider)
 	}
 	if strings.TrimSpace(config.APIKey) == "" {
 		config.APIKey = strings.TrimSpace(opts.APIKey)
 	}
 
-	switch strings.TrimSpace(strings.ToLower(config.Provider)) {
+	switch normalizeLowerTrimmed(config.Provider) {
 	case "openai-codex":
 		if strings.TrimSpace(config.AuthMode) == "" {
 			config.AuthMode = "oauth"
@@ -215,9 +215,9 @@ func providerAuthConfig(opts ProviderOptions) auth.ProviderAuthConfig {
 		}
 	}
 
-	config.Provider = strings.TrimSpace(strings.ToLower(config.Provider))
-	config.AuthMode = strings.TrimSpace(strings.ToLower(config.AuthMode))
-	config.OAuthProvider = strings.TrimSpace(strings.ToLower(config.OAuthProvider))
+	config.Provider = normalizeLowerTrimmed(config.Provider)
+	config.AuthMode = normalizeLowerTrimmed(config.AuthMode)
+	config.OAuthProvider = normalizeLowerTrimmed(config.OAuthProvider)
 	config.APIKey = strings.TrimSpace(config.APIKey)
 	config.CodexHome = strings.TrimSpace(config.CodexHome)
 	return config
@@ -242,8 +242,12 @@ func firstNonEmptyTrimmed(values ...string) string {
 	return ""
 }
 
+func normalizeLowerTrimmed(raw string) string {
+	return strings.ToLower(strings.TrimSpace(raw))
+}
+
 func normalizeReasoningEffort(raw string) string {
-	switch strings.TrimSpace(strings.ToLower(raw)) {
+	switch normalizeLowerTrimmed(raw) {
 	case "":
 		return ""
 	case "none", "off", "disabled":
@@ -264,11 +268,11 @@ func normalizeReasoningEffort(raw string) string {
 }
 
 func normalizeServiceTier(raw string) string {
-	switch strings.TrimSpace(strings.ToLower(raw)) {
+	switch normalized := normalizeLowerTrimmed(raw); normalized {
 	case "":
 		return ""
 	case "auto", "default", "flex", "priority":
-		return strings.TrimSpace(strings.ToLower(raw))
+		return normalized
 	default:
 		return ""
 	}

--- a/internal/llm/provider_test.go
+++ b/internal/llm/provider_test.go
@@ -10,6 +10,17 @@ import (
 	"github.com/devlikebear/tars/internal/auth"
 )
 
+func TestNormalizeLowerTrimmed(t *testing.T) {
+	t.Parallel()
+
+	if got := normalizeLowerTrimmed("  OpenAI-Codex "); got != "openai-codex" {
+		t.Fatalf("expected openai-codex, got %q", got)
+	}
+	if got := normalizeLowerTrimmed(" \t "); got != "" {
+		t.Fatalf("expected empty string, got %q", got)
+	}
+}
+
 func TestNewProvider_Unsupported(t *testing.T) {
 	_, err := NewProvider(ProviderOptions{
 		Provider: "unknown",

--- a/internal/llm/validation.go
+++ b/internal/llm/validation.go
@@ -1,0 +1,14 @@
+package llm
+
+import (
+	"fmt"
+	"strings"
+)
+
+func requireConfiguredValue(provider, field, raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", fmt.Errorf("%s %s is required", provider, field)
+	}
+	return trimmed, nil
+}

--- a/internal/tarsserver/telegram_redaction.go
+++ b/internal/tarsserver/telegram_redaction.go
@@ -1,11 +1,15 @@
 package tarsserver
 
 import (
+	"net/url"
 	"regexp"
 	"strings"
 )
 
-var telegramBotPathPattern = regexp.MustCompile(`/bot[^/\s]+/`)
+var (
+	telegramBotPathPattern        = regexp.MustCompile(`/bot[^/\\\s]+/`)
+	telegramBotEscapedPathPattern = regexp.MustCompile(`\\/bot[^\\/\s]+\\/`)
+)
 
 func sanitizeTelegramLogText(raw, botToken string) string {
 	text := strings.TrimSpace(raw)
@@ -15,7 +19,9 @@ func sanitizeTelegramLogText(raw, botToken string) string {
 	token := strings.TrimSpace(botToken)
 	if token != "" {
 		text = strings.ReplaceAll(text, token, "[REDACTED]")
+		text = redactTelegramEncodedToken(text, token)
 	}
+	text = telegramBotEscapedPathPattern.ReplaceAllString(text, `\/bot[REDACTED]\/`)
 	return telegramBotPathPattern.ReplaceAllString(text, "/bot[REDACTED]/")
 }
 
@@ -24,4 +30,19 @@ func sanitizeTelegramError(err error, botToken string) string {
 		return ""
 	}
 	return sanitizeTelegramLogText(err.Error(), botToken)
+}
+
+func redactTelegramEncodedToken(text, token string) string {
+	encodedVariants := []string{
+		url.QueryEscape(token),
+		url.PathEscape(token),
+	}
+	for _, variant := range encodedVariants {
+		if variant == "" {
+			continue
+		}
+		re := regexp.MustCompile(`(?i)` + regexp.QuoteMeta(variant))
+		text = re.ReplaceAllString(text, "[REDACTED]")
+	}
+	return text
 }

--- a/internal/tarsserver/telegram_redaction_test.go
+++ b/internal/tarsserver/telegram_redaction_test.go
@@ -28,6 +28,28 @@ func TestSanitizeTelegramLogText_RedactsBotToken(t *testing.T) {
 	}
 }
 
+func TestSanitizeTelegramLogText_RedactsURLEncodedToken(t *testing.T) {
+	raw := `telegram relay failed: GET "/relay?token=12345%3AABC&chat_id=1"`
+	redacted := sanitizeTelegramLogText(raw, "12345:ABC")
+	if strings.Contains(strings.ToLower(redacted), "12345%3aabc") {
+		t.Fatalf("expected encoded token to be redacted, got %q", redacted)
+	}
+	if !strings.Contains(redacted, "token=[REDACTED]") {
+		t.Fatalf("expected encoded token marker, got %q", redacted)
+	}
+}
+
+func TestSanitizeTelegramLogText_RedactsJSONEscapedBotPath(t *testing.T) {
+	raw := `{"description":"Post \"https:\/\/api.telegram.org\/bot12345:ABC\/sendMessage\": EOF"}`
+	redacted := sanitizeTelegramLogText(raw, "12345:ABC")
+	if strings.Contains(redacted, "12345:ABC") {
+		t.Fatalf("expected token to be redacted, got %q", redacted)
+	}
+	if !strings.Contains(redacted, `\/bot[REDACTED]\/sendMessage`) {
+		t.Fatalf("expected escaped bot path to be redacted, got %q", redacted)
+	}
+}
+
 func TestTelegramUpdatePoller_FetchUpdates_RedactsTokenInError(t *testing.T) {
 	poller := newTelegramUpdatePoller("secret-token", zerolog.New(io.Discard), func(context.Context, telegramUpdate) {})
 	if poller == nil {


### PR DESCRIPTION
## Summary

- Closes #79.
- Reduce low-risk duplication in `internal/llm` by sharing `Ask()` and constructor validation helpers.
- Harden Telegram log/error redaction so raw, URL-encoded, and JSON-escaped bot token forms are masked.

## Changes

- Main user-visible or developer-visible changes:
  - Added shared `Ask()` helper tests and constructor validation helper coverage for LLM clients.
  - Centralized repeated auth/config normalization paths in `internal/llm` without changing runtime behavior.
  - Extended Telegram redaction tests and implementation for encoded and escaped token exposures.
- API, config, or compatibility changes:
  - None.

## Validation

- [ ] `make test`
- [x] `make security-scan`
- [x] Additional manual verification, if needed

Additional manual verification:
- `go test ./internal/llm/...`
- `go test ./internal/tarsserver -run 'TestSanitizeTelegramLogText_Redacts(BotToken|URLEncodedToken|JSONEscapedBotPath)|TestTelegramUpdatePoller_FetchUpdates_RedactsTokenInError'`
- `go test ./internal/llm/... ./internal/tarsserver/...` hits an unrelated local environment failure in `TestBrowserAPIHandler_LoginCheckRun` because the `playwright` npm package is not installed in this shell.

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [x] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [x] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level: Low. The code paths are covered by focused tests and keep existing behavior intact outside the new redaction cases.
- Rollback plan: Revert commit `36b7bf7` or restore the affected `internal/llm` and `internal/tarsserver` files.