### PR TITLE
chore: deduplicate gateway disabled guards

### DIFF
--- a/internal/gateway/runtime.go
+++ b/internal/gateway/runtime.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"time"
@@ -66,6 +67,13 @@ func NewRuntime(opts RuntimeOptions) *Runtime {
 
 func (r *Runtime) Enabled() bool {
 	return r != nil && r.opts.Enabled
+}
+
+func (r *Runtime) requireEnabled() error {
+	if !r.Enabled() {
+		return fmt.Errorf("gateway runtime is disabled")
+	}
+	return nil
 }
 
 func (r *Runtime) Close(ctx context.Context) error {

--- a/internal/gateway/runtime_channels.go
+++ b/internal/gateway/runtime_channels.go
@@ -11,8 +11,8 @@ func (r *Runtime) MessageSend(channelID, threadID, text string) (ChannelMessage,
 }
 
 func (r *Runtime) MessageSendByWorkspace(workspaceID, channelID, threadID, text string) (ChannelMessage, error) {
-	if r == nil || !r.opts.Enabled {
-		return ChannelMessage{}, fmt.Errorf("gateway runtime is disabled")
+	if err := r.requireEnabled(); err != nil {
+		return ChannelMessage{}, err
 	}
 	if !r.opts.ChannelsLocalEnabled {
 		return ChannelMessage{}, fmt.Errorf("local channels are disabled")
@@ -25,8 +25,8 @@ func (r *Runtime) MessageRead(channelID string, limit int) ([]ChannelMessage, er
 }
 
 func (r *Runtime) MessageReadByWorkspace(workspaceID, channelID string, limit int) ([]ChannelMessage, error) {
-	if r == nil || !r.opts.Enabled {
-		return nil, fmt.Errorf("gateway runtime is disabled")
+	if err := r.requireEnabled(); err != nil {
+		return nil, err
 	}
 	key := strings.TrimSpace(channelID)
 	if key == "" {
@@ -61,8 +61,8 @@ func (r *Runtime) InboundWebhook(channelID, threadID, text string, payload map[s
 }
 
 func (r *Runtime) InboundWebhookByWorkspace(workspaceID, channelID, threadID, text string, payload map[string]any) (ChannelMessage, error) {
-	if r == nil || !r.opts.Enabled {
-		return ChannelMessage{}, fmt.Errorf("gateway runtime is disabled")
+	if err := r.requireEnabled(); err != nil {
+		return ChannelMessage{}, err
 	}
 	if !r.opts.ChannelsWebhookEnabled {
 		return ChannelMessage{}, fmt.Errorf("webhook channels are disabled")
@@ -75,8 +75,8 @@ func (r *Runtime) InboundTelegram(botID, threadID, text string, payload map[stri
 }
 
 func (r *Runtime) InboundTelegramByWorkspace(workspaceID, botID, threadID, text string, payload map[string]any) (ChannelMessage, error) {
-	if r == nil || !r.opts.Enabled {
-		return ChannelMessage{}, fmt.Errorf("gateway runtime is disabled")
+	if err := r.requireEnabled(); err != nil {
+		return ChannelMessage{}, err
 	}
 	if !r.opts.ChannelsTelegramEnabled {
 		return ChannelMessage{}, fmt.Errorf("telegram channels are disabled")
@@ -93,8 +93,8 @@ func (r *Runtime) OutboundTelegram(botID, chatID, threadID, text string, payload
 }
 
 func (r *Runtime) OutboundTelegramByWorkspace(workspaceID, botID, chatID, threadID, text string, payload map[string]any) (ChannelMessage, error) {
-	if r == nil || !r.opts.Enabled {
-		return ChannelMessage{}, fmt.Errorf("gateway runtime is disabled")
+	if err := r.requireEnabled(); err != nil {
+		return ChannelMessage{}, err
 	}
 	if !r.opts.ChannelsTelegramEnabled {
 		return ChannelMessage{}, fmt.Errorf("telegram channels are disabled")

--- a/internal/gateway/runtime_enabled_test.go
+++ b/internal/gateway/runtime_enabled_test.go
@@ -1,0 +1,47 @@
+package gateway
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRuntimeRequireEnabled(t *testing.T) {
+	t.Parallel()
+
+	disabledRuntime := NewRuntime(RuntimeOptions{})
+	enabledRuntime := NewRuntime(RuntimeOptions{Enabled: true})
+	t.Cleanup(func() {
+		if disabledRuntime != nil {
+			_ = disabledRuntime.Close(context.Background())
+		}
+		if enabledRuntime != nil {
+			_ = enabledRuntime.Close(context.Background())
+		}
+	})
+
+	tests := []struct {
+		name    string
+		runtime *Runtime
+		wantErr bool
+	}{
+		{name: "nil runtime", runtime: nil, wantErr: true},
+		{name: "disabled runtime", runtime: disabledRuntime, wantErr: true},
+		{name: "enabled runtime", runtime: enabledRuntime, wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.runtime.requireEnabled()
+			if tt.wantErr && err == nil {
+				t.Fatal("expected disabled runtime error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if tt.wantErr && err.Error() != "gateway runtime is disabled" {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/internal/gateway/runtime_executors.go
+++ b/internal/gateway/runtime_executors.go
@@ -115,8 +115,8 @@ func (r *Runtime) executorNamesLocked() []string {
 }
 
 func (r *Runtime) resolveExecutor(agentName string) (string, AgentExecutor, error) {
-	if r == nil {
-		return "", nil, fmt.Errorf("gateway runtime is disabled")
+	if err := r.requireEnabled(); err != nil {
+		return "", nil, err
 	}
 	requested := strings.TrimSpace(agentName)
 

--- a/internal/gateway/runtime_reports.go
+++ b/internal/gateway/runtime_reports.go
@@ -63,8 +63,8 @@ func (r *Runtime) ReportsSummary() (ReportSummary, error) {
 }
 
 func (r *Runtime) ReportsSummaryByWorkspace(workspaceID string) (ReportSummary, error) {
-	if r == nil || !r.opts.Enabled {
-		return ReportSummary{}, fmt.Errorf("gateway runtime is disabled")
+	if err := r.requireEnabled(); err != nil {
+		return ReportSummary{}, err
 	}
 	targetWorkspaceID := normalizeWorkspaceID(workspaceID)
 	r.mu.RLock()
@@ -119,8 +119,8 @@ func (r *Runtime) ReportsRuns(limit int) (ReportRuns, error) {
 }
 
 func (r *Runtime) ReportsRunsByWorkspace(workspaceID string, limit int) (ReportRuns, error) {
-	if r == nil || !r.opts.Enabled {
-		return ReportRuns{}, fmt.Errorf("gateway runtime is disabled")
+	if err := r.requireEnabled(); err != nil {
+		return ReportRuns{}, err
 	}
 	if !r.opts.GatewayArchiveEnabled {
 		return ReportRuns{}, fmt.Errorf("gateway archive report is disabled")
@@ -142,8 +142,8 @@ func (r *Runtime) ReportsChannels(limit int) (ReportChannels, error) {
 }
 
 func (r *Runtime) ReportsChannelsByWorkspace(workspaceID string, limit int) (ReportChannels, error) {
-	if r == nil || !r.opts.Enabled {
-		return ReportChannels{}, fmt.Errorf("gateway runtime is disabled")
+	if err := r.requireEnabled(); err != nil {
+		return ReportChannels{}, err
 	}
 	if !r.opts.GatewayArchiveEnabled {
 		return ReportChannels{}, fmt.Errorf("gateway archive report is disabled")

--- a/internal/gateway/runtime_run_bootstrap.go
+++ b/internal/gateway/runtime_run_bootstrap.go
@@ -10,8 +10,8 @@ import (
 )
 
 func (r *Runtime) Spawn(ctx context.Context, req SpawnRequest) (Run, error) {
-	if r == nil || !r.opts.Enabled {
-		return Run{}, fmt.Errorf("gateway runtime is disabled")
+	if err := r.requireEnabled(); err != nil {
+		return Run{}, err
 	}
 	prompt := strings.TrimSpace(req.Prompt)
 	if prompt == "" {

--- a/internal/gateway/runtime_runs.go
+++ b/internal/gateway/runtime_runs.go
@@ -149,8 +149,8 @@ func (r *Runtime) CancelByWorkspace(workspaceID, runID string) (Run, error) {
 }
 
 func (r *Runtime) cancelRun(runID, workspaceID string) (Run, error) {
-	if r == nil {
-		return Run{}, fmt.Errorf("gateway runtime is disabled")
+	if err := r.requireEnabled(); err != nil {
+		return Run{}, err
 	}
 	runID = strings.TrimSpace(runID)
 	targetWorkspaceID := strings.TrimSpace(workspaceID)


### PR DESCRIPTION
## Summary

- Closes #83.
- Centralize repeated `gateway runtime is disabled` guards behind a shared runtime helper.
- Keep nil/disabled runtime behavior unchanged while reducing duplicated checks.

## Changes

- Main user-visible or developer-visible changes:
  - Added `requireEnabled()` and focused runtime tests for nil, disabled, and enabled runtime cases.
  - Replaced repeated disabled guard branches in gateway channel, report, spawn, run, and executor paths.
- API, config, or compatibility changes:
  - None.

## Validation

- [ ] `make test`
- [x] `make security-scan`
- [x] Additional manual verification, if needed

Additional manual verification:
- `go test ./internal/gateway -run 'TestRuntimeRequireEnabled|TestRuntimeSpawnAndWait|TestRuntimeSpawn_UnknownAgent'`
- `go test ./internal/gateway/...` hits an unrelated local environment failure in Playwright-backed browser runtime tests because the `playwright` npm package is not installed in this shell.

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [x] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [x] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level: Low. The change only centralizes an existing guard and preserves the error text.
- Rollback plan: Revert commit `b81902e` or restore the affected `internal/gateway` files to their previous inline guard checks.