### PR TITLE
chore: centralize handler method checks

### DIFF
--- a/internal/tarsserver/handler_auth.go
+++ b/internal/tarsserver/handler_auth.go
@@ -10,8 +10,7 @@ import (
 func newAuthAPIHandler(authMode string) http.Handler {
 	mode := serverauth.NormalizeMode(authMode)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		if !requireMethod(w, r, http.MethodGet) {
 			return
 		}
 		role := strings.TrimSpace(serverauth.RoleFromRequest(r))

--- a/internal/tarsserver/handler_auth_test.go
+++ b/internal/tarsserver/handler_auth_test.go
@@ -82,3 +82,18 @@ func TestAuthWhoamiAPI_OffModeReturnsAnonymous(t *testing.T) {
 		t.Fatalf("expected auth_mode off, got %+v", body)
 	}
 }
+
+func TestAuthWhoamiAPI_RejectsNonGet(t *testing.T) {
+	handler := newAuthAPIHandler("required")
+	req := httptest.NewRequest(http.MethodPost, "/v1/auth/whoami", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	if rec.Body.String() != "method not allowed\n" {
+		t.Fatalf("expected plain text method-not-allowed body, got %q", rec.Body.String())
+	}
+}

--- a/internal/tarsserver/handler_cron.go
+++ b/internal/tarsserver/handler_cron.go
@@ -66,6 +66,9 @@ func newCronAPIHandlerWithRunnerAndResolver(
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "resolve workspace failed"})
 			return
 		}
+		if !requireMethod(w, r, http.MethodGet, http.MethodPost) {
+			return
+		}
 		switch r.Method {
 		case http.MethodGet:
 			jobs, err := reqStore.List()
@@ -121,8 +124,6 @@ func newCronAPIHandlerWithRunnerAndResolver(
 				return
 			}
 			writeJSON(w, http.StatusOK, job)
-		default:
-			requireMethod(w, r)
 		}
 	})
 
@@ -141,6 +142,9 @@ func newCronAPIHandlerWithRunnerAndResolver(
 		}
 		jobID := pathParts[0]
 		if len(pathParts) == 1 {
+			if !requireMethod(w, r, http.MethodGet, http.MethodPut, http.MethodDelete) {
+				return
+			}
 			switch r.Method {
 			case http.MethodGet:
 				job, err := reqStore.Get(jobID)
@@ -206,8 +210,6 @@ func newCronAPIHandlerWithRunnerAndResolver(
 					return
 				}
 				w.WriteHeader(http.StatusNoContent)
-			default:
-				requireMethod(w, r)
 			}
 			return
 		}

--- a/internal/tarsserver/handler_extensions.go
+++ b/internal/tarsserver/handler_extensions.go
@@ -20,8 +20,7 @@ type mcpProvider interface {
 func newMCPAPIHandler(provider mcpProvider, logger zerolog.Logger) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/mcp/servers", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		if !requireMethod(w, r, http.MethodGet) {
 			return
 		}
 		if provider == nil {
@@ -37,8 +36,7 @@ func newMCPAPIHandler(provider mcpProvider, logger zerolog.Logger) http.Handler 
 		writeJSON(w, http.StatusOK, servers)
 	})
 	mux.HandleFunc("/v1/mcp/tools", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		if !requireMethod(w, r, http.MethodGet) {
 			return
 		}
 		if provider == nil {
@@ -64,8 +62,7 @@ type extensionsProvider interface {
 func newExtensionsAPIHandler(provider extensionsProvider, logger zerolog.Logger, afterReload func() (bool, int)) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/skills", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		if !requireMethod(w, r, http.MethodGet) {
 			return
 		}
 		if provider == nil {
@@ -80,8 +77,7 @@ func newExtensionsAPIHandler(provider extensionsProvider, logger zerolog.Logger,
 		writeJSON(w, http.StatusOK, skills)
 	})
 	mux.HandleFunc("/v1/skills/", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		if !requireMethod(w, r, http.MethodGet) {
 			return
 		}
 		if provider == nil {
@@ -103,8 +99,7 @@ func newExtensionsAPIHandler(provider extensionsProvider, logger zerolog.Logger,
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "skill not found"})
 	})
 	mux.HandleFunc("/v1/plugins", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		if !requireMethod(w, r, http.MethodGet) {
 			return
 		}
 		if provider == nil {
@@ -119,8 +114,7 @@ func newExtensionsAPIHandler(provider extensionsProvider, logger zerolog.Logger,
 		writeJSON(w, http.StatusOK, plugins)
 	})
 	mux.HandleFunc("/v1/runtime/extensions/reload", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		if !requireMethod(w, r, http.MethodPost) {
 			return
 		}
 		if provider == nil {

--- a/internal/tarsserver/handler_gateway_channels.go
+++ b/internal/tarsserver/handler_gateway_channels.go
@@ -51,8 +51,7 @@ func newChannelsAPIHandlerWithTelegramPairings(
 }
 
 func handleWebhookInbound(w http.ResponseWriter, r *http.Request, runtime *gateway.Runtime, logger zerolog.Logger) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	if !requireMethod(w, r, http.MethodPost) {
 		return
 	}
 	if runtime == nil {
@@ -79,8 +78,7 @@ func handleWebhookInbound(w http.ResponseWriter, r *http.Request, runtime *gatew
 }
 
 func handleTelegramInbound(w http.ResponseWriter, r *http.Request, runtime *gateway.Runtime, logger zerolog.Logger) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	if !requireMethod(w, r, http.MethodPost) {
 		return
 	}
 	if runtime == nil {
@@ -113,8 +111,7 @@ func handleTelegramSend(
 	sender telegramSender,
 	logger zerolog.Logger,
 ) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	if !requireMethod(w, r, http.MethodPost) {
 		return
 	}
 	if runtime == nil {
@@ -190,8 +187,7 @@ func handleTelegramPairingsList(
 	dmPolicy string,
 	pollingEnabled bool,
 ) {
-	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	if !requireMethod(w, r, http.MethodGet) {
 		return
 	}
 	if pairings == nil {
@@ -207,8 +203,7 @@ func handleTelegramPairingsAction(w http.ResponseWriter, r *http.Request, pairin
 		http.NotFound(w, r)
 		return
 	}
-	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	if !requireMethod(w, r, http.MethodPost) {
 		return
 	}
 	if pairings == nil {

--- a/internal/tarsserver/handler_ops.go
+++ b/internal/tarsserver/handler_ops.go
@@ -17,8 +17,7 @@ func newOpsAPIHandler(manager *ops.Manager, logger zerolog.Logger, emit func(con
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "ops manager is not configured"})
 			return
 		}
-		if r.Method != http.MethodGet {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		if !requireMethod(w, r, http.MethodGet) {
 			return
 		}
 		status, err := manager.Status(r.Context())
@@ -35,8 +34,7 @@ func newOpsAPIHandler(manager *ops.Manager, logger zerolog.Logger, emit func(con
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "ops manager is not configured"})
 			return
 		}
-		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		if !requireMethod(w, r, http.MethodPost) {
 			return
 		}
 		plan, err := manager.CreateCleanupPlan(r.Context())
@@ -56,8 +54,7 @@ func newOpsAPIHandler(manager *ops.Manager, logger zerolog.Logger, emit func(con
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "ops manager is not configured"})
 			return
 		}
-		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		if !requireMethod(w, r, http.MethodPost) {
 			return
 		}
 		var req struct {
@@ -82,8 +79,7 @@ func newOpsAPIHandler(manager *ops.Manager, logger zerolog.Logger, emit func(con
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "ops manager is not configured"})
 			return
 		}
-		if r.Method != http.MethodGet {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		if !requireMethod(w, r, http.MethodGet) {
 			return
 		}
 		items, err := manager.ListApprovals()
@@ -107,8 +103,7 @@ func newOpsAPIHandler(manager *ops.Manager, logger zerolog.Logger, emit func(con
 		}
 		approvalID := strings.TrimSpace(parts[0])
 		action := strings.TrimSpace(parts[1])
-		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		if !requireMethod(w, r, http.MethodPost) {
 			return
 		}
 		var err error

--- a/internal/tarsserver/handler_project.go
+++ b/internal/tarsserver/handler_project.go
@@ -40,6 +40,9 @@ func newProjectAPIHandler(
 		}
 		briefID := strings.TrimSpace(parts[0])
 		if len(parts) == 1 {
+			if !requireMethod(w, r, http.MethodGet, http.MethodPatch) {
+				return
+			}
 			switch r.Method {
 			case http.MethodGet:
 				item, err := store.GetBrief(briefID)
@@ -107,14 +110,11 @@ func newProjectAPIHandler(
 					return
 				}
 				writeJSON(w, http.StatusOK, updated)
-			default:
-				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			}
 			return
 		}
 		if len(parts) == 2 && parts[1] == "finalize" {
-			if r.Method != http.MethodPost {
-				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			if !requireMethod(w, r, http.MethodPost) {
 				return
 			}
 			created, brief, err := store.FinalizeBrief(briefID, sessionStore)
@@ -144,6 +144,9 @@ func newProjectAPIHandler(
 	mux.HandleFunc("/v1/projects", func(w http.ResponseWriter, r *http.Request) {
 		if store == nil {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "project store is not configured"})
+			return
+		}
+		if !requireMethod(w, r, http.MethodGet, http.MethodPost) {
 			return
 		}
 		switch r.Method {
@@ -186,8 +189,6 @@ func newProjectAPIHandler(
 			}
 			writeJSON(w, http.StatusOK, created)
 			dashboardBroker.publish(newProjectDashboardEvent(created.ID, "activity"))
-		default:
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		}
 	})
 
@@ -205,6 +206,9 @@ func newProjectAPIHandler(
 		projectID := strings.TrimSpace(parts[0])
 
 		if len(parts) == 1 {
+			if !requireMethod(w, r, http.MethodGet, http.MethodPatch, http.MethodDelete) {
+				return
+			}
 			switch r.Method {
 			case http.MethodGet:
 				item, err := store.Get(projectID)
@@ -251,13 +255,14 @@ func newProjectAPIHandler(
 				}
 				dashboardBroker.publish(newProjectDashboardEvent(projectID, "activity"))
 				w.WriteHeader(http.StatusNoContent)
-			default:
-				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			}
 			return
 		}
 
 		if len(parts) == 2 && parts[1] == "state" {
+			if !requireMethod(w, r, http.MethodGet, http.MethodPatch) {
+				return
+			}
 			switch r.Method {
 			case http.MethodGet:
 				item, err := store.GetState(projectID)
@@ -314,13 +319,14 @@ func newProjectAPIHandler(
 				}
 				dashboardBroker.publish(newProjectDashboardEvent(projectID, "activity"))
 				writeJSON(w, http.StatusOK, updated)
-			default:
-				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			}
 			return
 		}
 
 		if len(parts) == 2 && parts[1] == "activity" {
+			if !requireMethod(w, r, http.MethodGet, http.MethodPost) {
+				return
+			}
 			switch r.Method {
 			case http.MethodGet:
 				limit, ok := parsePositiveLimit(w, r, 50)
@@ -378,13 +384,14 @@ func newProjectAPIHandler(
 				}
 				dashboardBroker.publish(newProjectDashboardEvent(projectID, "activity"))
 				writeJSON(w, http.StatusOK, item)
-			default:
-				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			}
 			return
 		}
 
 		if len(parts) == 2 && parts[1] == "board" {
+			if !requireMethod(w, r, http.MethodGet, http.MethodPatch) {
+				return
+			}
 			switch r.Method {
 			case http.MethodGet:
 				item, err := store.GetBoard(projectID)
@@ -426,15 +433,12 @@ func newProjectAPIHandler(
 				}
 				dashboardBroker.publish(newProjectDashboardEvent(projectID, "board"))
 				writeJSON(w, http.StatusOK, item)
-			default:
-				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			}
 			return
 		}
 
 		if len(parts) == 2 && parts[1] == "dispatch" {
-			if r.Method != http.MethodPost {
-				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			if !requireMethod(w, r, http.MethodPost) {
 				return
 			}
 			if taskRunner == nil {
@@ -480,6 +484,9 @@ func newProjectAPIHandler(
 				writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "project autopilot manager is not configured"})
 				return
 			}
+			if !requireMethod(w, r, http.MethodGet, http.MethodPost) {
+				return
+			}
 			switch r.Method {
 			case http.MethodGet:
 				item, ok := autopilot.Status(projectID)
@@ -505,15 +512,12 @@ func newProjectAPIHandler(
 					return
 				}
 				writeJSON(w, http.StatusOK, item)
-			default:
-				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			}
 			return
 		}
 
 		if len(parts) == 2 && parts[1] == "activate" {
-			if r.Method != http.MethodPost {
-				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			if !requireMethod(w, r, http.MethodPost) {
 				return
 			}
 			if sessionStore == nil {

--- a/internal/tarsserver/handler_project_test.go
+++ b/internal/tarsserver/handler_project_test.go
@@ -92,6 +92,65 @@ func TestProjectAPI_CRUDAndActivate(t *testing.T) {
 	}
 }
 
+func TestProjectAPI_RejectsDisallowedMethods(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "workspace")
+	if err := memory.EnsureWorkspace(root); err != nil {
+		t.Fatalf("ensure workspace: %v", err)
+	}
+	store := session.NewStore(root)
+	mainSess, err := store.Create("main")
+	if err != nil {
+		t.Fatalf("create main session: %v", err)
+	}
+
+	projectStore := project.NewStore(root, nil)
+	handler := newProjectAPIHandler(projectStore, store, mainSess.ID, nil, nil, nil, nil, zerolog.New(io.Discard))
+
+	createReq := httptest.NewRequest(http.MethodPost, "/v1/projects", strings.NewReader(`{"name":"Ops A","type":"operations"}`))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	handler.ServeHTTP(createRec, createReq)
+	if createRec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for create, got %d body=%q", createRec.Code, createRec.Body.String())
+	}
+	var created project.Project
+	if err := json.Unmarshal(createRec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode created project: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		req  *http.Request
+	}{
+		{
+			name: "projects collection",
+			req:  httptest.NewRequest(http.MethodPut, "/v1/projects", nil),
+		},
+		{
+			name: "brief finalize",
+			req:  httptest.NewRequest(http.MethodGet, "/v1/project-briefs/"+mainSess.ID+"/finalize", nil),
+		},
+		{
+			name: "project dispatch",
+			req:  httptest.NewRequest(http.MethodGet, "/v1/projects/"+created.ID+"/dispatch", nil),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, tc.req)
+
+			if rec.Code != http.StatusMethodNotAllowed {
+				t.Fatalf("expected 405, got %d body=%q", rec.Code, rec.Body.String())
+			}
+			if rec.Body.String() != "method not allowed\n" {
+				t.Fatalf("expected plain text method-not-allowed body, got %q", rec.Body.String())
+			}
+		})
+	}
+}
+
 func TestProjectAPI_PatchUpdatesPolicyFields(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "workspace")
 	if err := memory.EnsureWorkspace(root); err != nil {

--- a/internal/tarsserver/handler_schedule.go
+++ b/internal/tarsserver/handler_schedule.go
@@ -16,6 +16,9 @@ func newScheduleAPIHandler(store *schedule.Store, logger zerolog.Logger) http.Ha
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "schedule store is not configured"})
 			return
 		}
+		if !requireMethod(w, r, http.MethodGet, http.MethodPost) {
+			return
+		}
 		switch r.Method {
 		case http.MethodGet:
 			items, err := store.List()
@@ -50,8 +53,6 @@ func newScheduleAPIHandler(store *schedule.Store, logger zerolog.Logger) http.Ha
 				return
 			}
 			writeJSON(w, http.StatusOK, created)
-		default:
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		}
 	})
 
@@ -63,6 +64,9 @@ func newScheduleAPIHandler(store *schedule.Store, logger zerolog.Logger) http.Ha
 		id := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, "/v1/schedules/"))
 		if id == "" || strings.Contains(id, "/") {
 			http.NotFound(w, r)
+			return
+		}
+		if !requireMethod(w, r, http.MethodPatch, http.MethodDelete) {
 			return
 		}
 		switch r.Method {
@@ -105,8 +109,6 @@ func newScheduleAPIHandler(store *schedule.Store, logger zerolog.Logger) http.Ha
 				return
 			}
 			w.WriteHeader(http.StatusNoContent)
-		default:
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		}
 	})
 

--- a/internal/tarsserver/handler_session.go
+++ b/internal/tarsserver/handler_session.go
@@ -332,8 +332,7 @@ func newHealthzAPIHandler(nowFn func() time.Time, dashboardAuthStatus map[string
 
 func newCompactAPIHandler(workspaceDir string, store *session.Store, client llm.Client, logger zerolog.Logger) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		if !requireMethod(w, r, http.MethodPost) {
 			return
 		}
 		var req struct {

--- a/internal/tarsserver/handler_usage.go
+++ b/internal/tarsserver/handler_usage.go
@@ -18,8 +18,7 @@ func newUsageAPIHandler(tracker *usage.Tracker, authMode string, logger zerolog.
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "usage tracker is not configured"})
 			return
 		}
-		if r.Method != http.MethodGet {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		if !requireMethod(w, r, http.MethodGet) {
 			return
 		}
 		period := strings.TrimSpace(r.URL.Query().Get("period"))
@@ -40,6 +39,9 @@ func newUsageAPIHandler(tracker *usage.Tracker, authMode string, logger zerolog.
 	mux.HandleFunc("/v1/usage/limits", func(w http.ResponseWriter, r *http.Request) {
 		if tracker == nil {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "usage tracker is not configured"})
+			return
+		}
+		if !requireMethod(w, r, http.MethodGet, http.MethodPatch) {
 			return
 		}
 		switch r.Method {
@@ -79,8 +81,6 @@ func newUsageAPIHandler(tracker *usage.Tracker, authMode string, logger zerolog.
 				return
 			}
 			writeJSON(w, http.StatusOK, updated)
-		default:
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		}
 	})
 

--- a/internal/tarsserver/handlers.go
+++ b/internal/tarsserver/handlers.go
@@ -33,8 +33,7 @@ func newHeartbeatAPIHandlerWithRunner(
 ) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/heartbeat/run-once", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		if !requireMethod(w, r, http.MethodPost) {
 			return
 		}
 		result, err := runHeartbeat(r.Context())

--- a/internal/tarsserver/main_test.go
+++ b/internal/tarsserver/main_test.go
@@ -546,6 +546,60 @@ func TestCronAPI_ListCreateRun(t *testing.T) {
 	}
 }
 
+func TestCronAPI_RejectsDisallowedMethods(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "workspace")
+	if err := memory.EnsureWorkspace(root); err != nil {
+		t.Fatalf("ensure workspace: %v", err)
+	}
+
+	store := cron.NewStore(root)
+	handler := newCronAPIHandler(
+		store,
+		func(_ context.Context, prompt string) (string, error) { return "ok:" + prompt, nil },
+		zerolog.New(io.Discard),
+	)
+
+	createReq := httptest.NewRequest(http.MethodPost, "/v1/cron/jobs", strings.NewReader(`{"name":"morning","prompt":"check inbox"}`))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	handler.ServeHTTP(createRec, createReq)
+	if createRec.Code != http.StatusOK && createRec.Code != http.StatusCreated {
+		t.Fatalf("expected create status 200/201, got %d body=%q", createRec.Code, createRec.Body.String())
+	}
+	var created cron.Job
+	if err := json.Unmarshal(createRec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode created job: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		req  *http.Request
+	}{
+		{
+			name: "jobs collection",
+			req:  httptest.NewRequest(http.MethodPatch, "/v1/cron/jobs", nil),
+		},
+		{
+			name: "job run",
+			req:  httptest.NewRequest(http.MethodGet, "/v1/cron/jobs/"+created.ID+"/run", nil),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, tc.req)
+
+			if rec.Code != http.StatusMethodNotAllowed {
+				t.Fatalf("expected 405, got %d body=%q", rec.Code, rec.Body.String())
+			}
+			if rec.Body.String() != "method not allowed\n" {
+				t.Fatalf("expected plain text method-not-allowed body, got %q", rec.Body.String())
+			}
+		})
+	}
+}
+
 func TestCronAPI_RunDeletesJobWhenDeleteAfterRunEnabled(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "workspace")
 	if err := memory.EnsureWorkspace(root); err != nil {

--- a/internal/tarsserver/notify.go
+++ b/internal/tarsserver/notify.go
@@ -272,8 +272,7 @@ func (d *notificationDispatcher) Emit(ctx context.Context, evt notificationEvent
 
 func newEventStreamHandler(broker *eventBroker, logger zerolog.Logger) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		if !requireMethod(w, r, http.MethodGet) {
 			return
 		}
 		if broker == nil {
@@ -339,8 +338,7 @@ func newEventsAPIHandler(broker *eventBroker, store *notificationStore, logger z
 	mux.Handle("/v1/events/stream", newEventStreamHandler(broker, logger))
 
 	mux.HandleFunc("/v1/events/history", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		if !requireMethod(w, r, http.MethodGet) {
 			return
 		}
 		if store == nil {
@@ -372,8 +370,7 @@ func newEventsAPIHandler(broker *eventBroker, store *notificationStore, logger z
 	})
 
 	mux.HandleFunc("/v1/events/read", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		if !requireMethod(w, r, http.MethodPost) {
 			return
 		}
 		if store == nil {


### PR DESCRIPTION
## Summary

- Replace duplicated plain-text HTTP method guards in `internal/tarsserver` with the existing `requireMethod` helper.
- This keeps the response semantics unchanged while reducing repeated `http.Error(..., \"method not allowed\")` branches across handlers.
- Closes #95.

## Changes

- Main user-visible or developer-visible changes:
  - Centralized GET/POST/PATCH/DELETE guard logic in auth, extensions, gateway channel, ops, project, schedule, session, usage, heartbeat, notify, and cron handlers.
  - Added route-level regression tests for auth, project, and cron endpoints to lock the plain-text `405 method not allowed` response.
- API, config, or compatibility changes:
  - No API contract changes intended; handlers continue to return the same plain-text `405` body for these routes.

## Validation

- [ ] `make test`
  - Fails locally due missing Node `playwright` package required by browser runner tests in `internal/gateway`, `internal/tarsserver`, and `internal/tool`.
- [x] `make security-scan`
- [x] Additional manual verification, if needed
  - `go test ./internal/tarsserver -run 'Test(AuthWhoamiAPI_|ProjectAPI_|CronAPI_|RequireMethod_WritesMethodNotAllowed|OpsAPI_|ScheduleAPI_|UsageAPI_)'`
  - `make lint`

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [x] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [x] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level: Low. This is a behavior-preserving refactor around method dispatch only.
- Rollback plan: Revert this PR to restore the previous inline method checks.
