### PR TITLE
feat: add TARS Skill Hub CLI and companion file support

### DIFF
--- a/cmd/tars/main.go
+++ b/cmd/tars/main.go
@@ -47,6 +47,7 @@ func newRootCommand(stdin io.Reader, stdout, stderr io.Writer) *cobra.Command {
 	cmd.AddCommand(newServiceCommand(stdout, stderr))
 	cmd.AddCommand(newServeCommand(stdout, stderr))
 	cmd.AddCommand(newAssistantCommand(stdout, stderr))
+	cmd.AddCommand(newSkillCommand(stdout, stderr))
 	cmd.AddCommand(newVersionCommand(stdout))
 	return cmd
 }

--- a/cmd/tars/skill_main.go
+++ b/cmd/tars/skill_main.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/devlikebear/tars/internal/skillhub"
+	"github.com/spf13/cobra"
+)
+
+func newSkillCommand(stdout, stderr io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "skill",
+		Short: "Manage skills from the TARS Skill Hub",
+	}
+	cmd.AddCommand(newSkillSearchCommand(stdout))
+	cmd.AddCommand(newSkillInstallCommand(stdout, stderr))
+	cmd.AddCommand(newSkillUninstallCommand(stdout, stderr))
+	cmd.AddCommand(newSkillListCommand(stdout))
+	cmd.AddCommand(newSkillUpdateCommand(stdout, stderr))
+	cmd.AddCommand(newSkillInfoCommand(stdout))
+	return cmd
+}
+
+func newSkillSearchCommand(stdout io.Writer) *cobra.Command {
+	return &cobra.Command{
+		Use:   "search [query]",
+		Short: "Search the skill registry",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			query := ""
+			if len(args) > 0 {
+				query = args[0]
+			}
+			return runSkillSearch(cmd.Context(), stdout, query)
+		},
+	}
+}
+
+func runSkillSearch(ctx context.Context, stdout io.Writer, query string) error {
+	reg := skillhub.NewRegistry()
+	results, err := reg.Search(ctx, query)
+	if err != nil {
+		return fmt.Errorf("search failed: %w", err)
+	}
+	if len(results) == 0 {
+		fmt.Fprintln(stdout, "No skills found.")
+		return nil
+	}
+	for _, entry := range results {
+		invocable := ""
+		if entry.UserInvocable {
+			invocable = " [invocable]"
+		}
+		tags := ""
+		if len(entry.Tags) > 0 {
+			tags = " (" + strings.Join(entry.Tags, ", ") + ")"
+		}
+		fmt.Fprintf(stdout, "  %s@%s%s%s\n    %s\n", entry.Name, entry.Version, invocable, tags, entry.Description)
+	}
+	fmt.Fprintf(stdout, "\n%d skill(s) found.\n", len(results))
+	return nil
+}
+
+func newSkillInstallCommand(stdout, stderr io.Writer) *cobra.Command {
+	var workspaceDir string
+	cmd := &cobra.Command{
+		Use:   "install <name>",
+		Short: "Install a skill from the hub",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir, err := resolveWorkspaceDir(workspaceDir)
+			if err != nil {
+				return err
+			}
+			return runSkillInstall(cmd.Context(), stdout, stderr, dir, args[0])
+		},
+	}
+	cmd.Flags().StringVar(&workspaceDir, "workspace-dir", defaultWorkspaceDir(), "workspace directory")
+	return cmd
+}
+
+func runSkillInstall(ctx context.Context, stdout, _ io.Writer, workspaceDir, name string) error {
+	inst := skillhub.NewInstaller(workspaceDir)
+	if err := inst.Install(ctx, name); err != nil {
+		return fmt.Errorf("install %q: %w", name, err)
+	}
+	fmt.Fprintf(stdout, "Installed skill %q to %s/skills/%s\n", name, workspaceDir, name)
+	return nil
+}
+
+func newSkillUninstallCommand(stdout, stderr io.Writer) *cobra.Command {
+	var workspaceDir string
+	cmd := &cobra.Command{
+		Use:   "uninstall <name>",
+		Short: "Uninstall a skill",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir, err := resolveWorkspaceDir(workspaceDir)
+			if err != nil {
+				return err
+			}
+			return runSkillUninstall(stdout, stderr, dir, args[0])
+		},
+	}
+	cmd.Flags().StringVar(&workspaceDir, "workspace-dir", defaultWorkspaceDir(), "workspace directory")
+	return cmd
+}
+
+func runSkillUninstall(stdout, _ io.Writer, workspaceDir, name string) error {
+	inst := skillhub.NewInstaller(workspaceDir)
+	if err := inst.Uninstall(name); err != nil {
+		return fmt.Errorf("uninstall %q: %w", name, err)
+	}
+	fmt.Fprintf(stdout, "Uninstalled skill %q\n", name)
+	return nil
+}
+
+func newSkillListCommand(stdout io.Writer) *cobra.Command {
+	var workspaceDir string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List installed hub skills",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			dir, err := resolveWorkspaceDir(workspaceDir)
+			if err != nil {
+				return err
+			}
+			return runSkillList(stdout, dir)
+		},
+	}
+	cmd.Flags().StringVar(&workspaceDir, "workspace-dir", defaultWorkspaceDir(), "workspace directory")
+	return cmd
+}
+
+func runSkillList(stdout io.Writer, workspaceDir string) error {
+	inst := skillhub.NewInstaller(workspaceDir)
+	skills, err := inst.List()
+	if err != nil {
+		return err
+	}
+	if len(skills) == 0 {
+		fmt.Fprintln(stdout, "No hub skills installed.")
+		return nil
+	}
+	for _, s := range skills {
+		fmt.Fprintf(stdout, "  %s@%s  (%s)  %s\n", s.Name, s.Version, s.Source, s.Dir)
+	}
+	fmt.Fprintf(stdout, "\n%d skill(s) installed.\n", len(skills))
+	return nil
+}
+
+func newSkillUpdateCommand(stdout, stderr io.Writer) *cobra.Command {
+	var workspaceDir string
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update all installed hub skills to latest",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			dir, err := resolveWorkspaceDir(workspaceDir)
+			if err != nil {
+				return err
+			}
+			return runSkillUpdate(cmd.Context(), stdout, stderr, dir)
+		},
+	}
+	cmd.Flags().StringVar(&workspaceDir, "workspace-dir", defaultWorkspaceDir(), "workspace directory")
+	return cmd
+}
+
+func runSkillUpdate(ctx context.Context, stdout, _ io.Writer, workspaceDir string) error {
+	inst := skillhub.NewInstaller(workspaceDir)
+	updated, err := inst.Update(ctx)
+	if err != nil {
+		return err
+	}
+	if len(updated) == 0 {
+		fmt.Fprintln(stdout, "All skills are up to date.")
+		return nil
+	}
+	for _, name := range updated {
+		fmt.Fprintf(stdout, "  Updated: %s\n", name)
+	}
+	fmt.Fprintf(stdout, "\n%d skill(s) updated.\n", len(updated))
+	return nil
+}
+
+func newSkillInfoCommand(stdout io.Writer) *cobra.Command {
+	return &cobra.Command{
+		Use:   "info <name>",
+		Short: "Show detailed info about a skill in the registry",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSkillInfo(cmd.Context(), stdout, args[0])
+		},
+	}
+}
+
+func runSkillInfo(ctx context.Context, stdout io.Writer, name string) error {
+	reg := skillhub.NewRegistry()
+	entry, err := reg.FindByName(ctx, name)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "Name:        %s\n", entry.Name)
+	fmt.Fprintf(stdout, "Version:     %s\n", entry.Version)
+	fmt.Fprintf(stdout, "Author:      %s\n", entry.Author)
+	fmt.Fprintf(stdout, "Description: %s\n", entry.Description)
+	fmt.Fprintf(stdout, "Invocable:   %v\n", entry.UserInvocable)
+	if len(entry.Tags) > 0 {
+		fmt.Fprintf(stdout, "Tags:        %s\n", strings.Join(entry.Tags, ", "))
+	}
+	if entry.RequiresPlugin != "" {
+		fmt.Fprintf(stdout, "Plugin:      %s\n", entry.RequiresPlugin)
+	}
+	return nil
+}

--- a/internal/skill/mirror.go
+++ b/internal/skill/mirror.go
@@ -2,6 +2,7 @@ package skill
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -44,6 +45,13 @@ func MirrorToWorkspace(workspaceDir string, snapshot Snapshot) (Snapshot, error)
 		if err := os.WriteFile(target, []byte(content), 0o644); err != nil {
 			return Snapshot{}, fmt.Errorf("write mirrored skill file %q: %w", target, err)
 		}
+
+		// Copy companion files (scripts, configs, etc.) from the source directory.
+		srcDir := filepath.Dir(next.Skills[i].FilePath)
+		if strings.TrimSpace(srcDir) != "" && srcDir != "." {
+			_ = copyCompanionFiles(srcDir, dstDir)
+		}
+
 		next.Skills[i].RuntimePath = filepath.ToSlash(filepath.Join(runtimeMirrorRoot, slug, "SKILL.md"))
 	}
 
@@ -51,6 +59,51 @@ func MirrorToWorkspace(workspaceDir string, snapshot Snapshot) (Snapshot, error)
 		return Snapshot{}, err
 	}
 	return next, nil
+}
+
+// copyCompanionFiles copies all non-SKILL.md files from srcDir to dstDir,
+// preserving subdirectory structure. This allows scripts, configs, and other
+// reference files to be available at runtime alongside the skill.
+func copyCompanionFiles(srcDir, dstDir string) error {
+	return filepath.WalkDir(srcDir, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		rel, err := filepath.Rel(srcDir, path)
+		if err != nil || rel == "." {
+			return nil
+		}
+		dst := filepath.Join(dstDir, rel)
+		if d.IsDir() {
+			return os.MkdirAll(dst, 0o755)
+		}
+		if strings.EqualFold(filepath.Base(path), "SKILL.md") {
+			return nil // already written above
+		}
+		return copyFile(path, dst)
+	})
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	// Preserve executable bit if source is executable.
+	info, err := in.Stat()
+	if err == nil && info.Mode()&0o111 != 0 {
+		_ = out.Chmod(info.Mode())
+	}
+	return nil
 }
 
 func cleanupMirroredSkills(root string, keep map[string]struct{}) error {

--- a/internal/skill/mirror_test.go
+++ b/internal/skill/mirror_test.go
@@ -46,3 +46,74 @@ func TestMirrorToWorkspace(t *testing.T) {
 		t.Fatalf("unexpected mirrored content: %q", string(data))
 	}
 }
+
+func TestMirrorToWorkspace_CompanionFiles(t *testing.T) {
+	workspaceDir := t.TempDir()
+
+	// Create a source skill directory with SKILL.md + companion files.
+	srcDir := filepath.Join(t.TempDir(), "skills", "my-skill")
+	if err := os.MkdirAll(filepath.Join(srcDir, "scripts"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "SKILL.md"), []byte("# My Skill"), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "helper.sh"), []byte("#!/bin/bash\necho hello"), 0o755); err != nil {
+		t.Fatalf("write helper.sh: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "scripts", "run.py"), []byte("print('hello')"), 0o644); err != nil {
+		t.Fatalf("write run.py: %v", err)
+	}
+
+	snapshot := Snapshot{
+		Skills: []Definition{
+			{
+				Name:     "my-skill",
+				Source:   SourceUser,
+				FilePath: filepath.Join(srcDir, "SKILL.md"),
+				Content:  "# My Skill",
+			},
+		},
+	}
+
+	next, err := MirrorToWorkspace(workspaceDir, snapshot)
+	if err != nil {
+		t.Fatalf("mirror: %v", err)
+	}
+
+	runtimeDir := filepath.Join(workspaceDir, "_shared", "skills_runtime", "my_skill")
+
+	// SKILL.md should exist.
+	if _, err := os.Stat(filepath.Join(runtimeDir, "SKILL.md")); err != nil {
+		t.Fatalf("SKILL.md not mirrored: %v", err)
+	}
+
+	// helper.sh should be copied.
+	helperData, err := os.ReadFile(filepath.Join(runtimeDir, "helper.sh"))
+	if err != nil {
+		t.Fatalf("helper.sh not mirrored: %v", err)
+	}
+	if string(helperData) != "#!/bin/bash\necho hello" {
+		t.Fatalf("unexpected helper.sh content: %q", string(helperData))
+	}
+
+	// Check executable bit preserved.
+	info, err := os.Stat(filepath.Join(runtimeDir, "helper.sh"))
+	if err != nil {
+		t.Fatalf("stat helper.sh: %v", err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Fatalf("helper.sh should be executable, got %v", info.Mode())
+	}
+
+	// Subdirectory file should be copied.
+	pyData, err := os.ReadFile(filepath.Join(runtimeDir, "scripts", "run.py"))
+	if err != nil {
+		t.Fatalf("scripts/run.py not mirrored: %v", err)
+	}
+	if string(pyData) != "print('hello')" {
+		t.Fatalf("unexpected run.py content: %q", string(pyData))
+	}
+
+	_ = next
+}

--- a/internal/skillhub/install.go
+++ b/internal/skillhub/install.go
@@ -1,0 +1,206 @@
+package skillhub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	hubSkillsDir    = "skills"
+	installedDBFile = "skillhub.json"
+)
+
+// InstalledDB tracks installed hub skills.
+type InstalledDB struct {
+	Skills []InstalledSkill `json:"skills"`
+}
+
+// Installer handles installing and managing hub skills.
+type Installer struct {
+	WorkspaceDir string
+	Registry     *Registry
+}
+
+// NewInstaller creates an installer for the given workspace.
+func NewInstaller(workspaceDir string) *Installer {
+	return &Installer{
+		WorkspaceDir: workspaceDir,
+		Registry:     NewRegistry(),
+	}
+}
+
+// Install downloads and installs a skill from the registry.
+func (inst *Installer) Install(ctx context.Context, name string) error {
+	entry, err := inst.Registry.FindByName(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	content, err := inst.Registry.FetchSkillContent(ctx, entry)
+	if err != nil {
+		return err
+	}
+
+	skillDir := inst.skillDir(entry.Name)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		return fmt.Errorf("create skill dir: %w", err)
+	}
+	skillFile := filepath.Join(skillDir, "SKILL.md")
+	if err := os.WriteFile(skillFile, content, 0o644); err != nil {
+		return fmt.Errorf("write skill file: %w", err)
+	}
+
+	// Download companion files listed in the registry entry.
+	for _, relPath := range entry.Files {
+		fileContent, err := inst.Registry.FetchFile(ctx, entry, relPath)
+		if err != nil {
+			continue // best-effort: skip files that fail to download
+		}
+		dst := filepath.Join(skillDir, filepath.FromSlash(relPath))
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			continue
+		}
+		if err := os.WriteFile(dst, fileContent, 0o644); err != nil {
+			continue
+		}
+	}
+
+	return inst.addToDB(InstalledSkill{
+		Name:    entry.Name,
+		Version: entry.Version,
+		Source:  "tars-hub",
+		Dir:     skillDir,
+	})
+}
+
+// Uninstall removes an installed skill.
+func (inst *Installer) Uninstall(name string) error {
+	db, err := inst.loadDB()
+	if err != nil {
+		return err
+	}
+	key := strings.ToLower(strings.TrimSpace(name))
+	found := false
+	var remaining []InstalledSkill
+	for _, s := range db.Skills {
+		if strings.ToLower(s.Name) == key {
+			found = true
+			_ = os.RemoveAll(s.Dir)
+			continue
+		}
+		remaining = append(remaining, s)
+	}
+	if !found {
+		return fmt.Errorf("skill %q is not installed", name)
+	}
+	db.Skills = remaining
+	return inst.saveDB(db)
+}
+
+// List returns all installed hub skills.
+func (inst *Installer) List() ([]InstalledSkill, error) {
+	db, err := inst.loadDB()
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return db.Skills, nil
+}
+
+// Update re-installs all installed skills with the latest version.
+func (inst *Installer) Update(ctx context.Context) ([]string, error) {
+	db, err := inst.loadDB()
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var updated []string
+	for i, skill := range db.Skills {
+		entry, err := inst.Registry.FindByName(ctx, skill.Name)
+		if err != nil {
+			continue
+		}
+		if entry.Version == skill.Version {
+			continue
+		}
+		content, err := inst.Registry.FetchSkillContent(ctx, entry)
+		if err != nil {
+			continue
+		}
+		skillFile := filepath.Join(skill.Dir, "SKILL.md")
+		if err := os.WriteFile(skillFile, content, 0o644); err != nil {
+			continue
+		}
+		for _, relPath := range entry.Files {
+			fileContent, fetchErr := inst.Registry.FetchFile(ctx, entry, relPath)
+			if fetchErr != nil {
+				continue
+			}
+			dst := filepath.Join(skill.Dir, filepath.FromSlash(relPath))
+			_ = os.MkdirAll(filepath.Dir(dst), 0o755)
+			_ = os.WriteFile(dst, fileContent, 0o644)
+		}
+		db.Skills[i].Version = entry.Version
+		updated = append(updated, skill.Name)
+	}
+	if len(updated) > 0 {
+		_ = inst.saveDB(db)
+	}
+	return updated, nil
+}
+
+func (inst *Installer) skillDir(name string) string {
+	return filepath.Join(inst.WorkspaceDir, hubSkillsDir, name)
+}
+
+func (inst *Installer) dbPath() string {
+	return filepath.Join(inst.WorkspaceDir, installedDBFile)
+}
+
+func (inst *Installer) loadDB() (*InstalledDB, error) {
+	data, err := os.ReadFile(inst.dbPath())
+	if err != nil {
+		return nil, err
+	}
+	var db InstalledDB
+	if err := json.Unmarshal(data, &db); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", installedDBFile, err)
+	}
+	return &db, nil
+}
+
+func (inst *Installer) saveDB(db *InstalledDB) error {
+	data, err := json.MarshalIndent(db, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(inst.dbPath(), append(data, '\n'), 0o644)
+}
+
+func (inst *Installer) addToDB(skill InstalledSkill) error {
+	db, err := inst.loadDB()
+	if err != nil {
+		if os.IsNotExist(err) {
+			db = &InstalledDB{}
+		} else {
+			return err
+		}
+	}
+	key := strings.ToLower(skill.Name)
+	for i, s := range db.Skills {
+		if strings.ToLower(s.Name) == key {
+			db.Skills[i] = skill
+			return inst.saveDB(db)
+		}
+	}
+	db.Skills = append(db.Skills, skill)
+	return inst.saveDB(db)
+}

--- a/internal/skillhub/install_test.go
+++ b/internal/skillhub/install_test.go
@@ -1,0 +1,138 @@
+package skillhub
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstallAndList(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	inst := &Installer{
+		WorkspaceDir: tmpDir,
+		Registry: &Registry{
+			RegistryURL:  srv.URL + "/registry.json",
+			SkillBaseURL: srv.URL,
+			HTTPClient:   srv.Client(),
+		},
+	}
+
+	if err := inst.Install(context.Background(), "project-start"); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	// Verify file exists.
+	skillFile := filepath.Join(tmpDir, "skills", "project-start", "SKILL.md")
+	if _, err := os.Stat(skillFile); err != nil {
+		t.Fatalf("skill file not found: %v", err)
+	}
+
+	// List should show it.
+	skills, err := inst.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(skills) != 1 || skills[0].Name != "project-start" {
+		t.Fatalf("expected [project-start], got %v", skills)
+	}
+}
+
+func TestUninstall(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	inst := &Installer{
+		WorkspaceDir: tmpDir,
+		Registry: &Registry{
+			RegistryURL:  srv.URL + "/registry.json",
+			SkillBaseURL: srv.URL,
+			HTTPClient:   srv.Client(),
+		},
+	}
+
+	if err := inst.Install(context.Background(), "project-start"); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if err := inst.Uninstall("project-start"); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+
+	skills, err := inst.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(skills) != 0 {
+		t.Fatalf("expected empty list, got %v", skills)
+	}
+
+	// Directory should be removed.
+	skillDir := filepath.Join(tmpDir, "skills", "project-start")
+	if _, err := os.Stat(skillDir); !os.IsNotExist(err) {
+		t.Fatalf("expected skill dir to be removed")
+	}
+}
+
+func TestUninstallNotInstalled(t *testing.T) {
+	tmpDir := t.TempDir()
+	inst := NewInstaller(tmpDir)
+	err := inst.Uninstall("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for uninstalling non-installed skill")
+	}
+}
+
+func TestListEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	inst := NewInstaller(tmpDir)
+	skills, err := inst.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(skills) != 0 {
+		t.Fatalf("expected empty list, got %v", skills)
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	inst := &Installer{
+		WorkspaceDir: tmpDir,
+		Registry: &Registry{
+			RegistryURL:  srv.URL + "/registry.json",
+			SkillBaseURL: srv.URL,
+			HTTPClient:   srv.Client(),
+		},
+	}
+
+	// Install first.
+	if err := inst.Install(context.Background(), "project-start"); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	// Manually downgrade version in DB to simulate outdated.
+	db, _ := inst.loadDB()
+	db.Skills[0].Version = "0.1.0"
+	_ = inst.saveDB(db)
+
+	updated, err := inst.Update(context.Background())
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(updated) != 1 || updated[0] != "project-start" {
+		t.Fatalf("expected [project-start] updated, got %v", updated)
+	}
+
+	// Verify version was updated.
+	db, _ = inst.loadDB()
+	if db.Skills[0].Version != "0.6.0" {
+		t.Fatalf("expected version 0.6.0, got %s", db.Skills[0].Version)
+	}
+}

--- a/internal/skillhub/registry.go
+++ b/internal/skillhub/registry.go
@@ -1,0 +1,147 @@
+package skillhub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultRegistryURL = "https://raw.githubusercontent.com/devlikebear/tars-skills/main/registry.json"
+	DefaultSkillBaseURL = "https://raw.githubusercontent.com/devlikebear/tars-skills/main"
+)
+
+// Registry fetches and searches the remote skill registry.
+type Registry struct {
+	RegistryURL  string
+	SkillBaseURL string
+	HTTPClient   *http.Client
+}
+
+// NewRegistry creates a registry with default URLs.
+func NewRegistry() *Registry {
+	return &Registry{
+		RegistryURL:  DefaultRegistryURL,
+		SkillBaseURL: DefaultSkillBaseURL,
+		HTTPClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// FetchIndex downloads and parses registry.json.
+func (r *Registry) FetchIndex(ctx context.Context) (*RegistryIndex, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.RegistryURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build registry request: %w", err)
+	}
+	req.Header.Set("Cache-Control", "no-cache")
+	resp, err := r.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch registry: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("registry returned status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read registry body: %w", err)
+	}
+	var index RegistryIndex
+	if err := json.Unmarshal(body, &index); err != nil {
+		return nil, fmt.Errorf("parse registry: %w", err)
+	}
+	return &index, nil
+}
+
+// Search returns entries matching the query (substring match on name, description, tags).
+func (r *Registry) Search(ctx context.Context, query string) ([]RegistryEntry, error) {
+	index, err := r.FetchIndex(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if query == "" {
+		return index.Skills, nil
+	}
+	q := strings.ToLower(query)
+	var results []RegistryEntry
+	for _, entry := range index.Skills {
+		if matchesQuery(entry, q) {
+			results = append(results, entry)
+		}
+	}
+	return results, nil
+}
+
+// FindByName returns the exact-match entry.
+func (r *Registry) FindByName(ctx context.Context, name string) (*RegistryEntry, error) {
+	index, err := r.FetchIndex(ctx)
+	if err != nil {
+		return nil, err
+	}
+	key := strings.ToLower(strings.TrimSpace(name))
+	for _, entry := range index.Skills {
+		if strings.ToLower(entry.Name) == key {
+			return &entry, nil
+		}
+	}
+	return nil, fmt.Errorf("skill %q not found in registry", name)
+}
+
+// FetchSkillContent downloads the SKILL.md for the given entry.
+func (r *Registry) FetchSkillContent(ctx context.Context, entry *RegistryEntry) ([]byte, error) {
+	url := r.SkillBaseURL + "/" + entry.Path + "/SKILL.md"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build skill request: %w", err)
+	}
+	req.Header.Set("Cache-Control", "no-cache")
+	resp, err := r.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch skill: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("skill fetch returned status %d", resp.StatusCode)
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, 1*1024*1024))
+}
+
+// FetchFile downloads a companion file relative to the skill's path.
+func (r *Registry) FetchFile(ctx context.Context, entry *RegistryEntry, relPath string) ([]byte, error) {
+	url := r.SkillBaseURL + "/" + entry.Path + "/" + relPath
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build file request: %w", err)
+	}
+	req.Header.Set("Cache-Control", "no-cache")
+	resp, err := r.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch file: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("file fetch returned status %d", resp.StatusCode)
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, 1*1024*1024))
+}
+
+func matchesQuery(entry RegistryEntry, q string) bool {
+	if strings.Contains(strings.ToLower(entry.Name), q) {
+		return true
+	}
+	if strings.Contains(strings.ToLower(entry.Description), q) {
+		return true
+	}
+	for _, tag := range entry.Tags {
+		if strings.Contains(strings.ToLower(tag), q) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/skillhub/registry_test.go
+++ b/internal/skillhub/registry_test.go
@@ -1,0 +1,167 @@
+package skillhub
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func testIndex() RegistryIndex {
+	return RegistryIndex{
+		Version: 1,
+		Skills: []RegistryEntry{
+			{
+				Name:          "project-start",
+				Description:   "Kick off a software project",
+				Version:       "0.6.0",
+				Author:        "devlikebear",
+				Tags:          []string{"project", "kickoff"},
+				Path:          "skills/project-start",
+				UserInvocable: true,
+			},
+			{
+				Name:          "novelist",
+				Description:   "Creative writing guide",
+				Version:       "0.6.0",
+				Author:        "devlikebear",
+				Tags:          []string{"creative", "writing"},
+				Path:          "skills/novelist",
+				UserInvocable: true,
+			},
+		},
+	}
+}
+
+func newTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/registry.json", func(w http.ResponseWriter, _ *http.Request) {
+		data, _ := json.Marshal(testIndex())
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(data)
+	})
+	mux.HandleFunc("/skills/project-start/SKILL.md", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("---\nname: project-start\n---\n# Project Start\n"))
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestFetchIndex(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	reg := &Registry{
+		RegistryURL: srv.URL + "/registry.json",
+		HTTPClient:  srv.Client(),
+	}
+	index, err := reg.FetchIndex(context.Background())
+	if err != nil {
+		t.Fatalf("FetchIndex: %v", err)
+	}
+	if len(index.Skills) != 2 {
+		t.Fatalf("expected 2 skills, got %d", len(index.Skills))
+	}
+}
+
+func TestSearchByName(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	reg := &Registry{
+		RegistryURL: srv.URL + "/registry.json",
+		HTTPClient:  srv.Client(),
+	}
+	results, err := reg.Search(context.Background(), "novelist")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 1 || results[0].Name != "novelist" {
+		t.Fatalf("expected novelist, got %v", results)
+	}
+}
+
+func TestSearchByTag(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	reg := &Registry{
+		RegistryURL: srv.URL + "/registry.json",
+		HTTPClient:  srv.Client(),
+	}
+	results, err := reg.Search(context.Background(), "project")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for tag search, got %d", len(results))
+	}
+}
+
+func TestSearchEmpty(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	reg := &Registry{
+		RegistryURL: srv.URL + "/registry.json",
+		HTTPClient:  srv.Client(),
+	}
+	results, err := reg.Search(context.Background(), "")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected all 2 skills, got %d", len(results))
+	}
+}
+
+func TestFindByName(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	reg := &Registry{
+		RegistryURL: srv.URL + "/registry.json",
+		HTTPClient:  srv.Client(),
+	}
+	entry, err := reg.FindByName(context.Background(), "project-start")
+	if err != nil {
+		t.Fatalf("FindByName: %v", err)
+	}
+	if entry.Name != "project-start" {
+		t.Fatalf("expected project-start, got %s", entry.Name)
+	}
+}
+
+func TestFindByNameNotFound(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	reg := &Registry{
+		RegistryURL: srv.URL + "/registry.json",
+		HTTPClient:  srv.Client(),
+	}
+	_, err := reg.FindByName(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent skill")
+	}
+}
+
+func TestFetchSkillContent(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	reg := &Registry{
+		RegistryURL:  srv.URL + "/registry.json",
+		SkillBaseURL: srv.URL,
+		HTTPClient:   srv.Client(),
+	}
+	entry := &RegistryEntry{Path: "skills/project-start"}
+	content, err := reg.FetchSkillContent(context.Background(), entry)
+	if err != nil {
+		t.Fatalf("FetchSkillContent: %v", err)
+	}
+	if len(content) == 0 {
+		t.Fatal("expected non-empty content")
+	}
+}

--- a/internal/skillhub/types.go
+++ b/internal/skillhub/types.go
@@ -1,0 +1,28 @@
+package skillhub
+
+// RegistryIndex is the top-level structure of registry.json.
+type RegistryIndex struct {
+	Version int             `json:"version"`
+	Skills  []RegistryEntry `json:"skills"`
+}
+
+// RegistryEntry describes a single skill in the registry.
+type RegistryEntry struct {
+	Name           string   `json:"name"`
+	Description    string   `json:"description"`
+	Version        string   `json:"version"`
+	Author         string   `json:"author"`
+	Tags           []string `json:"tags"`
+	Path           string   `json:"path"`
+	UserInvocable  bool     `json:"user_invocable"`
+	RequiresPlugin string   `json:"requires_plugin,omitempty"`
+	Files          []string `json:"files,omitempty"`
+}
+
+// InstalledSkill tracks a skill that has been installed locally.
+type InstalledSkill struct {
+	Name      string `json:"name"`
+	Version   string `json:"version"`
+	Source    string `json:"source"` // "tars-hub" or "openclaw"
+	Dir       string `json:"dir"`
+}


### PR DESCRIPTION
## Summary
- `tars skill {search,install,uninstall,list,update,info}` CLI commands for the TARS Skill Hub
- `internal/skillhub` package: registry fetch from `devlikebear/tars-skills`, install/uninstall/list/update with `skillhub.json` tracking
- Companion file support: `files` field in registry.json entries, downloaded alongside SKILL.md on install
- `internal/skill/mirror.go`: copies companion files (.sh, .py, templates, etc.) to runtime mirror directory, preserving executable permissions and subdirectory structure

## Test plan
- [x] `go test ./internal/skill/... ./internal/skillhub/...` — 19 tests pass
- [x] `tars skill search` — lists all 5 registry skills from live GitHub
- [x] `tars skill install daily-briefing` — downloads SKILL.md + briefing.sh + templates/summary.txt
- [x] Mirror test: companion files copied to `_shared/skills_runtime/` with executable bit preserved