### PR TITLE
fix: harden gateway executor env vars

### DIFF
--- a/internal/gateway/executor.go
+++ b/internal/gateway/executor.go
@@ -280,13 +280,13 @@ func (e *CommandExecutor) Execute(ctx context.Context, req ExecuteRequest) (stri
 	for key, value := range e.env {
 		env = append(env, key+"="+value)
 	}
-	if v := strings.TrimSpace(req.RunID); v != "" {
+	if v, ok := sanitizeMetadataEnvValue(req.RunID); ok {
 		env = append(env, "TARS_RUN_ID="+v)
 	}
-	if v := strings.TrimSpace(req.SessionID); v != "" {
+	if v, ok := sanitizeMetadataEnvValue(req.SessionID); ok {
 		env = append(env, "TARS_SESSION_ID="+v)
 	}
-	if v := strings.TrimSpace(req.WorkspaceID); v != "" {
+	if v, ok := sanitizeMetadataEnvValue(req.WorkspaceID); ok {
 		env = append(env, "TARS_WORKSPACE_ID="+v)
 	}
 	cmd.Env = env
@@ -312,6 +312,19 @@ func normalizePolicyMode(raw string) string {
 		return mode
 	}
 	return "full"
+}
+
+func sanitizeMetadataEnvValue(raw string) (string, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", false
+	}
+	for _, r := range trimmed {
+		if r < 0x20 || r == 0x7f {
+			return "", false
+		}
+	}
+	return trimmed, true
 }
 
 func sanitizeToolsAllow(raw []string) []string {

--- a/internal/gateway/executor_test.go
+++ b/internal/gateway/executor_test.go
@@ -7,6 +7,34 @@ import (
 	"time"
 )
 
+func TestSanitizeMetadataEnvValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  string
+		want   string
+		wantOK bool
+	}{
+		{name: "accepts normal identifier", input: "run_123", want: "run_123", wantOK: true},
+		{name: "rejects newline", input: "run_123\nINJECT=1", want: "", wantOK: false},
+		{name: "rejects null byte", input: "session\x00abc", want: "", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := sanitizeMetadataEnvValue(tt.input)
+			if ok != tt.wantOK {
+				t.Fatalf("expected ok=%v, got %v", tt.wantOK, ok)
+			}
+			if got != tt.want {
+				t.Fatalf("expected value %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
 func TestNewCommandExecutor_ValidateRequiredFields(t *testing.T) {
 	if _, err := NewCommandExecutor(CommandExecutorOptions{
 		Command: "sh",
@@ -40,6 +68,29 @@ func TestCommandExecutor_Execute_StdinAndMetadata(t *testing.T) {
 		t.Fatalf("execute: %v", err)
 	}
 	if out != "run_123|session_abc|hello from prompt" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestCommandExecutor_Execute_SkipsUnsafeMetadataEnvValues(t *testing.T) {
+	executor, err := NewCommandExecutor(CommandExecutorOptions{
+		Name:    "worker",
+		Command: "sh",
+		Args:    []string{"-c", `printf "%s|%s|%s" "${TARS_RUN_ID:-missing}" "${TARS_SESSION_ID:-missing}" "${TARS_WORKSPACE_ID:-missing}"`},
+	})
+	if err != nil {
+		t.Fatalf("new command executor: %v", err)
+	}
+
+	out, err := executor.Execute(context.Background(), ExecuteRequest{
+		RunID:       "run_123\nINJECT=1",
+		SessionID:   "session_abc\r\nINJECT=1",
+		WorkspaceID: "workspace\x00abc",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if out != "missing|missing|missing" {
 		t.Fatalf("unexpected output: %q", out)
 	}
 }


### PR DESCRIPTION
## Summary

- closes #87
- sanitize gateway executor metadata before exporting run/session/workspace identifiers into subprocess env vars
- reject malformed metadata values containing control characters instead of forwarding them verbatim

## Changes

- add `sanitizeMetadataEnvValue` in `CommandExecutor` to guard exported metadata env values
- apply the sanitizer only to `TARS_RUN_ID`, `TARS_SESSION_ID`, and `TARS_WORKSPACE_ID`
- add focused tests for accepted identifiers and rejected malformed values

## Validation

- [ ] `make test`
- [x] `make security-scan`
- [x] Additional manual verification, if needed
- `go test ./internal/gateway -run "TestSanitizeMetadataEnvValue|TestCommandExecutor_Execute_StdinAndMetadata|TestCommandExecutor_Execute_SkipsUnsafeMetadataEnvValues|TestCommandExecutor_Execute_Timeout|TestCommandExecutor_Execute_StderrOnFailure"`
- `go test ./internal/gateway/...` *(fails locally because `scripts/playwright_browser_runner.mjs` cannot import the `playwright` package in this shell)*

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [ ] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [ ] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level: Low
- Rollback plan: Revert commit f88a3cb if executor metadata env sanitization causes regressions
