### PR TITLE
fix: reduce codex refresh token persistence

### DIFF
--- a/internal/auth/codex_oauth.go
+++ b/internal/auth/codex_oauth.go
@@ -182,6 +182,11 @@ func resolveCodexCredentialFromFile(path string) (CodexCredential, error) {
 		return CodexCredential{}, fmt.Errorf("openai-codex auth file %q missing tokens.access_token", path)
 	}
 	refresh := strings.TrimSpace(asString(tokens["refresh_token"]))
+	if store := currentCodexRefreshTokenStore(); store != nil {
+		if secureRefresh, loadErr := store.Load(path); loadErr == nil && strings.TrimSpace(secureRefresh) != "" {
+			refresh = strings.TrimSpace(secureRefresh)
+		}
+	}
 	accountID := strings.TrimSpace(asString(tokens["account_id"]))
 	if accountID == "" {
 		accountID = ParseCodexAccountIDFromJWT(access)
@@ -210,7 +215,18 @@ func persistCodexCredentialFile(path string, cred CodexCredential) error {
 		tokens = map[string]any{}
 	}
 	tokens["access_token"] = cred.AccessToken
-	tokens["refresh_token"] = cred.RefreshToken
+	refreshPersistedSecurely := false
+	if store := currentCodexRefreshTokenStore(); store != nil && strings.TrimSpace(cred.RefreshToken) != "" {
+		if err := store.Save(path, cred.RefreshToken); err == nil {
+			delete(tokens, "refresh_token")
+			parsed["refresh_token_store"] = store.Name()
+			refreshPersistedSecurely = true
+		}
+	}
+	if !refreshPersistedSecurely {
+		tokens["refresh_token"] = cred.RefreshToken
+		delete(parsed, "refresh_token_store")
+	}
 	if strings.TrimSpace(cred.AccountID) != "" {
 		tokens["account_id"] = cred.AccountID
 	}

--- a/internal/auth/codex_oauth_test.go
+++ b/internal/auth/codex_oauth_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -38,6 +39,7 @@ func TestResolveCodexCredential_EnvOnly(t *testing.T) {
 }
 
 func TestResolveCodexCredential_File(t *testing.T) {
+	withCodexRefreshTokenStoreForTests(t, nil)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("OPENAI_CODEX_OAUTH_TOKEN", "")
@@ -73,6 +75,7 @@ func TestResolveCodexCredential_File(t *testing.T) {
 }
 
 func TestResolveCodexCredential_PrefersEnvOverFile(t *testing.T) {
+	withCodexRefreshTokenStoreForTests(t, nil)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	path := filepath.Join(home, ".codex", "auth.json")
@@ -166,6 +169,7 @@ func TestRefreshCodexCredential_RequiresFields(t *testing.T) {
 }
 
 func TestRefreshCodexCredential_PersistAtomic(t *testing.T) {
+	withCodexRefreshTokenStoreForTests(t, nil)
 	home := t.TempDir()
 	path := filepath.Join(home, ".codex", "auth.json")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -234,4 +238,171 @@ func makeJWTWithAccountID(t *testing.T, accountID string) string {
 	payloadJSON := `{"https://api.openai.com/auth":{"chatgpt_account_id":"` + accountID + `"}}`
 	payload := base64.RawURLEncoding.EncodeToString([]byte(payloadJSON))
 	return header + "." + payload + ".sig"
+}
+
+type stubCodexRefreshTokenStore struct {
+	name      string
+	loadToken string
+	loadErr   error
+	saveErr   error
+	savedPath string
+	saved     string
+}
+
+func (s *stubCodexRefreshTokenStore) Name() string {
+	if strings.TrimSpace(s.name) == "" {
+		return "stub"
+	}
+	return s.name
+}
+
+func (s *stubCodexRefreshTokenStore) Load(path string) (string, error) {
+	s.savedPath = path
+	return s.loadToken, s.loadErr
+}
+
+func (s *stubCodexRefreshTokenStore) Save(path string, token string) error {
+	s.savedPath = path
+	s.saved = token
+	return s.saveErr
+}
+
+func withCodexRefreshTokenStoreForTests(t *testing.T, store codexRefreshTokenStore) {
+	t.Helper()
+	prev := currentCodexRefreshTokenStore
+	currentCodexRefreshTokenStore = func() codexRefreshTokenStore {
+		return store
+	}
+	t.Cleanup(func() {
+		currentCodexRefreshTokenStore = prev
+	})
+}
+
+func TestResolveCodexCredential_FilePrefersSecureStoreRefreshToken(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("OPENAI_CODEX_OAUTH_TOKEN", "")
+	t.Setenv("OPENAI_CODEX_REFRESH_TOKEN", "")
+	t.Setenv("OPENAI_CODEX_ACCOUNT_ID", "")
+	path := filepath.Join(home, ".codex", "auth.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(`{"tokens":{"access_token":"file-access","refresh_token":"file-refresh","account_id":"acc-file"}}`), 0o644); err != nil {
+		t.Fatalf("write auth file: %v", err)
+	}
+	withCodexRefreshTokenStoreForTests(t, &stubCodexRefreshTokenStore{
+		name:      "test-store",
+		loadToken: "secure-refresh",
+	})
+
+	cred, err := ResolveCodexCredential(CodexResolveOptions{})
+	if err != nil {
+		t.Fatalf("resolve codex credential: %v", err)
+	}
+	if cred.RefreshToken != "secure-refresh" {
+		t.Fatalf("expected secure-store refresh token, got %q", cred.RefreshToken)
+	}
+}
+
+func TestRefreshCodexCredential_PersistUsesSecureStoreWhenAvailable(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".codex", "auth.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(`{"tokens":{"access_token":"old-access","refresh_token":"old-refresh","account_id":"acc-old"}}`), 0o644); err != nil {
+		t.Fatalf("write auth file: %v", err)
+	}
+
+	store := &stubCodexRefreshTokenStore{name: "test-store"}
+	withCodexRefreshTokenStoreForTests(t, store)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"access_token":"new-access","refresh_token":"new-refresh","expires_in":3600}`))
+	}))
+	defer srv.Close()
+
+	_, err := RefreshCodexCredential(context.Background(), CodexCredential{
+		AccessToken:  "old-access",
+		RefreshToken: "old-refresh",
+		AccountID:    "acc-old",
+		Source:       CodexCredentialSourceFile,
+		SourcePath:   path,
+	}, CodexRefreshOptions{
+		TokenURL:    srv.URL,
+		HTTPClient:  srv.Client(),
+		PersistFile: true,
+	})
+	if err != nil {
+		t.Fatalf("refresh codex credential: %v", err)
+	}
+	if store.saved != "new-refresh" {
+		t.Fatalf("expected secure store save new-refresh, got %q", store.saved)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read auth file: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse auth file: %v", err)
+	}
+	tokens, _ := parsed["tokens"].(map[string]any)
+	if _, ok := tokens["refresh_token"]; ok {
+		t.Fatalf("expected refresh_token to be scrubbed from auth file, got %+v", tokens)
+	}
+}
+
+func TestRefreshCodexCredential_PersistFallsBackToFileWhenSecureStoreFails(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".codex", "auth.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(`{"tokens":{"access_token":"old-access","refresh_token":"old-refresh","account_id":"acc-old"}}`), 0o644); err != nil {
+		t.Fatalf("write auth file: %v", err)
+	}
+
+	withCodexRefreshTokenStoreForTests(t, &stubCodexRefreshTokenStore{
+		name:    "test-store",
+		saveErr: errors.New("save failed"),
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"access_token":"new-access","refresh_token":"new-refresh","expires_in":3600}`))
+	}))
+	defer srv.Close()
+
+	_, err := RefreshCodexCredential(context.Background(), CodexCredential{
+		AccessToken:  "old-access",
+		RefreshToken: "old-refresh",
+		AccountID:    "acc-old",
+		Source:       CodexCredentialSourceFile,
+		SourcePath:   path,
+	}, CodexRefreshOptions{
+		TokenURL:    srv.URL,
+		HTTPClient:  srv.Client(),
+		PersistFile: true,
+	})
+	if err != nil {
+		t.Fatalf("refresh codex credential: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read auth file: %v", err)
+	}
+	var parsed struct {
+		Tokens struct {
+			RefreshToken string `json:"refresh_token"`
+		} `json:"tokens"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse auth file: %v", err)
+	}
+	if parsed.Tokens.RefreshToken != "new-refresh" {
+		t.Fatalf("expected file fallback refresh token new-refresh, got %q", parsed.Tokens.RefreshToken)
+	}
 }

--- a/internal/auth/codex_refresh_store.go
+++ b/internal/auth/codex_refresh_store.go
@@ -1,0 +1,108 @@
+package auth
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+const (
+	codexRefreshTokenStorageModeEnv  = "TARS_OPENAI_CODEX_REFRESH_TOKEN_STORAGE"
+	codexRefreshTokenStorageAuto     = "auto"
+	codexRefreshTokenStorageFile     = "file"
+	codexRefreshTokenStorageKeychain = "keychain"
+	codexRefreshTokenKeychainService = "github.com/devlikebear/tars/openai-codex/refresh-token"
+)
+
+type codexRefreshTokenStore interface {
+	Name() string
+	Load(path string) (string, error)
+	Save(path string, token string) error
+}
+
+var currentCodexRefreshTokenStore = func() codexRefreshTokenStore {
+	mode := normalizeCodexRefreshTokenStorageMode(os.Getenv(codexRefreshTokenStorageModeEnv))
+	switch mode {
+	case codexRefreshTokenStorageFile:
+		return nil
+	case codexRefreshTokenStorageKeychain:
+		if runtime.GOOS == "darwin" {
+			return newKeychainCodexRefreshTokenStore(defaultCodexSecurityRunner)
+		}
+		return nil
+	default:
+		if runtime.GOOS == "darwin" {
+			return newKeychainCodexRefreshTokenStore(defaultCodexSecurityRunner)
+		}
+		return nil
+	}
+}
+
+type codexSecurityRunner func(name string, args ...string) ([]byte, error)
+
+type keychainCodexRefreshTokenStore struct {
+	run codexSecurityRunner
+}
+
+func newKeychainCodexRefreshTokenStore(run codexSecurityRunner) codexRefreshTokenStore {
+	if run == nil {
+		run = defaultCodexSecurityRunner
+	}
+	return keychainCodexRefreshTokenStore{run: run}
+}
+
+func (s keychainCodexRefreshTokenStore) Name() string {
+	return "macos-keychain"
+}
+
+func (s keychainCodexRefreshTokenStore) Load(path string) (string, error) {
+	account := codexRefreshTokenStoreAccount(path)
+	if account == "" {
+		return "", nil
+	}
+	out, err := s.run("/usr/bin/security", "find-generic-password", "-a", account, "-s", codexRefreshTokenKeychainService, "-w")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func (s keychainCodexRefreshTokenStore) Save(path string, token string) error {
+	account := codexRefreshTokenStoreAccount(path)
+	token = strings.TrimSpace(token)
+	if account == "" || token == "" {
+		return nil
+	}
+	_, err := s.run("/usr/bin/security", "add-generic-password", "-U", "-a", account, "-s", codexRefreshTokenKeychainService, "-w", token)
+	return err
+}
+
+func defaultCodexSecurityRunner(name string, args ...string) ([]byte, error) {
+	cmd := exec.Command(name, args...)
+	return cmd.CombinedOutput()
+}
+
+func normalizeCodexRefreshTokenStorageMode(raw string) string {
+	switch strings.TrimSpace(strings.ToLower(raw)) {
+	case "", codexRefreshTokenStorageAuto:
+		return codexRefreshTokenStorageAuto
+	case codexRefreshTokenStorageFile:
+		return codexRefreshTokenStorageFile
+	case codexRefreshTokenStorageKeychain:
+		return codexRefreshTokenStorageKeychain
+	default:
+		return codexRefreshTokenStorageAuto
+	}
+}
+
+func codexRefreshTokenStoreAccount(path string) string {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(trimmed))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/auth/provider_credentials_test.go
+++ b/internal/auth/provider_credentials_test.go
@@ -29,6 +29,7 @@ func TestResolveProviderCredential_APIKeyStrategy(t *testing.T) {
 }
 
 func TestResolveProviderCredential_OpenAICodexOAuthStrategy(t *testing.T) {
+	withCodexRefreshTokenStoreForTests(t, nil)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	path := filepath.Join(home, ".codex", "auth.json")
@@ -56,6 +57,7 @@ func TestResolveProviderCredential_OpenAICodexOAuthStrategy(t *testing.T) {
 }
 
 func TestRefreshProviderCredential_OpenAICodexStrategy(t *testing.T) {
+	withCodexRefreshTokenStoreForTests(t, nil)
 	home := t.TempDir()
 	path := filepath.Join(home, ".codex", "auth.json")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {


### PR DESCRIPTION
## Summary

- closes #93
- reduce the plaintext persistence surface for OpenAI Codex OAuth refresh tokens by preferring the macOS keychain when TARS refreshes file-backed credentials
- keep file fallback behavior when secure storage is unavailable or disabled

## Changes

- add a small Codex refresh-token store abstraction with `auto` / `keychain` / `file` selection via `TARS_OPENAI_CODEX_REFRESH_TOKEN_STORAGE`
- prefer keychain-backed refresh token load/save on macOS while preserving auth file fallback elsewhere
- add focused auth tests for secure-store override, secure persistence, and file fallback

## Validation

- [ ] `make test`
- [x] `make security-scan`
- [x] Additional manual verification, if needed
- `go test ./internal/auth ./internal/llm`
- `make lint`

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [ ] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [ ] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level: Medium
- Rollback plan: Revert commit 8bf8452 if Codex auth interoperability regresses
