### PR TITLE
fix: limit json request body sizes

### DIFF
--- a/internal/tarsserver/handler_chat_context.go
+++ b/internal/tarsserver/handler_chat_context.go
@@ -1,7 +1,6 @@
 package tarsserver
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -29,15 +28,16 @@ type chatRunState struct {
 	injectedSchemas     []llm.ToolSchema
 }
 
-func decodeChatRequestPayload(r *http.Request) (chatRequestPayload, int, string) {
+func decodeChatRequestPayload(w http.ResponseWriter, r *http.Request) (chatRequestPayload, bool) {
 	var req chatRequestPayload
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return chatRequestPayload{}, http.StatusBadRequest, "invalid request body"
+	if !decodeJSONBody(w, r, &req) {
+		return chatRequestPayload{}, false
 	}
 	if strings.TrimSpace(req.Message) == "" {
-		return chatRequestPayload{}, http.StatusBadRequest, "message is required"
+		writeError(w, http.StatusBadRequest, "", "message is required")
+		return chatRequestPayload{}, false
 	}
-	return req, 0, ""
+	return req, true
 }
 
 func prepareChatRunState(r *http.Request, req chatRequestPayload, deps chatHandlerDeps) (chatRunState, int, string, error) {

--- a/internal/tarsserver/handler_chat_pipeline.go
+++ b/internal/tarsserver/handler_chat_pipeline.go
@@ -44,9 +44,8 @@ func handleChatRequest(w http.ResponseWriter, r *http.Request, deps chatHandlerD
 		defer release()
 	}
 
-	req, status, message := decodeChatRequestPayload(r)
-	if status != 0 {
-		writeError(w, status, "", message)
+	req, ok := decodeChatRequestPayload(w, r)
+	if !ok {
 		return
 	}
 

--- a/internal/tarsserver/handler_ops.go
+++ b/internal/tarsserver/handler_ops.go
@@ -2,7 +2,6 @@ package tarsserver
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -64,8 +63,7 @@ func newOpsAPIHandler(manager *ops.Manager, logger zerolog.Logger, emit func(con
 		var req struct {
 			ApprovalID string `json:"approval_id"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		if !decodeJSONBody(w, r, &req) {
 			return
 		}
 		result, err := manager.ApplyCleanup(r.Context(), strings.TrimSpace(req.ApprovalID))

--- a/internal/tarsserver/handler_ops_test.go
+++ b/internal/tarsserver/handler_ops_test.go
@@ -61,3 +61,31 @@ func TestOpsAPI_StatusAndApprovalFlow(t *testing.T) {
 		t.Fatalf("expected 200 for apply, got %d body=%q", applyRec.Code, applyRec.Body.String())
 	}
 }
+
+func TestOpsAPI_CleanupApplyRejectsOversizedBody(t *testing.T) {
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	home := filepath.Join(t.TempDir(), "home")
+	if err := os.MkdirAll(filepath.Join(home, "Downloads"), 0o755); err != nil {
+		t.Fatalf("mkdir downloads: %v", err)
+	}
+	mgr := ops.NewManager(workspace, ops.Options{HomeDir: home})
+	handler := newOpsAPIHandler(mgr, zerolog.New(io.Discard), nil)
+
+	body := `{"approval_id":"` + strings.Repeat("a", int(defaultJSONBodyLimitBytes+1)) + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/ops/cleanup/apply", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	var payload map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response body: %v", err)
+	}
+	if payload["error"] != "request body too large" {
+		t.Fatalf("unexpected body: %+v", payload)
+	}
+}

--- a/internal/tarsserver/handler_project.go
+++ b/internal/tarsserver/handler_project.go
@@ -2,8 +2,6 @@ package tarsserver
 
 import (
 	"context"
-	"encoding/json"
-	"io"
 	"net/http"
 	"strings"
 
@@ -76,8 +74,7 @@ func newProjectAPIHandler(
 					Summary            *string  `json:"summary,omitempty"`
 					Body               *string  `json:"body,omitempty"`
 				}
-				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-					writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+				if !decodeJSONBody(w, r, &req) {
 					return
 				}
 				updated, err := store.UpdateBrief(briefID, project.BriefUpdateInput{
@@ -167,8 +164,7 @@ func newProjectAPIHandler(
 				Instructions string `json:"instructions,omitempty"`
 				CloneRepo    bool   `json:"clone_repo,omitempty"`
 			}
-			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+			if !decodeJSONBody(w, r, &req) {
 				return
 			}
 			created, err := store.Create(project.CreateInput{
@@ -224,8 +220,7 @@ func newProjectAPIHandler(
 				writeJSON(w, http.StatusOK, item)
 			case http.MethodPatch:
 				var req project.UpdatePayload
-				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-					writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+				if !decodeJSONBody(w, r, &req) {
 					return
 				}
 				updated, err := store.Update(projectID, req.ToUpdateInput())
@@ -289,8 +284,7 @@ func newProjectAPIHandler(
 					StopReason        *string  `json:"stop_reason,omitempty"`
 					Body              *string  `json:"body,omitempty"`
 				}
-				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-					writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+				if !decodeJSONBody(w, r, &req) {
 					return
 				}
 				updated, err := store.UpdateState(projectID, project.ProjectStateUpdateInput{
@@ -355,8 +349,7 @@ func newProjectAPIHandler(
 					Timestamp string            `json:"timestamp,omitempty"`
 					Meta      map[string]string `json:"meta,omitempty"`
 				}
-				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-					writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+				if !decodeJSONBody(w, r, &req) {
 					return
 				}
 				item, err := store.AppendActivity(projectID, project.ActivityAppendInput{
@@ -410,8 +403,7 @@ func newProjectAPIHandler(
 					Columns []string            `json:"columns,omitempty"`
 					Tasks   []project.BoardTask `json:"tasks,omitempty"`
 				}
-				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-					writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+				if !decodeJSONBody(w, r, &req) {
 					return
 				}
 				item, err := store.UpdateBoard(projectID, project.BoardUpdateInput{
@@ -452,8 +444,7 @@ func newProjectAPIHandler(
 			var req struct {
 				Stage string `json:"stage,omitempty"`
 			}
-			if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
-				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+			if !decodeOptionalJSONBody(w, r, &req) {
 				return
 			}
 			orchestrator := project.NewOrchestratorWithGitHubAuthChecker(store, taskRunner, githubAuthChecker)
@@ -541,8 +532,7 @@ func newProjectAPIHandler(
 			var req struct {
 				SessionID string `json:"session_id,omitempty"`
 			}
-			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+			if !decodeJSONBody(w, r, &req) {
 				return
 			}
 			sessionID := strings.TrimSpace(req.SessionID)

--- a/internal/tarsserver/handler_schedule.go
+++ b/internal/tarsserver/handler_schedule.go
@@ -1,7 +1,6 @@
 package tarsserver
 
 import (
-	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -35,8 +34,7 @@ func newScheduleAPIHandler(store *schedule.Store, logger zerolog.Logger) http.Ha
 				ProjectID string `json:"project_id,omitempty"`
 				Timezone  string `json:"timezone,omitempty"`
 			}
-			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+			if !decodeJSONBody(w, r, &req) {
 				return
 			}
 			created, err := store.Create(schedule.CreateInput{
@@ -77,8 +75,7 @@ func newScheduleAPIHandler(store *schedule.Store, logger zerolog.Logger) http.Ha
 				ProjectID *string `json:"project_id,omitempty"`
 				Timezone  *string `json:"timezone,omitempty"`
 			}
-			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+			if !decodeJSONBody(w, r, &req) {
 				return
 			}
 			updated, err := store.Update(id, schedule.UpdateInput{

--- a/internal/tarsserver/handler_session.go
+++ b/internal/tarsserver/handler_session.go
@@ -1,7 +1,6 @@
 package tarsserver
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -342,8 +341,7 @@ func newCompactAPIHandler(workspaceDir string, store *session.Store, client llm.
 			KeepRecent       int    `json:"keep_recent"`
 			KeepRecentTokens int    `json:"keep_recent_tokens"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		if !decodeJSONBody(w, r, &req) {
 			return
 		}
 

--- a/internal/tarsserver/handler_transport_helpers.go
+++ b/internal/tarsserver/handler_transport_helpers.go
@@ -2,10 +2,14 @@ package tarsserver
 
 import (
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
 )
+
+const defaultJSONBodyLimitBytes int64 = 10 << 20
 
 func requireMethod(w http.ResponseWriter, r *http.Request, allowed ...string) bool {
 	if r == nil {
@@ -22,7 +26,27 @@ func requireMethod(w http.ResponseWriter, r *http.Request, allowed ...string) bo
 }
 
 func decodeJSONBody(w http.ResponseWriter, r *http.Request, dst any) bool {
-	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+	return decodeJSONBodyWithLimit(w, r, dst, defaultJSONBodyLimitBytes, false)
+}
+
+func decodeOptionalJSONBody(w http.ResponseWriter, r *http.Request, dst any) bool {
+	return decodeJSONBodyWithLimit(w, r, dst, defaultJSONBodyLimitBytes, true)
+}
+
+func decodeJSONBodyWithLimit(w http.ResponseWriter, r *http.Request, dst any, maxBytes int64, allowEOF bool) bool {
+	body := r.Body
+	if maxBytes > 0 {
+		body = http.MaxBytesReader(w, r.Body, maxBytes)
+	}
+	if err := json.NewDecoder(body).Decode(dst); err != nil {
+		if allowEOF && errors.Is(err, io.EOF) {
+			return true
+		}
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, map[string]string{"error": "request body too large"})
+			return false
+		}
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
 		return false
 	}

--- a/internal/tarsserver/handler_transport_helpers_test.go
+++ b/internal/tarsserver/handler_transport_helpers_test.go
@@ -54,6 +54,47 @@ func TestDecodeJSONBody_WritesInvalidRequestBodyError(t *testing.T) {
 	}
 }
 
+func TestDecodeJSONBodyWithLimit_WritesRequestEntityTooLarge(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/v1/test", strings.NewReader(`{"name":"too-long"}`))
+	rec := httptest.NewRecorder()
+	var payload struct {
+		Name string `json:"name"`
+	}
+
+	ok := decodeJSONBodyWithLimit(rec, req, &payload, 8, false)
+
+	if ok {
+		t.Fatal("expected decodeJSONBodyWithLimit to reject oversized body")
+	}
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d", rec.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	if body["error"] != "request body too large" {
+		t.Fatalf("expected request body too large error, got %+v", body)
+	}
+}
+
+func TestDecodeJSONBodyWithLimit_AllowsOptionalEOF(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/v1/test", strings.NewReader(""))
+	rec := httptest.NewRecorder()
+	var payload struct {
+		Name string `json:"name"`
+	}
+
+	ok := decodeJSONBodyWithLimit(rec, req, &payload, 8, true)
+
+	if !ok {
+		t.Fatal("expected decodeJSONBodyWithLimit to allow empty body when EOF is permitted")
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected recorder to stay untouched, got %d", rec.Code)
+	}
+}
+
 func TestParsePositiveLimit_WritesValidationError(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/v1/test?limit=0", nil)
 	rec := httptest.NewRecorder()

--- a/internal/tarsserver/handler_usage.go
+++ b/internal/tarsserver/handler_usage.go
@@ -1,7 +1,6 @@
 package tarsserver
 
 import (
-	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -57,8 +56,7 @@ func newUsageAPIHandler(tracker *usage.Tracker, authMode string, logger zerolog.
 				MonthlyUSD *float64 `json:"monthly_usd,omitempty"`
 				Mode       *string  `json:"mode,omitempty"`
 			}
-			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+			if !decodeJSONBody(w, r, &req) {
 				return
 			}
 			next := tracker.Limits()

--- a/internal/tarsserver/notify.go
+++ b/internal/tarsserver/notify.go
@@ -383,8 +383,7 @@ func newEventsAPIHandler(broker *eventBroker, store *notificationStore, logger z
 		var req struct {
 			LastID int64 `json:"last_id"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		if !decodeJSONBody(w, r, &req) {
 			return
 		}
 		role := normalizeNotificationRoleKey(serverauth.RoleFromRequest(r))


### PR DESCRIPTION
## Summary

- closes #89
- apply a shared 10MB limit before JSON decoding in `internal/tarsserver` helper paths and remaining direct decode handlers
- return `413` for oversized request bodies while keeping existing `400` handling for invalid JSON

## Changes

- add `defaultJSONBodyLimitBytes`, `decodeJSONBodyWithLimit`, and `decodeOptionalJSONBody` in `handler_transport_helpers.go`
- route direct JSON decode paths in chat, ops, project, schedule, session, usage, and notification handlers through the shared helper
- add focused tests for oversized body rejection and optional EOF handling

## Validation

- [ ] `make test`
- [x] `make security-scan`
- [x] Additional manual verification, if needed
- `go test ./internal/tarsserver -run "Test(DecodeJSONBody|OpsAPI|ScheduleAPI|Project|UsageAPI|SessionAPI|CronAPI|Compact)"`
- `go test ./internal/tarsserver` *(fails locally because browser handler tests require the `playwright` package in `scripts/playwright_browser_runner.mjs`)*
- `make lint`

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [ ] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [ ] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level: Low
- Rollback plan: Revert commit d08406c if body size limits cause unexpected client failures
