### PR TITLE
chore: deduplicate tool bounds normalization

### DIFF
--- a/internal/tool/bounds.go
+++ b/internal/tool/bounds.go
@@ -1,0 +1,15 @@
+package tool
+
+func resolvePositiveBoundedInt(defaultValue, maxValue int, override *int) int {
+	value := defaultValue
+	if override != nil {
+		value = *override
+	}
+	if value <= 0 {
+		value = defaultValue
+	}
+	if maxValue > 0 && value > maxValue {
+		value = maxValue
+	}
+	return value
+}

--- a/internal/tool/bounds_test.go
+++ b/internal/tool/bounds_test.go
@@ -1,0 +1,55 @@
+package tool
+
+import "testing"
+
+func TestResolvePositiveBoundedInt(t *testing.T) {
+	t.Parallel()
+
+	override := func(v int) *int { return &v }
+
+	tests := []struct {
+		name         string
+		defaultValue int
+		maxValue     int
+		override     *int
+		want         int
+	}{
+		{
+			name:         "uses default when override is nil",
+			defaultValue: 10,
+			maxValue:     20,
+			override:     nil,
+			want:         10,
+		},
+		{
+			name:         "falls back to default when override is not positive",
+			defaultValue: 10,
+			maxValue:     20,
+			override:     override(0),
+			want:         10,
+		},
+		{
+			name:         "clamps to max when override is too large",
+			defaultValue: 10,
+			maxValue:     20,
+			override:     override(25),
+			want:         20,
+		},
+		{
+			name:         "uses override when within bounds",
+			defaultValue: 10,
+			maxValue:     20,
+			override:     override(15),
+			want:         15,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := resolvePositiveBoundedInt(tt.defaultValue, tt.maxValue, tt.override); got != tt.want {
+				t.Fatalf("expected %d, got %d", tt.want, got)
+			}
+		})
+	}
+}

--- a/internal/tool/glob.go
+++ b/internal/tool/glob.go
@@ -54,16 +54,7 @@ func NewGlobTool(workspaceDir string) Tool {
 				return jsonTextResult(globResponse{Message: "pattern escapes workspace"}, true), nil
 			}
 
-			limit := defaultGlobLimit
-			if input.Limit != nil {
-				limit = *input.Limit
-			}
-			if limit <= 0 {
-				limit = defaultGlobLimit
-			}
-			if limit > maxGlobLimit {
-				limit = maxGlobLimit
-			}
+			limit := resolvePositiveBoundedInt(defaultGlobLimit, maxGlobLimit, input.Limit)
 
 			rootAbs, err := filepath.Abs(workspaceDir)
 			if err != nil {

--- a/internal/tool/list_dir.go
+++ b/internal/tool/list_dir.go
@@ -52,16 +52,7 @@ func NewListDirTool(workspaceDir string) Tool {
 				return listDirErrorResult(fmt.Sprintf("invalid arguments: %v", err)), nil
 			}
 
-			maxEntries := defaultListDirMaxEntries
-			if input.MaxEntries != nil {
-				maxEntries = *input.MaxEntries
-			}
-			if maxEntries <= 0 {
-				maxEntries = defaultListDirMaxEntries
-			}
-			if maxEntries > maxListDirMaxEntries {
-				maxEntries = maxListDirMaxEntries
-			}
+			maxEntries := resolvePositiveBoundedInt(defaultListDirMaxEntries, maxListDirMaxEntries, input.MaxEntries)
 
 			absPath, err := resolveWorkspacePath(workspaceDir, input.Path)
 			if err != nil {

--- a/internal/tool/memory_search.go
+++ b/internal/tool/memory_search.go
@@ -61,16 +61,7 @@ func NewMemorySearchTool(workspaceDir string) Tool {
 				return memorySearchErrorResult("query is required"), nil
 			}
 
-			limit := defaultMemorySearchLimit
-			if input.Limit != nil {
-				limit = *input.Limit
-			}
-			if limit <= 0 {
-				limit = defaultMemorySearchLimit
-			}
-			if limit > maxMemorySearchLimit {
-				limit = maxMemorySearchLimit
-			}
+			limit := resolvePositiveBoundedInt(defaultMemorySearchLimit, maxMemorySearchLimit, input.Limit)
 
 			includeMemory := true
 			if input.IncludeMemory != nil {

--- a/internal/tool/read_file.go
+++ b/internal/tool/read_file.go
@@ -55,16 +55,7 @@ func newReadToolWithName(name, workspaceDir string) Tool {
 				return readFileErrorResult("path is required"), nil
 			}
 
-			maxBytes := defaultReadFileMaxBytes
-			if input.MaxBytes != nil {
-				maxBytes = *input.MaxBytes
-			}
-			if maxBytes <= 0 {
-				maxBytes = defaultReadFileMaxBytes
-			}
-			if maxBytes > maxReadFileMaxBytes {
-				maxBytes = maxReadFileMaxBytes
-			}
+			maxBytes := resolvePositiveBoundedInt(defaultReadFileMaxBytes, maxReadFileMaxBytes, input.MaxBytes)
 
 			absPath, err := resolveWorkspacePath(workspaceDir, input.Path)
 			if err != nil {

--- a/internal/tool/web_fetch.go
+++ b/internal/tool/web_fetch.go
@@ -77,16 +77,7 @@ func NewWebFetchToolWithOptions(opts WebFetchOptions) Tool {
 			if rawURL == "" {
 				return jsonTextResult(webFetchResponse{Message: "url is required"}, true), nil
 			}
-			maxChars := defaultWebFetchMaxChars
-			if input.MaxChars != nil {
-				maxChars = *input.MaxChars
-			}
-			if maxChars <= 0 {
-				maxChars = defaultWebFetchMaxChars
-			}
-			if maxChars > maxWebFetchMaxChars {
-				maxChars = maxWebFetchMaxChars
-			}
+			maxChars := resolvePositiveBoundedInt(defaultWebFetchMaxChars, maxWebFetchMaxChars, input.MaxChars)
 
 			finalURL, resp, err := fetchWithSSRFGuard(ctx, httpClient, rawURL, opts.AllowPrivateHosts, allowlist)
 			if err != nil {


### PR DESCRIPTION
## Summary

- Closes #81.
- Extract a shared positive bounded integer helper for `internal/tool` parameter parsing.
- Replace repeated default/override/clamp logic in tool handlers without changing behavior.

## Changes

- Main user-visible or developer-visible changes:
  - Added `resolvePositiveBoundedInt` and unit coverage for default, invalid, and over-limit cases.
  - Switched `read_file`, `list_dir`, `glob`, `memory_search`, and `web_fetch` to the shared bounds helper.
- API, config, or compatibility changes:
  - None.

## Validation

- [ ] `make test`
- [x] `make security-scan`
- [x] Additional manual verification, if needed

Additional manual verification:
- `go test ./internal/tool -run 'TestResolvePositiveBoundedInt|TestReadFileTool|TestListDirTool|TestGlobTool|TestWebFetchTool'`
- `go test ./internal/tool/...` hits an unrelated local environment failure in browser Playwright-backed tests because the `playwright` npm package is not installed in this shell.

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [x] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [x] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level: Low. The change centralizes existing clamp behavior behind a small helper with focused tests.
- Rollback plan: Revert commit `7bdec1e` or restore the affected `internal/tool` files to their previous inline bounds logic.