### PR TITLE
chore: reduce llm chat request boilerplate

### DIFF
--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -55,20 +55,13 @@ func newAnthropicClientWithConfig(baseURL, apiKey, model string, config ClientCo
 
 func (c *AnthropicClient) Chat(ctx context.Context, messages []ChatMessage, opts ChatOptions) (ChatResponse, error) {
 	streaming := opts.OnDelta != nil
-	zlog.Debug().
-		Str("provider", "anthropic").
-		Str("model", c.model).
-		Str("url", c.baseURL+"/v1/messages").
-		Int("message_count", len(messages)).
-		Bool("stream", streaming).
-		Int("tool_count", len(opts.Tools)).
-		Str("tool_choice", strings.TrimSpace(opts.ToolChoice)).
-		Msg("llm request start")
+	url := c.baseURL + "/v1/messages"
+	logChatRequestStart("anthropic", c.model, url, len(messages), streaming, len(opts.Tools), opts.ToolChoice)
 
 	reqBody := c.buildChatRequest(messages, opts, streaming)
-	req, err := jsonRequestSpec{
+	_, resp, err := executeJSONChatRequest(ctx, jsonRequestSpec{
 		Provider: "anthropic",
-		URL:      c.baseURL + "/v1/messages",
+		URL:      url,
 		Headers: map[string]string{
 			"x-api-key":         c.apiKey,
 			"anthropic-version": anthropicAPIVersion,
@@ -76,16 +69,11 @@ func (c *AnthropicClient) Chat(ctx context.Context, messages []ChatMessage, opts
 			"content-type":      "application/json",
 		},
 		Body: reqBody,
-	}.buildRequest(ctx)
-	if err != nil {
-		return ChatResponse{}, err
-	}
-	resp, err := doPreparedRequest(req, "anthropic", transportHTTPClient(c.httpClient, streaming))
+	}, c.httpClient, streaming)
 	if err != nil {
 		return ChatResponse{}, err
 	}
 	defer resp.Body.Close()
-	zlog.Debug().Str("provider", "anthropic").Int("status", resp.StatusCode).Msg("llm response received")
 
 	if streaming {
 		return c.chatStreamingResponse(resp.Body, opts.OnDelta)

--- a/internal/llm/gemini_native.go
+++ b/internal/llm/gemini_native.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"sync"
 
-	zlog "github.com/rs/zerolog/log"
 	"google.golang.org/genai"
 )
 
@@ -85,15 +84,7 @@ func (c *GeminiNativeClient) Chat(ctx context.Context, messages []ChatMessage, o
 	}
 
 	streaming := opts.OnDelta != nil
-	zlog.Debug().
-		Str("provider", "gemini-native").
-		Str("model", c.model).
-		Str("url", c.requestURL(streaming)).
-		Int("message_count", len(messages)).
-		Bool("stream", streaming).
-		Int("tool_count", len(opts.Tools)).
-		Str("tool_choice", strings.TrimSpace(opts.ToolChoice)).
-		Msg("llm request start")
+	logChatRequestStart("gemini-native", c.model, c.requestURL(streaming), len(messages), streaming, len(opts.Tools), opts.ToolChoice)
 
 	contents := toGeminiNativeContents(messages)
 	config := c.buildGenerateContentConfig(messages, opts)

--- a/internal/llm/openai_compat_client.go
+++ b/internal/llm/openai_compat_client.go
@@ -60,39 +60,27 @@ func NewGeminiClient(baseURL, apiKey, model string) (*OpenAICompatibleClient, er
 
 func (c *OpenAICompatibleClient) Chat(ctx context.Context, messages []ChatMessage, opts ChatOptions) (ChatResponse, error) {
 	streaming := opts.OnDelta != nil
-	zlog.Debug().
-		Str("provider", c.label).
-		Str("model", c.model).
-		Str("url", c.baseURL+"/chat/completions").
-		Int("message_count", len(messages)).
-		Bool("stream", streaming).
-		Int("tool_count", len(opts.Tools)).
-		Str("tool_choice", strings.TrimSpace(opts.ToolChoice)).
-		Msg("llm request start")
+	url := c.baseURL + "/chat/completions"
+	logChatRequestStart(c.label, c.model, url, len(messages), streaming, len(opts.Tools), opts.ToolChoice)
 
 	reqBody, err := c.buildChatRequest(messages, opts)
 	if err != nil {
 		return ChatResponse{}, err
 	}
 
-	req, err := jsonRequestSpec{
+	req, resp, err := executeJSONChatRequest(ctx, jsonRequestSpec{
 		Provider: c.label,
-		URL:      c.baseURL + "/chat/completions",
+		URL:      url,
 		Headers: map[string]string{
 			"Authorization": "Bearer " + c.apiKey,
 			"Content-Type":  "application/json",
 		},
 		Body: reqBody,
-	}.buildRequest(ctx)
-	if err != nil {
-		return ChatResponse{}, err
-	}
-	resp, err := doPreparedRequest(req, c.label, transportHTTPClient(c.httpClient, streaming))
+	}, c.httpClient, streaming)
 	if err != nil {
 		return ChatResponse{}, err
 	}
 	defer resp.Body.Close()
-	zlog.Debug().Str("provider", c.label).Int("status", resp.StatusCode).Msg("llm response received")
 
 	req = req.WithContext(context.WithValue(req.Context(), openAICompatibleResponseContextKey{}, resp))
 	if opts.OnDelta != nil {

--- a/internal/llm/transport.go
+++ b/internal/llm/transport.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+
+	zlog "github.com/rs/zerolog/log"
 )
 
 type jsonRequestSpec struct {
@@ -47,11 +49,34 @@ func transportHTTPClient(base *http.Client, streaming bool) *http.Client {
 }
 
 func doJSONRequest(spec jsonRequestSpec, httpClient *http.Client, streaming bool) (*http.Response, error) {
-	req, err := spec.buildRequest(context.Background())
+	_, resp, err := executeJSONChatRequest(context.Background(), spec, httpClient, streaming)
+	return resp, err
+}
+
+func executeJSONChatRequest(ctx context.Context, spec jsonRequestSpec, httpClient *http.Client, streaming bool) (*http.Request, *http.Response, error) {
+	req, err := spec.buildRequest(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return doPreparedRequest(req, strings.TrimSpace(spec.Provider), transportHTTPClient(httpClient, streaming))
+	provider := strings.TrimSpace(spec.Provider)
+	resp, err := doPreparedRequest(req, provider, transportHTTPClient(httpClient, streaming))
+	if err != nil {
+		return nil, nil, err
+	}
+	zlog.Debug().Str("provider", provider).Int("status", resp.StatusCode).Msg("llm response received")
+	return req, resp, nil
+}
+
+func logChatRequestStart(provider, model, url string, messageCount int, streaming bool, toolCount int, toolChoice string) {
+	zlog.Debug().
+		Str("provider", strings.TrimSpace(provider)).
+		Str("model", strings.TrimSpace(model)).
+		Str("url", strings.TrimSpace(url)).
+		Int("message_count", messageCount).
+		Bool("stream", streaming).
+		Int("tool_count", toolCount).
+		Str("tool_choice", strings.TrimSpace(toolChoice)).
+		Msg("llm request start")
 }
 
 func doPreparedRequest(req *http.Request, provider string, httpClient *http.Client) (*http.Response, error) {

--- a/internal/llm/transport_test.go
+++ b/internal/llm/transport_test.go
@@ -1,6 +1,7 @@
 package llm
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -8,6 +9,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/rs/zerolog"
+	zlog "github.com/rs/zerolog/log"
 )
 
 func TestJSONRequestSpec_BuildRequest(t *testing.T) {
@@ -101,6 +105,75 @@ func TestJSONRequestSpec_DoRequestWrapsHTTPStatus(t *testing.T) {
 	}
 	if !strings.Contains(providerErr.Error(), "anthropic status 401: denied") {
 		t.Fatalf("unexpected error message: %v", providerErr)
+	}
+}
+
+func TestExecuteJSONChatRequest_ReturnsRequestAndResponse(t *testing.T) {
+	var capturedAuth string
+	var capturedBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuth = r.Header.Get("Authorization")
+		if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	req, resp, err := executeJSONChatRequest(context.Background(), jsonRequestSpec{
+		Provider: "openai",
+		URL:      server.URL,
+		Headers: map[string]string{
+			"Authorization": "Bearer test-key",
+			"Content-Type":  "application/json",
+		},
+		Body: map[string]any{"model": "gpt-test"},
+	}, &http.Client{Timeout: time.Second}, false)
+	if err != nil {
+		t.Fatalf("execute json chat request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if req == nil {
+		t.Fatal("expected request")
+	}
+	if resp == nil {
+		t.Fatal("expected response")
+	}
+	if got := req.URL.String(); got != server.URL {
+		t.Fatalf("expected request URL %q, got %q", server.URL, got)
+	}
+	if capturedAuth != "Bearer test-key" {
+		t.Fatalf("expected authorization header, got %q", capturedAuth)
+	}
+	if capturedBody["model"] != "gpt-test" {
+		t.Fatalf("unexpected request body: %+v", capturedBody)
+	}
+}
+
+func TestLogChatRequestStart_LogsStructuredFields(t *testing.T) {
+	var buf bytes.Buffer
+	prev := zlog.Logger
+	zlog.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
+	defer func() { zlog.Logger = prev }()
+
+	logChatRequestStart("openai", "gpt-4o-mini", "https://example.com/v1/chat/completions", 2, true, 1, "required")
+
+	logged := buf.String()
+	for _, want := range []string{
+		`"provider":"openai"`,
+		`"model":"gpt-4o-mini"`,
+		`"url":"https://example.com/v1/chat/completions"`,
+		`"message_count":2`,
+		`"stream":true`,
+		`"tool_count":1`,
+		`"tool_choice":"required"`,
+		`"message":"llm request start"`,
+	} {
+		if !strings.Contains(logged, want) {
+			t.Fatalf("expected log to contain %q, got %q", want, logged)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Closes #85.
- Reduce duplicated chat request lifecycle boilerplate across the HTTP-based LLM clients.
- Reuse the same request-start logging structure across Anthropic, OpenAI-compatible, and Gemini Native clients.

## Changes

- Main user-visible or developer-visible changes:
  - Added shared helpers for JSON chat request execution and request-start logging.
  - Switched Anthropic and OpenAI-compatible chat flows to the shared execution helper.
  - Switched Gemini Native to the shared request-start logging helper.
- API, config, or compatibility changes:
  - None.

## Validation

- [ ] `make test`
- [x] `make security-scan`
- [x] Additional manual verification, if needed

Additional manual verification:
- `go test ./internal/llm -run 'TestExecuteJSONChatRequest_ReturnsRequestAndResponse|TestLogChatRequestStart_LogsStructuredFields|TestAnthropicClientAsk|TestOpenAIClientAsk|TestBifrostClientAsk|TestGeminiNativeClientChat'`
- `go test ./internal/llm/...`

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [x] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [x] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level: Low. The change only centralizes existing request lifecycle boilerplate and keeps existing tests green.
- Rollback plan: Revert commit `c59add7` or restore the affected `internal/llm` files to their previous inline request handling.