### PR TITLE
docs: add Go AI agent runtime tutorial (23 steps)

### DIFF
--- a/docs/tutorials/00-overview.md
+++ b/docs/tutorials/00-overview.md
@@ -1,0 +1,63 @@
+# Go AI 에이전트 런타임 만들기 — 튜토리얼
+
+> TARS 프로젝트를 기반으로 Go AI 채팅 런타임을 처음부터 만들어보는 실습 가이드
+
+## 대상
+
+- Go 기본 문법을 아는 개발자
+- LLM 기반 애플리케이션 구조를 직접 만들어보고 싶은 사람
+
+## 사전지식
+
+- Go, `net/http`, JSON, context
+- 런타임: Go 1.22+
+
+## 전체 커리큘럼
+
+| Step | 주제 | 학습 목표 |
+|------|------|-----------|
+| 1 | 얇은 CLI | 엔트리포인트에 비즈니스 로직을 두지 않는 원칙 |
+| 2 | 세션과 Transcript | JSONL 기반 대화 이력 영속화 패턴 |
+| 3 | 프롬프트 빌더 + 도구 Registry | 시스템 프롬프트 조립과 tool schema 구조 |
+| 4 | HTTP/SSE 채팅 엔드포인트 | 전체 파이프라인 연결 및 스트리밍 |
+
+## 아키텍처 한눈에 보기
+
+```
+CLI (cmd/tars/)
+ └── serve 명령
+      └── server.Serve()
+           ├── session.Store     ← 세션/transcript 관리
+           ├── prompt.Build()    ← 시스템 프롬프트 조립
+           ├── tool.Registry     ← 도구 등록/실행
+           ├── agent.Loop        ← LLM 호출 + tool call 반복
+           └── SSEWriter         ← 실시간 스트리밍 응답
+```
+
+## 핵심 데이터 흐름
+
+```
+POST /v1/chat { session_id, message }
+  → 세션 resolve
+  → transcript에서 히스토리 읽기
+  → 프롬프트 조립 (시스템 + 히스토리 + 유저)
+  → agent loop (LLM 호출 → tool call → 반복)
+  → SSE delta 스트리밍
+  → transcript에 assistant 응답 저장
+  → SSE done
+```
+
+## 실행 방법
+
+```bash
+# 서버 시작
+go run ./cmd/tars/ serve
+
+# 채팅 테스트
+curl -N -X POST http://localhost:8080/v1/chat \
+  -H "Content-Type: application/json" \
+  -d '{"message":"안녕하세요"}'
+
+# 테스트 실행
+go test ./...
+```

--- a/docs/tutorials/01-thin-cli.md
+++ b/docs/tutorials/01-thin-cli.md
@@ -1,0 +1,142 @@
+# Step 1. 얇은 CLI 만들기
+
+> 학습 목표: 엔트리포인트는 비즈니스 로직을 갖지 않는다는 원칙 이해
+
+## 원본 코드 분석 (TARS)
+
+TARS의 `cmd/tars/main.go`를 보면 `main()` 함수가 하는 일은 딱 세 가지입니다:
+
+```go
+func main() {
+    bootstrapEnv()           // .env 파일 로딩
+    runOnMainThread(func() { // 플랫폼 shim
+        newRootCommand().Execute()  // Cobra 명령 실행
+    })
+    os.Exit(exitCode)
+}
+```
+
+비즈니스 로직은 전부 `internal/` 패키지에 있고, `cmd/` 는 플래그 파싱과 내부 함수 호출만 합니다.
+
+### 핵심 설계 원칙 3가지
+
+1. **`main.go`에 비즈니스 로직 없음** — env 로딩, cobra 명령 연결, `os.Exit`만
+2. **각 서브커맨드는 "옵션 구조체 → 내부 패키지 호출"** — `server_main.go`는 `serveOptions`를 만들어 `tarsserver.Serve()`에 넘기기만 함
+3. **플랫폼 차이는 빌드 태그로 분리** — `mainthread_darwin.go` vs `mainthread_other.go`
+
+## 실습
+
+### 1-1. 프로젝트 초기화
+
+```bash
+mkdir -p tars
+cd tars
+go mod init github.com/devlikebear/tars
+go get github.com/spf13/cobra
+```
+
+### 1-2. buildinfo 패키지
+
+빌드 시 `-ldflags`로 버전 정보를 주입하는 패턴입니다.
+
+**`internal/buildinfo/buildinfo.go`**
+
+```go
+package buildinfo
+
+import "fmt"
+
+var (
+    Version = "dev"
+    Commit  = "unknown"
+    Date    = "unknown"
+)
+
+func Summary() string {
+    return fmt.Sprintf("tars %s (%s, %s)", Version, Commit, Date)
+}
+```
+
+`var`로 선언하면 빌드 시 `go build -ldflags "-X .../buildinfo.Version=1.0.0"` 처럼 외부에서 값을 주입할 수 있습니다.
+
+### 1-3. main.go
+
+```go
+// cmd/tars/main.go
+func main() {
+    if err := newRootCommand(os.Stdout).Execute(); err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+}
+
+func newRootCommand(stdout io.Writer) *cobra.Command {
+    cmd := &cobra.Command{
+        Use:   "tars",
+        Short: "Minimal clone of TARS",
+        RunE: func(cmd *cobra.Command, args []string) error {
+            return cmd.Help()
+        },
+    }
+    cmd.AddCommand(newVersionCommand(stdout))
+    return cmd
+}
+```
+
+**포인트:**
+- `newRootCommand()`가 `io.Writer`를 받는 이유 → 테스트할 때 stdout을 바꿔 끼울 수 있음
+- 기본 동작은 `cmd.Help()` — 나중에 클라이언트(TUI)로 교체 예정
+
+### 1-4. serve 서브커맨드
+
+원본 패턴을 따라 **파일을 분리**합니다.
+
+```go
+// cmd/tars/serve.go
+type serveOptions struct {
+    port    int
+    verbose bool
+}
+
+func newServeCommand(stdout, stderr io.Writer) *cobra.Command {
+    opts := serveOptions{port: 8080}
+    cmd := &cobra.Command{
+        Use:   "serve",
+        Short: "Run tars server",
+        RunE: func(cmd *cobra.Command, args []string) error {
+            return runServe(cmd.Context(), opts, stdout, stderr)
+        },
+    }
+    cmd.Flags().IntVar(&opts.port, "port", opts.port, "listen port")
+    cmd.Flags().BoolVar(&opts.verbose, "verbose", false, "verbose logging")
+    return cmd
+}
+```
+
+## 확인
+
+```bash
+go run ./cmd/tars/              # help 출력
+go run ./cmd/tars/ version      # tars dev (unknown, unknown)
+go run ./cmd/tars/ serve        # starting tars server on :8080
+go run ./cmd/tars/ serve --port 3000  # starting tars server on :3000
+```
+
+## 체크포인트
+
+- [x] 엔트리포인트(`main.go`)가 비즈니스 로직을 갖지 않는다
+- [x] `version`, `serve` 서브커맨드가 동작한다
+- [x] 서버 옵션이 플래그로 받아진다
+
+## 최종 구조
+
+```
+tars/
+├── cmd/tars/
+│   ├── main.go          ← 엔트리포인트 (로직 없음)
+│   └── serve.go         ← 옵션 구조체 + 내부 위임
+├── internal/
+│   └── buildinfo/
+│       └── buildinfo.go ← 빌드 메타데이터
+└── go.mod
+```

--- a/docs/tutorials/02-session-transcript.md
+++ b/docs/tutorials/02-session-transcript.md
@@ -1,0 +1,157 @@
+# Step 2. 세션과 Transcript
+
+> 학습 목표: JSONL 기반으로 대화 이력을 영속화하는 패턴 이해
+
+## 원본 코드 분석 (TARS)
+
+TARS의 `internal/session/` 패키지는 4개 파일로 구성됩니다:
+
+```
+internal/session/
+├── message.go      ← Message 구조체 (role, content, timestamp)
+├── locks.go        ← 파일 경로별 mutex (동시 쓰기 보호)
+├── session.go      ← Store: 세션 생성/조회/삭제, index 관리
+└── transcript.go   ← JSONL append/read/rewrite
+```
+
+### 핵심 설계 포인트
+
+**1. 세션 = 메타데이터, Transcript = 대화 내용 (분리)**
+- `sessions/sessions.json` — 모든 세션의 메타 정보 (ID, 제목, 생성일)
+- `sessions/{id}.jsonl` — 해당 세션의 메시지들 (한 줄에 하나씩)
+
+**2. JSONL (JSON Lines) 패턴**
+```
+{"role":"user","content":"안녕","timestamp":"2026-03-22T10:00:00Z"}
+{"role":"assistant","content":"반가워요","timestamp":"2026-03-22T10:00:01Z"}
+```
+- append가 빠름 (파일 끝에 한 줄 추가)
+- 부분 읽기가 가능
+- 파일이 중간에 깨져도 나머지 줄은 살릴 수 있음
+
+**3. 파일 잠금** — `sync.Map`으로 경로별 mutex
+- 같은 파일에 동시 쓰기를 막는 가벼운 in-process 락
+
+## 실습
+
+### 2-1. 메시지 타입
+
+**`internal/session/message.go`**
+
+```go
+package session
+
+import "time"
+
+type Message struct {
+    Role      string    `json:"role"`
+    Content   string    `json:"content"`
+    Timestamp time.Time `json:"timestamp"`
+}
+```
+
+### 2-2. 세션 Store
+
+세션 메타데이터를 JSON 인덱스 파일로 관리합니다.
+
+**`internal/session/session.go`** 핵심 구조:
+
+```go
+type Session struct {
+    ID        string    `json:"id"`
+    Title     string    `json:"title"`
+    CreatedAt time.Time `json:"created_at"`
+    UpdatedAt time.Time `json:"updated_at"`
+}
+
+type Store struct {
+    dir string  // workspace/sessions/
+}
+
+func NewStore(dir string) *Store {
+    return &Store{dir: filepath.Join(dir, "sessions")}
+}
+```
+
+**인덱스 관리:**
+- `loadIndex()` — `sessions.json` 파일을 `map[string]Session`으로 읽기
+- `saveIndex()` — map을 JSON으로 직렬화해서 저장
+- 파일이 없으면 빈 map 반환 (에러가 아님)
+
+**ID 생성:**
+```go
+func generateID() (string, error) {
+    raw := make([]byte, 8)
+    if _, err := rand.Read(raw); err != nil {
+        return "", err
+    }
+    return hex.EncodeToString(raw), nil  // 16자리 hex
+}
+```
+`crypto/rand`를 사용해 충돌 가능성이 극히 낮은 ID를 만듭니다.
+
+**원본과 비교해서 생략한 것:**
+- `lockPath()` — 동시성 보호 (나중에 추가 가능)
+- `Kind`, `Hidden`, `ProjectID` — 프로젝트 연동 전까지 불필요
+- `EnsureMain()`, `EnsureWorker()` — 단일 세션으로 충분
+
+### 2-3. Transcript (JSONL 읽기/쓰기)
+
+**`internal/session/transcript.go`** 핵심 두 함수:
+
+```go
+// 한 줄 추가
+func AppendMessage(path string, msg Message) error {
+    f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+    // ...
+    data, _ := json.Marshal(msg)
+    f.Write(append(data, '\n'))
+}
+
+// 전체 읽기
+func ReadMessages(path string) ([]Message, error) {
+    f, err := os.Open(path)
+    if os.IsNotExist(err) {
+        return nil, nil  // 파일 없으면 빈 결과
+    }
+    scanner := bufio.NewScanner(f)
+    for scanner.Scan() {
+        json.Unmarshal(scanner.Bytes(), &msg)
+        messages = append(messages, msg)
+    }
+}
+```
+
+**포인트:**
+- `O_APPEND` — OS 레벨에서 원자적 append 보장
+- 파일이 없으면 `nil, nil` 반환 — 에러가 아니라 "아직 대화 없음"
+
+### 2-4. 테스트
+
+7개 테스트로 검증합니다:
+
+| 테스트 | 검증 내용 |
+|--------|-----------|
+| `CreateAndGet` | 세션 생성 → ID로 다시 조회 |
+| `ListSessions` | 여러 세션 생성 후 목록 조회 |
+| `TranscriptAppendAndRead` | JSONL에 쌓고 순서대로 읽기 |
+| `FileNotExist` | 없는 파일 읽으면 nil, 에러 없음 |
+| `TranscriptPath` | Store와 transcript 연동 |
+| `NotFound` | 없는 세션 조회 시 에러 |
+| `EmptyFile` | 빈 파일도 안전하게 처리 |
+
+```bash
+go test ./internal/session/ -v
+```
+
+## 체크포인트
+
+- [x] 새 세션 생성 후 다시 읽을 수 있다
+- [x] 사용자/assistant 메시지가 JSONL에 순서대로 쌓인다
+- [x] 파일이 없어도 에러 없이 빈 결과를 반환한다
+
+## 배운 패턴
+
+- **인덱스와 데이터 분리** — `sessions.json`(메타) + `{id}.jsonl`(내용)
+- **JSONL** — append-friendly, 부분 읽기 가능, 깨져도 복구 쉬움
+- **Graceful 빈 상태 처리** — 에러가 아니라 nil 반환

--- a/docs/tutorials/03-prompt-tool-registry.md
+++ b/docs/tutorials/03-prompt-tool-registry.md
@@ -1,0 +1,183 @@
+# Step 3. 프롬프트 빌더 + 도구 Registry
+
+> 학습 목표: 시스템 프롬프트 조립과 tool schema를 LLM에 넘기는 구조 이해
+
+## 원본 코드 분석 (TARS)
+
+### 프롬프트 빌더 (`internal/prompt/`)
+
+```
+builder.go              ← 시스템 프롬프트 조립 엔진
+bootstrap_sections.go   ← 워크스페이스에서 읽을 파일 목록 정의
+memory_retrieval.go     ← semantic memory 주입 (고급 기능)
+```
+
+조립 흐름:
+```
+"You are TARS..." (고정 인사)
++ 현재 시각
++ PROJECT.md 내용 (있으면)
++ USER.md 내용 (있으면)
++ IDENTITY.md 내용 (있으면)
++ relevant memory (있으면)
+→ 하나의 시스템 프롬프트 문자열
+```
+
+원본에는 토큰 예산 관리(`trimToBudget`, `estimateTokens`)가 있어서 프롬프트가 무한히 커지지 않습니다. 최소 버전에서는 생략합니다.
+
+### 도구 Registry (`internal/tool/tool.go`)
+
+```go
+type Tool struct {
+    Name        string
+    Description string
+    Parameters  json.RawMessage      // JSON Schema
+    Execute     func(ctx, params) (Result, error)
+}
+
+type Registry struct {
+    tools map[string]Tool
+}
+```
+
+`Schemas()` 메서드가 등록된 도구를 OpenAI tool format으로 변환합니다:
+```json
+{
+  "type": "function",
+  "function": {
+    "name": "echo",
+    "description": "Echoes back the given message",
+    "parameters": { "type": "object", "properties": { ... } }
+  }
+}
+```
+
+## 핵심 설계 질문과 답변
+
+### Q: Parameters를 구조체가 아니라 `json.RawMessage`로 한 이유?
+
+**LLM API가 JSON Schema 원문을 그대로 요구하기 때문입니다.**
+
+JSON Schema는 `oneOf`, `anyOf`, `$ref`, `additionalProperties` 등 끝없이 복잡해질 수 있습니다. 이걸 전부 Go 구조체로 모델링하는 것은 과잉 설계입니다.
+
+`json.RawMessage`를 쓰면:
+- JSON을 파싱하지 않고 바이트 그대로 보관
+- LLM에 보낼 때 그냥 직렬화하면 끝
+- 도구 작성자가 자유롭게 schema를 정의할 수 있음
+
+**원칙: "통과시키기만 하면 되는 데이터"는 구조체로 만들 필요가 없다.**
+
+### Q: OpenAI와 Anthropic의 tool 구조는 동일한가?
+
+비슷하지만 다릅니다:
+
+| | OpenAI | Anthropic |
+|--|--------|-----------|
+| 래핑 | `{"type":"function","function":{...}}` | 없음 (flat) |
+| schema 필드명 | `parameters` | `input_schema` |
+| schema 내용 | JSON Schema | JSON Schema (동일) |
+
+**JSON Schema 부분은 동일합니다.** 그래서 `json.RawMessage`로 들고 있으면, 보낼 때만 감싸는 형태를 바꿔주면 됩니다. 이것이 provider adapter를 별도로 분리하는 이유입니다.
+
+### Q: 도구 실행 시 `error` 리턴 vs `Result{IsError: true}` 리턴의 차이?
+
+| | `return Result{}, err` | `return Result{IsError: true}, nil` |
+|--|--|--|
+| 의미 | 시스템 장애 (도구 실행 자체 실패) | 도구는 실행됐지만 결과가 실패 |
+| 예시 | DB 연결 끊김, 파일시스템 오류 | 잘못된 파라미터, 검색 결과 없음 |
+| LLM에게 | 에러 메시지를 보여주지 않을 수도 있음 | "실패했어, 다시 시도해봐" 라고 알려줌 |
+
+LLM이 잘못된 인자를 보냈을 때는 `IsError: true`로 돌려줘서 수정 기회를 주고, 시스템이 터졌을 때만 `error`를 반환합니다.
+
+## 실습
+
+### 3-1. LLM 타입
+
+도구 registry가 참조하는 공통 타입입니다.
+
+**`internal/llm/types.go`**
+
+```go
+type ToolFunctionSchema struct {
+    Name        string          `json:"name"`
+    Description string          `json:"description"`
+    Parameters  json.RawMessage `json:"parameters,omitempty"`
+}
+
+type ToolSchema struct {
+    Type     string             `json:"type"`
+    Function ToolFunctionSchema `json:"function"`
+}
+```
+
+### 3-2. 도구 Registry
+
+```go
+// internal/tool/tool.go
+type Registry struct {
+    tools map[string]Tool
+}
+
+func (r *Registry) Register(t Tool)           // 등록
+func (r *Registry) Get(name string) (Tool, bool) // 이름으로 조회
+func (r *Registry) Schemas() []llm.ToolSchema    // LLM 포맷 변환
+```
+
+`Schemas()`는 이름순으로 정렬해서 반환합니다. 결과가 결정적(deterministic)이어야 테스트와 디버깅이 쉬워지기 때문입니다.
+
+### 3-3. 샘플 도구
+
+도구 하나 = 함수 하나 (`NewXxxTool()`) 패턴:
+
+```go
+// internal/tool/echo.go
+func NewEchoTool() Tool {
+    return Tool{
+        Name:        "echo",
+        Description: "Echoes back the given message",
+        Parameters: json.RawMessage(`{
+            "type": "object",
+            "properties": {
+                "message": { "type": "string", "description": "..." }
+            },
+            "required": ["message"]
+        }`),
+        Execute: func(ctx context.Context, params json.RawMessage) (Result, error) {
+            var args struct { Message string `json:"message"` }
+            json.Unmarshal(params, &args)
+            return Result{Content: args.Message}, nil
+        },
+    }
+}
+```
+
+### 3-4. 프롬프트 빌더
+
+```go
+// internal/prompt/builder.go
+func Build(opts BuildOptions) string {
+    // 1. 고정 인사 + 현재 시각
+    // 2. 워크스페이스 파일 읽기 (PROJECT.md, USER.md, IDENTITY.md)
+    // 3. 파일이 없으면 조용히 건너뜀
+}
+```
+
+### 3-5. 테스트
+
+```bash
+go test ./internal/tool/ -v     # 5개 PASS
+go test ./internal/prompt/ -v   # 3개 PASS
+```
+
+## 체크포인트
+
+- [x] 툴 schema를 LLM에 넘길 수 있다
+- [x] 툴이 없어도 기본 채팅이 동작한다
+- [x] 프롬프트에 워크스페이스 파일이 자동 반영된다
+
+## 배운 패턴
+
+- **`json.RawMessage`로 JSON Schema 통과** — 파싱 불필요한 데이터는 구조체로 만들지 않는다
+- **프롬프트 = 고정 텍스트 + 파일 기반 섹션** — 파일이 없으면 조용히 건너뜀
+- **도구 = 이름 + 설명 + schema + 실행 함수** — 하나의 구조체에 전부 담김
+- **error vs IsError** — 시스템 장애와 도구 실패를 구분

--- a/docs/tutorials/04-http-sse-chat.md
+++ b/docs/tutorials/04-http-sse-chat.md
@@ -1,0 +1,312 @@
+# Step 4. HTTP/SSE 채팅 엔드포인트
+
+> 학습 목표: 지금까지 만든 세션, 프롬프트, 도구를 전부 연결해서 실제 채팅 서버 구현
+
+## 원본 코드 분석 (TARS)
+
+원본은 채팅 파이프라인을 5개 파일로 나눕니다:
+
+| 파일 | 책임 |
+|------|------|
+| `handler_chat_pipeline.go` | 전체 흐름 오케스트레이션 |
+| `handler_chat_context.go` | 세션 resolve, 프롬프트/도구 조립 |
+| `handler_chat.go` | LLM 메시지 빌드, 헬퍼 함수 |
+| `handler_chat_execution.go` | agent loop 실행, 결과 저장 |
+| (여러 파일) | SSE 스트리밍 |
+
+### 전체 흐름
+
+```
+POST /v1/chat { session_id, message }
+  │
+  ├─ 1. 요청 파싱 + 검증
+  ├─ 2. 세션 resolve (없으면 생성)
+  ├─ 3. transcript에서 이전 대화 읽기
+  ├─ 4. 프롬프트 조립 (시스템 프롬프트 + 워크스페이스 파일)
+  ├─ 5. LLM 메시지 구성 (system + history + user)
+  ├─ 6. 유저 메시지를 transcript에 저장
+  ├─ 7. SSE 스트림 시작
+  ├─ 8. Agent loop 실행 (LLM 호출 → tool call → 반복)
+  ├─ 9. assistant 응답을 transcript에 저장
+  └─ 10. SSE done 이벤트
+```
+
+### 핵심 타입 (원본 `internal/llm/provider.go`)
+
+```go
+type Client interface {
+    Chat(ctx context.Context, messages []ChatMessage, opts ChatOptions) (ChatResponse, error)
+}
+
+type ChatMessage struct {
+    Role       string     `json:"role"`      // system, user, assistant, tool
+    Content    string     `json:"content"`
+    ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
+    ToolCallID string     `json:"tool_call_id,omitempty"`
+}
+
+type ChatOptions struct {
+    OnDelta    func(text string)  // SSE 스트리밍 콜백
+    Tools      []ToolSchema
+    ToolChoice string
+}
+```
+
+### Agent Loop 핵심 로직 (원본 `internal/agent/loop.go`)
+
+```go
+for i := 0; i < maxIters; i++ {
+    resp = client.Chat(messages, tools)     // LLM 호출
+    if len(resp.ToolCalls) == 0 {
+        return resp                          // tool call 없으면 끝
+    }
+    for each toolCall {
+        result = registry.Execute(toolCall)  // 도구 실행
+        messages += tool result              // 결과를 대화에 추가
+    }
+    // 다음 반복에서 LLM이 결과를 보고 다시 판단
+}
+```
+
+원본에는 추가로 다음이 있습니다 (최소 버전에서는 생략):
+- Hook 시스템 (`EventBeforeLLM`, `EventAfterTool` 등)
+- 반복 tool call 감지 (무한 루프 방지)
+- `autoCorrectExecArguments` (exec 도구 전용 보정)
+- `allowedTools` 검증 (보안 레이어)
+
+## 실습
+
+### 4-1. LLM Client 인터페이스 확장
+
+기존 `internal/llm/types.go`에 전체 타입을 추가합니다:
+
+```go
+type ToolCall struct {
+    ID        string `json:"id"`
+    Name      string `json:"name"`
+    Arguments string `json:"arguments"`
+}
+
+type ChatMessage struct {
+    Role       string     `json:"role"`
+    Content    string     `json:"content"`
+    ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
+    ToolCallID string     `json:"tool_call_id,omitempty"`
+}
+
+type Client interface {
+    Chat(ctx context.Context, messages []ChatMessage, opts ChatOptions) (ChatResponse, error)
+}
+```
+
+### 4-2. Agent Loop
+
+LLM 호출 → tool call 확인 → 도구 실행 → 반복하는 핵심 루프입니다.
+
+**`internal/agent/loop.go`** 핵심:
+
+```go
+func (l *Loop) Run(ctx, messages, opts) (ChatResponse, error) {
+    for i := 0; i < maxIters; i++ {
+        resp := l.client.Chat(ctx, msgs, chatOpts)
+        msgs = append(msgs, resp.Message)
+
+        if len(resp.Message.ToolCalls) == 0 {
+            return resp, nil  // 완료
+        }
+
+        for _, call := range resp.Message.ToolCalls {
+            t, _ := l.registry.Get(call.Name)
+            result, _ := t.Execute(ctx, call.Arguments)
+            msgs = append(msgs, toolResultMessage)
+        }
+    }
+    return error("exceeded max iterations")
+}
+```
+
+### 4-3. SSE 스트림 작성기
+
+서버가 클라이언트에게 실시간으로 응답을 보내는 SSE(Server-Sent Events)입니다.
+
+**`internal/server/sse.go`**
+
+SSE 프로토콜:
+```
+event: status
+data: {"session_id":"abc","status":"stream_open","message":"connected"}
+
+event: delta
+data: {"session_id":"abc","text":"안녕"}
+
+event: delta
+data: {"session_id":"abc","text":"하세요"}
+
+event: done
+data: {"session_id":"abc","usage":{"input_tokens":50,"output_tokens":10}}
+```
+
+핵심 포인트:
+- `Content-Type: text/event-stream` 헤더 필수
+- `event:` — 이벤트 타입, `data:` — JSON 페이로드
+- 빈 줄(`\n\n`) — 이벤트 구분자
+- `http.Flusher.Flush()` — 버퍼를 즉시 전송 (이게 없으면 스트리밍 안 됨)
+
+### 4-4. 채팅 핸들러
+
+원본 5개 파일의 핵심을 하나로 합칩니다.
+
+**`internal/server/handler_chat.go`**
+
+10단계 흐름을 하나의 `ServeHTTP` 메서드에서 처리:
+1. 요청 파싱
+2. 세션 resolve
+3. 히스토리 로드
+4. 프롬프트 조립
+5. LLM 메시지 구성
+6. 유저 메시지 저장
+7. SSE 스트림 시작
+8. Agent loop 실행
+9. assistant 응답 저장
+10. done 이벤트
+
+### 4-5. 서버 부트스트랩
+
+**`internal/server/server.go`** — 모든 조각을 조립:
+
+```go
+func Serve(ctx context.Context, cfg Config) error {
+    store := session.NewStore(cfg.WorkspaceDir)
+
+    registry := tool.NewRegistry()
+    registry.Register(tool.NewEchoTool())
+    registry.Register(tool.NewCurrentTimeTool())
+
+    chatHandler := NewChatHandler(store, cfg.Client, registry, cfg.WorkspaceDir)
+
+    mux := http.NewServeMux()
+    mux.Handle("/v1/chat", chatHandler)
+
+    return http.ListenAndServe(addr, mux)
+}
+```
+
+### 4-6. Mock LLM Client
+
+실제 API 키 없이 동작을 확인할 수 있는 테스트용 클라이언트입니다.
+
+**`internal/llm/mock.go`**
+
+동작:
+- "시간" 또는 "time"이 포함되면 → `current_time` tool call 반환
+- tool 결과가 있으면 → 결과를 포함한 응답 반환
+- 그 외 → 메시지를 echo
+
+**주의: tool 결과 확인을 키워드 체크보다 먼저 해야 합니다!**
+
+```go
+func (m *MockClient) Chat(...) {
+    // ★ tool 결과 확인을 먼저!
+    for _, msg := range messages {
+        if msg.Role == "tool" {
+            return 응답 with tool 결과
+        }
+    }
+    // 그 다음 키워드 체크
+    if contains("시간") {
+        return tool call
+    }
+}
+```
+
+이 순서가 잘못되면 agent loop가 무한 반복합니다 — tool call을 반환하고, tool 실행 후 다시 호출되면 또 키워드에 매칭되어 다시 tool call을 반환하기 때문입니다.
+
+## 테스트
+
+```bash
+# 서버 시작
+go run ./cmd/tars/ serve
+
+# 일반 채팅
+curl -N -X POST http://localhost:8080/v1/chat \
+  -H "Content-Type: application/json" \
+  -d '{"message":"안녕하세요"}'
+
+# tool call 테스트 (current_time 도구 실행됨)
+curl -N -X POST http://localhost:8080/v1/chat \
+  -H "Content-Type: application/json" \
+  -d '{"message":"지금 시간 알려줘"}'
+```
+
+**기대 결과 (일반 채팅):**
+```
+event: status
+data: {"session_id":"...","status":"stream_open","message":"connected"}
+
+event: delta
+data: {"session_id":"...","text":"echo: 안녕하세요"}
+
+event: done
+data: {"session_id":"...","usage":{"input_tokens":20,"output_tokens":5}}
+```
+
+**기대 결과 (시간 질문 — tool call 발생):**
+```
+event: status
+data: {"session_id":"...","status":"stream_open","message":"connected"}
+
+event: delta
+data: {"session_id":"...","text":"현재 시각은 2026-03-22T... 입니다."}
+
+event: done
+data: {"session_id":"...","usage":{"input_tokens":30,"output_tokens":10}}
+```
+
+## 체크포인트
+
+- [x] SSE delta 이벤트가 순서대로 온다
+- [x] 세션 ID가 응답에 포함된다
+- [x] tool call이 있으면 실행 후 결과를 다시 LLM에 넘긴다
+- [x] 대화가 transcript에 저장된다
+
+## 최종 구조
+
+```
+tars/
+├── cmd/tars/
+│   ├── main.go
+│   └── serve.go              ← server.Serve() 호출
+├── internal/
+│   ├── buildinfo/
+│   │   └── buildinfo.go
+│   ├── llm/
+│   │   ├── types.go           ← Client interface, ChatMessage, ToolCall, ...
+│   │   └── mock.go            ← 테스트용 Mock Client
+│   ├── agent/
+│   │   └── loop.go            ← LLM + tool call 반복 루프
+│   ├── prompt/
+│   │   ├── builder.go
+│   │   └── builder_test.go
+│   ├── session/
+│   │   ├── message.go
+│   │   ├── session.go
+│   │   ├── transcript.go
+│   │   └── session_test.go
+│   ├── server/
+│   │   ├── server.go          ← 부트스트랩 + HTTP mux
+│   │   ├── handler_chat.go    ← 채팅 핸들러 (10단계 파이프라인)
+│   │   └── sse.go             ← SSE 스트림 작성기
+│   └── tool/
+│       ├── tool.go
+│       ├── echo.go
+│       ├── current_time.go
+│       └── tool_test.go
+└── go.mod
+```
+
+## 배운 패턴
+
+- **Agent Loop** — LLM 호출 → tool call 확인 → 실행 → 반복의 핵심 구조
+- **SSE 스트리밍** — `text/event-stream` + `Flush()`로 실시간 응답
+- **Mock Client** — 외부 의존성 없이 전체 파이프라인 검증
+- **10단계 파이프라인** — 요청 → 세션 → 히스토리 → 프롬프트 → LLM → 도구 → 저장 → 스트리밍

--- a/docs/tutorials/05-openai-provider.md
+++ b/docs/tutorials/05-openai-provider.md
@@ -1,0 +1,189 @@
+# Step 5. OpenAI 호환 Provider Adapter
+
+> 학습 목표: 실제 LLM API(OpenAI `/chat/completions`)를 연결하고, SSE 스트리밍을 파싱하는 adapter 작성
+
+## 원본 코드 분석 (TARS)
+
+TARS의 `internal/llm/openai_compat_client.go`는 OpenAI 호환 API를 호출하는 클라이언트입니다. 핵심 구조:
+
+```
+openai_compat_client.go   ← Chat() 메서드, SSE 파싱
+transport.go              ← 공통 HTTP 유틸
+http_utils.go             ← 에러 처리 헬퍼
+```
+
+### 핵심 설계 포인트
+
+**1. Wire Format 변환**
+
+내부 `ChatMessage`와 OpenAI API의 JSON 형식은 다릅니다. 보낼 때는 내부 → wire로 변환하고, 받을 때는 wire → 내부로 변환합니다.
+
+```go
+// 내부 타입
+type ToolCall struct { ID, Name, Arguments string }
+
+// OpenAI wire 타입 — function이 중첩 객체
+type wireToolCall struct {
+    ID       string `json:"id"`
+    Type     string `json:"type"`     // 항상 "function"
+    Function struct {
+        Name      string `json:"name"`
+        Arguments string `json:"arguments"`
+    } `json:"function"`
+}
+```
+
+**2. SSE 스트리밍에서 Tool Call 누적**
+
+OpenAI의 스트리밍 응답에서 tool call은 여러 청크에 걸쳐 옵니다:
+
+```
+chunk 1: tool_calls[0] = { index: 0, id: "call_abc", function: { name: "echo" } }
+chunk 2: tool_calls[0] = { index: 0, function: { arguments: '{"mes' } }
+chunk 3: tool_calls[0] = { index: 0, function: { arguments: 'sage":"hi"}' } }
+```
+
+`map[int]ToolCall`로 index별로 누적한 뒤, 마지막에 index 순서로 정렬합니다.
+
+**3. 스트리밍 vs 비스트리밍 분기**
+
+`OnDelta` 콜백이 있으면 스트리밍, 없으면 비스트리밍입니다. 스트리밍 시에는 `http.Client`의 `Timeout`을 제거합니다 — 스트리밍은 응답이 점진적으로 오기 때문에 전체 타임아웃을 걸면 긴 응답이 잘립니다.
+
+## 실습
+
+### 5-1. OpenAI 클라이언트 구조체
+
+**`internal/llm/openai.go`**
+
+```go
+type OpenAIClient struct {
+    baseURL    string
+    apiKey     string
+    model      string
+    httpClient *http.Client
+}
+
+func NewOpenAIClient(baseURL, apiKey, model string) (*OpenAIClient, error) {
+    // 빈 값 검증: baseURL, apiKey, model 모두 필수
+    return &OpenAIClient{
+        baseURL:    strings.TrimRight(baseURL, "/"),
+        apiKey:     apiKey,
+        model:      model,
+        httpClient: &http.Client{Timeout: 120 * time.Second},
+    }, nil
+}
+```
+
+### 5-2. Chat() 메서드 — 요청 빌드와 전송
+
+```go
+func (c *OpenAIClient) Chat(ctx, messages, opts) (ChatResponse, error) {
+    streaming := opts.OnDelta != nil
+
+    // 1. 요청 바디 구성
+    reqBody := map[string]any{
+        "model":    c.model,
+        "messages": toWireMessages(messages),  // 내부 → wire 변환
+    }
+    if len(opts.Tools) > 0 {
+        reqBody["tools"] = opts.Tools          // ToolSchema는 이미 OpenAI 포맷
+    }
+    if streaming {
+        reqBody["stream"] = true
+    }
+
+    // 2. HTTP POST
+    req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+    // 스트리밍 시 전체 타임아웃 제거
+    httpClient := c.httpClient
+    if streaming {
+        httpClient = &http.Client{Transport: c.httpClient.Transport}
+    }
+
+    // 3. 응답 분기
+    if streaming {
+        return c.parseStreaming(resp.Body, opts)
+    }
+    return c.parseNonStreaming(resp.Body)
+}
+```
+
+### 5-3. SSE 스트리밍 파싱
+
+OpenAI SSE 프로토콜:
+```
+data: {"choices":[{"delta":{"content":"안녕"}}]}
+
+data: {"choices":[{"delta":{"content":"하세요"}}]}
+
+data: [DONE]
+```
+
+파싱 핵심:
+1. `bufio.Scanner`로 한 줄씩 읽기
+2. `data:` 접두사만 처리, 나머지 무시
+3. `[DONE]`이면 종료
+4. `delta.content`가 있으면 `OnDelta` 콜백 호출
+5. `delta.tool_calls`는 index로 누적
+
+```go
+func (c *OpenAIClient) parseStreaming(body io.Reader, opts ChatOptions) (ChatResponse, error) {
+    toolCalls := map[int]ToolCall{}  // ← index별 누적
+
+    scanner := bufio.NewScanner(body)
+    for scanner.Scan() {
+        line := scanner.Text()
+        // "data:" 접두사 처리
+        // JSON 파싱
+        // delta.content → OnDelta 콜백
+        // delta.tool_calls → map에 누적
+    }
+
+    return ChatResponse{
+        Message: ChatMessage{
+            ToolCalls: orderedToolCalls(toolCalls),  // index 순 정렬
+        },
+    }, nil
+}
+```
+
+### 5-4. Wire Format 변환 함수들
+
+```go
+// 내부 ChatMessage → OpenAI API JSON
+func toWireMessages(messages []ChatMessage) []wireMessage { ... }
+
+// map[int]ToolCall → []ToolCall (index 순 정렬)
+func orderedToolCalls(m map[int]ToolCall) []ToolCall { ... }
+```
+
+`orderedToolCalls`는 `sort.Ints`로 index를 정렬합니다. 빈 이름의 tool call은 제거합니다.
+
+## 테스트
+
+```bash
+# 컴파일 확인
+go build ./...
+
+# 실제 OpenAI API로 테스트 (API 키 필요)
+MYCLAW_PROVIDER=openai MYCLAW_API_KEY=sk-... MYCLAW_MODEL=gpt-4o-mini \
+  go run ./cmd/tars/ serve
+
+curl -N -X POST http://localhost:8080/v1/chat \
+  -H "Content-Type: application/json" \
+  -d '{"message":"안녕하세요"}'
+```
+
+## 체크포인트
+
+- [x] `OpenAIClient`가 `Client` 인터페이스를 구현한다
+- [x] SSE 스트리밍 delta가 `OnDelta` 콜백으로 전달된다
+- [x] tool call이 여러 청크에 걸쳐 올 때 올바르게 누적된다
+
+## 배운 패턴
+
+- **Wire Format 변환** — 내부 타입과 API 타입을 분리해서, API 변경이 내부에 전파되지 않게 함
+- **SSE Tool Call 누적** — `map[int]ToolCall`로 index별 누적 후 정렬
+- **스트리밍 타임아웃 분리** — 스트리밍 시에는 전체 타임아웃을 제거 (Transport만 복사)
+- **Scanner 기반 SSE 파싱** — `bufio.Scanner`로 한 줄씩 읽어 `data:` 접두사 처리

--- a/docs/tutorials/06-config-system.md
+++ b/docs/tutorials/06-config-system.md
@@ -1,0 +1,182 @@
+# Step 6. 설정 시스템
+
+> 학습 목표: 하드코딩된 값을 설정 파일과 환경 변수로 외부화하는 3단계 설정 로딩
+
+## 원본 코드 분석 (TARS)
+
+TARS의 `internal/config/` 패키지:
+
+```
+load.go                 ← 설정 로딩 엔진 (defaults < YAML < env)
+config_input_fields.go  ← 필드 테이블 (이름, 환경변수, 기본값 매핑)
+defaults.go             ← 기본값 정의
+```
+
+### 핵심 설계 포인트
+
+**1. 3단계 우선순위: defaults < YAML < env**
+
+```
+Default()      → port: 8080, provider: "mock"
+    ↓
+YAML 파일      → port: 3000  (override)
+    ↓
+환경 변수      → MYCLAW_PORT=9000  (최종 override)
+```
+
+가장 구체적인 설정이 우선합니다. 환경 변수는 배포 환경(Docker, CI)에서 코드 변경 없이 설정을 바꿀 때 유용합니다.
+
+**2. YAML 파일이 없으면 에러가 아님**
+
+```go
+func loadYAML(path string, cfg *Config) error {
+    data, err := os.ReadFile(path)
+    if os.IsNotExist(err) {
+        return nil  // 파일 없으면 조용히 건너뜀
+    }
+}
+```
+
+Phase 1의 Session과 같은 패턴 — "없으면 기본값 사용"은 에러가 아닙니다.
+
+**3. 환경 변수 네이밍 컨벤션**
+
+접두사 `MYCLAW_` + 대문자 필드명: `MYCLAW_PORT`, `MYCLAW_API_KEY`, `MYCLAW_PROVIDER`
+
+접두사가 있어야 다른 애플리케이션의 환경 변수와 충돌하지 않습니다.
+
+## 실습
+
+### 6-1. Config 구조체와 기본값
+
+**`internal/config/config.go`**
+
+```go
+type Config struct {
+    Port         int    `yaml:"port"`
+    WorkspaceDir string `yaml:"workspace_dir"`
+    Provider     string `yaml:"provider"`
+    Model        string `yaml:"model"`
+    APIKey       string `yaml:"api_key"`
+    BaseURL      string `yaml:"base_url"`
+}
+
+func Default() Config {
+    return Config{
+        Port:         8080,
+        WorkspaceDir: ".workspace",
+        Provider:     "mock",
+        Model:        "gpt-5.4-nano",
+        BaseURL:      "https://api.openai.com/v1",
+    }
+}
+```
+
+`yaml` 태그를 붙이면 `yaml.Unmarshal`이 자동으로 매핑합니다.
+
+### 6-2. Load 함수 — 3단계 합성
+
+```go
+func Load(path string) (Config, error) {
+    cfg := Default()              // 1. 기본값
+    if path != "" {
+        loadYAML(path, &cfg)      // 2. YAML (있으면 덮어씀)
+    }
+    applyEnv(&cfg)                // 3. 환경 변수 (최종 override)
+    return cfg, nil
+}
+```
+
+### 6-3. 환경 변수 적용
+
+```go
+func applyEnv(cfg *Config) {
+    if v := envStr("MYCLAW_PROVIDER"); v != "" {
+        cfg.Provider = v
+    }
+    if v := envStr("MYCLAW_PORT"); v != "" {
+        if port, err := strconv.Atoi(v); err == nil {
+            cfg.Port = port
+        }
+    }
+    // ... 나머지 필드도 동일 패턴
+}
+```
+
+포인트:
+- 빈 문자열이면 override하지 않음 (기본값 유지)
+- `Port`는 `strconv.Atoi`로 변환 — 환경 변수는 항상 문자열
+
+### 6-4. serve.go 변경 — Config 통합
+
+기존에 플래그로 받던 값들을 Config로 교체:
+
+```go
+func newServeCommand(stdout, stderr io.Writer) *cobra.Command {
+    configPath := ""
+    cmd := &cobra.Command{
+        RunE: func(cmd *cobra.Command, args []string) error {
+            cfg, err := config.Load(configPath)
+            return runServe(cmd.Context(), cfg, stdout, stderr)
+        },
+    }
+    cmd.Flags().StringVar(&configPath, "config", "", "path to config file")
+    return cmd
+}
+
+func buildLLMClient(cfg config.Config) (llm.Client, error) {
+    switch strings.ToLower(cfg.Provider) {
+    case "openai":
+        return llm.NewOpenAIClient(cfg.BaseURL, cfg.APIKey, cfg.Model)
+    case "mock", "":
+        return llm.NewMockClient(), nil
+    default:
+        return nil, fmt.Errorf("unknown provider: %s", cfg.Provider)
+    }
+}
+```
+
+## 테스트
+
+```bash
+# 기본값으로 실행 (mock provider)
+go run ./cmd/tars/ serve
+
+# 환경 변수로 포트 변경
+MYCLAW_PORT=3000 go run ./cmd/tars/ serve
+
+# YAML 설정 파일
+cat > config.yaml <<'EOF'
+port: 3000
+provider: openai
+model: gpt-4o-mini
+api_key: sk-...
+EOF
+
+go run ./cmd/tars/ serve --config config.yaml
+```
+
+## 체크포인트
+
+- [x] `config.yaml`로 provider, model, port를 변경할 수 있다
+- [x] 환경 변수가 YAML 값을 override한다
+- [x] 설정 파일이 없어도 기본값으로 정상 동작한다
+
+## 최종 구조 (Phase 2 추가분)
+
+```
+tars/
+├── internal/
+│   ├── config/
+│   │   └── config.go           ← Config 구조체 + Load() + Default()
+│   └── ...
+└── cmd/tars/
+    └── serve.go                ← config.Load() → buildLLMClient() → server.Serve()
+```
+
+## 배운 패턴
+
+- **3단계 설정 합성** — defaults < YAML < env, 가장 구체적인 것이 우선
+- **없으면 기본값** — YAML 파일이 없어도 에러가 아님 (graceful degradation)
+- **접두사 환경 변수** — `MYCLAW_` 접두사로 네임스페이스 충돌 방지
+- **`yaml` 태그** — 구조체 필드를 YAML 키에 자동 매핑

--- a/docs/tutorials/07-practical-tools.md
+++ b/docs/tutorials/07-practical-tools.md
@@ -1,0 +1,170 @@
+# Step 7. 실용 도구 추가
+
+> 학습 목표: LLM이 실제로 활용할 수 있는 파일 읽기/쓰기/명령 실행 도구 구현과 보안 고려사항
+
+## 원본 코드 분석 (TARS)
+
+TARS의 `internal/tool/` 디렉터리에는 다양한 도구가 있습니다:
+
+```
+read_file.go    ← 파일 읽기 (줄 번호, 오프셋, 제한)
+write_file.go   ← 파일 쓰기 (디렉터리 자동 생성)
+exec.go         ← 셸 명령 실행 (보안 필터링, 타임아웃)
+web_fetch.go    ← URL 가져오기
+list_files.go   ← glob 패턴으로 파일 목록
+search_files.go ← 파일 내용 검색
+```
+
+### 핵심 설계 포인트
+
+**1. 워크스페이스 경계**
+
+모든 도구는 `workspaceDir`을 기준으로 동작합니다. 상대 경로를 받아서 `filepath.Join(workspaceDir, path)`로 절대 경로를 만듭니다. 이렇게 하면 LLM이 워크스페이스 밖의 파일에 접근하는 것을 방지합니다.
+
+**2. 출력 크기 제한**
+
+LLM의 컨텍스트 윈도우는 유한합니다. 파일이 수 MB일 수 있으므로 출력을 제한합니다:
+- `read_file`: 8KB 초과 시 잘라냄
+- `exec`: stdout 8KB, stderr 2KB 제한
+
+참고로 실제 AI agent들의 파일 읽기 제한:
+- **Gemini CLI**: 2,000줄 (20MB 초과 시 거부)
+- **Codex**: 2,000줄 (줄당 500자 제한)
+- **Claude Code**: 2,000줄 (~25K 토큰)
+
+**3. 위험한 명령어 차단**
+
+```go
+var blockedCommands = map[string]struct{}{
+    "sudo": {}, "rm": {}, "shutdown": {}, "reboot": {},
+    "halt": {}, "poweroff": {}, "mkfs": {}, "dd": {},
+}
+```
+
+LLM이 실수로 위험한 명령을 실행하는 것을 방지합니다. 최소 버전에서는 명령어 이름만 체크하지만, 원본에는 더 정교한 필터가 있습니다.
+
+**4. `IsError: true` vs `error` 반환**
+
+| | `return Result{}, err` | `return Result{IsError: true}, nil` |
+|--|--|--|
+| 의미 | 시스템 장애 | 도구는 실행됐지만 결과가 실패 |
+| 예시 | 메모리 부족, 패닉 | 파일 없음, 잘못된 인자, 차단된 명령 |
+| LLM에게 | 에러를 노출하지 않을 수도 있음 | "실패했어, 다시 해봐" 전달 |
+
+실용 도구에서는 대부분 `IsError: true`를 사용합니다. LLM에게 실패 이유를 알려줘서 수정 기회를 줍니다.
+
+## 실습
+
+### 7-1. read_file 도구
+
+**`internal/tool/read_file.go`**
+
+```go
+func NewReadFileTool(workspaceDir string) Tool {
+    return Tool{
+        Name:        "read_file",
+        Description: "Read a text file from the workspace",
+        Parameters: json.RawMessage(`{
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "File path relative to workspace"}
+            },
+            "required": ["path"]
+        }`),
+        Execute: func(_ context.Context, params json.RawMessage) (Result, error) {
+            // 1. 인자 파싱
+            // 2. 절대 경로 구성: filepath.Join(workspaceDir, filepath.Clean(path))
+            // 3. 파일 읽기 (없으면 IsError)
+            // 4. 8KB 초과 시 잘라냄
+        },
+    }
+}
+```
+
+`filepath.Clean()`은 `../` 같은 경로 조작을 정리합니다.
+
+### 7-2. write_file 도구
+
+**`internal/tool/write_file.go`**
+
+```go
+func NewWriteFileTool(workspaceDir string) Tool {
+    Execute: func(_ context.Context, params json.RawMessage) (Result, error) {
+        // 1. path, content 파싱
+        // 2. 부모 디렉터리 자동 생성: os.MkdirAll(filepath.Dir(absPath), 0o755)
+        // 3. 파일 쓰기: os.WriteFile(absPath, content, 0o644)
+        // 4. 결과: "wrote N bytes to path"
+    }
+}
+```
+
+`MkdirAll`이 핵심입니다 — LLM이 새 디렉터리에 파일을 쓸 때 별도로 `mkdir` 명령을 실행할 필요가 없습니다.
+
+### 7-3. exec 도구
+
+**`internal/tool/exec.go`**
+
+보안 3계층:
+
+```go
+// 1. 차단된 명령어 확인
+if _, blocked := blockedCommands[fields[0]]; blocked {
+    return Result{Content: "blocked: " + fields[0], IsError: true}, nil
+}
+
+// 2. 타임아웃 10초
+runCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+defer cancel()
+
+// 3. 출력 크기 제한
+out := truncate(stdout.String(), 8192)
+```
+
+`exec.CommandContext`를 쓰면 타임아웃 시 프로세스가 자동 kill됩니다.
+
+### 7-4. 서버에 도구 등록
+
+**`internal/server/server.go`** 변경:
+
+```go
+registry := tool.NewRegistry()
+registry.Register(tool.NewEchoTool())
+registry.Register(tool.NewCurrentTimeTool())
+registry.Register(tool.NewReadFileTool(cfg.WorkspaceDir))   // 추가
+registry.Register(tool.NewWriteFileTool(cfg.WorkspaceDir))  // 추가
+registry.Register(tool.NewExecTool(cfg.WorkspaceDir))       // 추가
+```
+
+도구 생성자가 `workspaceDir`을 받아서 클로저에 캡처합니다. 이 패턴 덕분에 도구 구현체가 전역 상태 없이 동작합니다.
+
+## 테스트
+
+```bash
+# 서버 시작
+go run ./cmd/tars/ serve
+
+# 파일 읽기 (도구 실행 확인)
+curl -N -X POST http://localhost:8080/v1/chat \
+  -H "Content-Type: application/json" \
+  -d '{"message":"go.mod 파일 읽어줘"}'
+
+# 명령 실행
+curl -N -X POST http://localhost:8080/v1/chat \
+  -H "Content-Type: application/json" \
+  -d '{"message":"현재 디렉터리의 파일 목록을 보여줘"}'
+```
+
+## 체크포인트
+
+- [x] LLM이 도구를 선택하고 실행 결과를 활용한다
+- [x] 위험한 명령어가 차단된다
+- [x] 파일 출력이 8KB로 제한된다
+- [x] 부모 디렉터리가 자동 생성된다
+
+## 배운 패턴
+
+- **워크스페이스 경계** — 모든 경로를 `workspaceDir` 기준으로 제한
+- **출력 크기 제한** — 컨텍스트 윈도우 보호와 토큰 비용 절약
+- **차단 목록** — 위험한 명령어를 사전 차단 (화이트리스트보다 구현이 쉬움)
+- **클로저 패턴** — 도구 생성자가 `workspaceDir`을 캡처해서 전역 상태 없이 동작
+- **`IsError: true`** — 도구 실패를 LLM에게 전달해서 재시도 기회 제공

--- a/docs/tutorials/08-anthropic-provider.md
+++ b/docs/tutorials/08-anthropic-provider.md
@@ -1,0 +1,262 @@
+# Step 8. Anthropic Provider Adapter
+
+> 학습 목표: 두 번째 provider를 추가하면서, OpenAI와의 구조적 차이를 adapter 패턴으로 흡수
+
+## 원본 코드 분석 (TARS)
+
+TARS의 `internal/llm/anthropic.go`는 Anthropic `/v1/messages` API 전용 adapter입니다. OpenAI adapter와 **같은 `Client` 인터페이스**를 구현하지만, wire format이 크게 다릅니다.
+
+### OpenAI vs Anthropic 주요 차이
+
+| 항목 | OpenAI | Anthropic |
+|------|--------|-----------|
+| 엔드포인트 | `/chat/completions` | `/v1/messages` |
+| 인증 헤더 | `Authorization: Bearer KEY` | `x-api-key: KEY` |
+| system 메시지 | messages 배열 안에 포함 | 별도 `system` 필드 |
+| tool schema | `{"type":"function","function":{...,"parameters":...}}` | flat `{"name":...,"input_schema":...}` |
+| tool 결과 | `role: "tool"` | `role: "user"` + `type: "tool_result"` |
+| assistant tool call | `tool_calls: [{function:{name,arguments}}]` | `content: [{type:"tool_use",name,input}]` |
+| SSE 이벤트 | `data:` 한 줄 | `event:` + `data:` 두 줄 |
+| max_tokens | 선택 (기본값 있음) | **필수** |
+
+### 핵심 변환 포인트 3가지
+
+**1. system 메시지 분리**
+
+```go
+// OpenAI: system이 messages 안에 있음
+messages: [
+  {"role": "system", "content": "You are..."},
+  {"role": "user", "content": "안녕"}
+]
+
+// Anthropic: system을 별도 필드로 분리
+system: "You are...",
+messages: [
+  {"role": "user", "content": "안녕"}
+]
+```
+
+**2. tool schema 변환**
+
+```go
+// OpenAI (내부 저장 포맷)
+{"type": "function", "function": {"name": "echo", "parameters": {...}}}
+
+// Anthropic (전송 포맷)
+{"name": "echo", "input_schema": {...}}
+```
+
+래핑을 벗기고 `parameters` → `input_schema`로 키만 바꿉니다.
+
+**3. tool result 변환**
+
+```go
+// OpenAI
+{"role": "tool", "tool_call_id": "call_abc", "content": "결과"}
+
+// Anthropic
+{"role": "user", "content": [{"type": "tool_result", "tool_use_id": "call_abc", "content": "결과"}]}
+```
+
+`role`이 `"user"`로 바뀌고, content가 배열이 됩니다.
+
+## 실습
+
+### 8-1. AnthropicClient 구조체
+
+**`internal/llm/anthropic.go`**
+
+```go
+type AnthropicClient struct {
+    baseURL    string
+    apiKey     string
+    model      string
+    maxTokens  int        // Anthropic는 필수!
+    httpClient *http.Client
+}
+
+func NewAnthropicClient(baseURL, apiKey, model string) (*AnthropicClient, error) {
+    return &AnthropicClient{
+        maxTokens: 4096,   // 기본값 설정
+        // ...
+    }, nil
+}
+```
+
+### 8-2. 요청 빌드 — 가장 큰 차이
+
+```go
+func (c *AnthropicClient) buildRequest(messages, opts, streaming) map[string]any {
+    // 1. system 메시지 분리
+    var systemParts []string
+    var nonSystem []ChatMessage
+    for _, msg := range messages {
+        if msg.Role == "system" {
+            systemParts = append(systemParts, msg.Content)
+        } else {
+            nonSystem = append(nonSystem, msg)
+        }
+    }
+
+    reqBody := map[string]any{
+        "model":      c.model,
+        "max_tokens": c.maxTokens,            // 필수!
+        "messages":   toAnthropicMessages(nonSystem),
+    }
+    if len(systemParts) > 0 {
+        reqBody["system"] = strings.Join(systemParts, "\n")
+    }
+
+    // 2. tool 변환
+    if len(opts.Tools) > 0 {
+        reqBody["tools"] = toAnthropicTools(opts.Tools)
+    }
+    return reqBody
+}
+```
+
+### 8-3. 메시지 변환 — role과 content 구조 차이
+
+```go
+func toAnthropicMessages(messages []ChatMessage) []map[string]any {
+    for _, msg := range messages {
+        switch msg.Role {
+        case "assistant":
+            // tool call이 있으면 content를 블록 배열로 변환
+            // [{type:"text",text:"..."}, {type:"tool_use",id:...,name:...,input:...}]
+        case "tool":
+            // role을 "user"로 바꾸고 tool_result 블록으로 감쌈
+            // {role:"user", content:[{type:"tool_result",tool_use_id:...,content:...}]}
+        default:
+            // user 등은 그대로
+        }
+    }
+}
+```
+
+assistant의 tool call에서 `Arguments`(문자열)를 `input`(객체)으로 변환할 때 `json.Unmarshal`이 필요합니다. OpenAI는 arguments가 문자열이지만 Anthropic의 input은 JSON 객체입니다.
+
+### 8-4. SSE 파싱 — event + data 조합
+
+OpenAI와 가장 다른 부분:
+
+```
+event: content_block_start
+data: {"index":0,"content_block":{"type":"tool_use","id":"toolu_abc","name":"echo"}}
+
+event: content_block_delta
+data: {"index":0,"delta":{"partial_json":"{\"message\":"}}
+
+event: content_block_delta
+data: {"index":0,"delta":{"partial_json":"\"hello\"}"}}
+
+event: message_delta
+data: {"delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":15}}
+```
+
+파싱 전략:
+1. `event:` 줄이 오면 이벤트 타입을 저장
+2. `data:` 줄이 오면 저장된 이벤트 타입에 따라 처리
+3. `content_block_start` — tool call의 ID와 이름 기록
+4. `content_block_delta` — 텍스트 또는 `partial_json` 누적
+5. `message_start` — input_tokens 기록
+6. `message_delta` — output_tokens, stop_reason 기록
+
+### 8-5. serve.go에 provider 추가
+
+```go
+func buildLLMClient(cfg config.Config) (llm.Client, error) {
+    switch strings.ToLower(cfg.Provider) {
+    case "openai":
+        return llm.NewOpenAIClient(cfg.BaseURL, cfg.APIKey, cfg.Model)
+    case "anthropic":
+        return llm.NewAnthropicClient(cfg.BaseURL, cfg.APIKey, cfg.Model)  // 추가
+    case "mock", "":
+        return llm.NewMockClient(), nil
+    }
+}
+```
+
+## 테스트
+
+```bash
+# Anthropic API로 테스트
+MYCLAW_PROVIDER=anthropic \
+  MYCLAW_API_KEY=sk-ant-... \
+  MYCLAW_MODEL=claude-sonnet-4-20250514 \
+  MYCLAW_BASE_URL=https://api.anthropic.com \
+  go run ./cmd/tars/ serve
+
+curl -N -X POST http://localhost:8080/v1/chat \
+  -H "Content-Type: application/json" \
+  -d '{"message":"안녕하세요"}'
+```
+
+## 체크포인트
+
+- [x] provider별 wire format 차이를 별도 구현체로 분리했다
+- [x] config에서 provider를 바꾸면 다른 LLM이 사용된다
+- [x] `Client` 인터페이스 덕분에 나머지 코드는 변경 없음
+
+## 최종 구조 (Phase 2 완료)
+
+```
+tars/
+├── cmd/tars/
+│   ├── main.go
+│   └── serve.go                ← config.Load() + buildLLMClient()
+├── internal/
+│   ├── buildinfo/
+│   │   └── buildinfo.go
+│   ├── config/
+│   │   └── config.go           ← Config + Load() + Default()
+│   ├── llm/
+│   │   ├── types.go            ← Client interface, ChatMessage, ...
+│   │   ├── mock.go             ← 테스트용 Mock
+│   │   ├── openai.go           ← OpenAI /chat/completions adapter
+│   │   └── anthropic.go        ← Anthropic /v1/messages adapter
+│   ├── agent/
+│   │   └── loop.go
+│   ├── prompt/
+│   │   ├── builder.go
+│   │   └── builder_test.go
+│   ├── session/
+│   │   ├── message.go
+│   │   ├── session.go
+│   │   ├── transcript.go
+│   │   └── session_test.go
+│   ├── server/
+│   │   ├── server.go           ← 도구 5개 등록
+│   │   ├── handler_chat.go
+│   │   └── sse.go
+│   └── tool/
+│       ├── tool.go
+│       ├── echo.go
+│       ├── current_time.go
+│       ├── read_file.go        ← 파일 읽기 (8KB 제한)
+│       ├── write_file.go       ← 파일 쓰기 (디렉터리 자동 생성)
+│       ├── exec.go             ← 명령 실행 (차단 목록, 타임아웃)
+│       └── tool_test.go
+├── docs/
+│   └── lessons/
+│       ├── 00-overview.md
+│       ├── 01-thin-cli.md
+│       ├── 02-session-transcript.md
+│       ├── 03-prompt-tool-registry.md
+│       ├── 04-http-sse-chat.md
+│       ├── 05-openai-provider.md
+│       ├── 06-config-system.md
+│       ├── 07-practical-tools.md
+│       ├── 08-anthropic-provider.md
+│       └── 99-roadmap.md
+└── go.mod
+```
+
+## 배운 패턴
+
+- **Adapter 패턴** — 같은 인터페이스 뒤에 다른 wire format을 숨김
+- **system 메시지 분리** — provider에 따라 system 메시지 위치가 다름
+- **`parameters` ↔ `input_schema`** — JSON Schema는 동일하고, 키 이름만 다름
+- **event + data SSE** — Anthropic은 OpenAI와 달리 event 줄이 별도로 옴
+- **`partial_json` 누적** — tool call arguments가 JSON 조각으로 올 때 문자열 연결

--- a/docs/tutorials/09-transcript-compaction.md
+++ b/docs/tutorials/09-transcript-compaction.md
@@ -1,0 +1,113 @@
+# Step 9. Transcript Compaction
+
+> 학습 목표: 긴 대화의 토큰 비용을 줄이는 압축 메커니즘과, atomic write 패턴 이해
+
+## 원본 코드 분석 (TARS)
+
+TARS의 `internal/session/compaction.go`는 대화가 길어지면 오래된 메시지를 요약으로 교체합니다.
+
+### 핵심 아이디어
+
+```
+[오래된 메시지 30개] → [요약 1줄] + [최근 메시지 20개]
+```
+
+### 업계 비교: OpenClaw, Gemini CLI, TARS
+
+| | OpenClaw | Gemini CLI | TARS |
+|--|----------|------------|------|
+| 트리거 | 컨텍스트 윈도우 근접 시 | 토큰 70% 도달 시 | 토큰 예산(20K) 초과 시 |
+| 요약 방식 | **LLM 요약** | **LLM 요약** (XML 구조) | **규칙 기반** (기본) |
+| 요약 포맷 | 자유 텍스트 | `<state_snapshot>` XML | `[COMPACTION SUMMARY]` 텍스트 |
+| 보존 범위 | 최근 메시지 | 최근 30% | 최근 12K 토큰 / 최소 5개 |
+
+OpenClaw과 Gemini CLI는 **LLM한테 요약을 시키는** 반면, TARS는 **규칙 기반 요약**을 기본으로 쓰되, 콜백으로 LLM 요약으로 교체할 수 있는 구조입니다. 최소 버전에서는 규칙 기반으로 시작합니다.
+
+### 토큰 추정
+
+```go
+cost := len(content) / 4  // 4글자 ≈ 1토큰
+```
+
+정확하진 않지만, 비용 대비 충분히 실용적입니다. tiktoken 같은 라이브러리를 도입하면 정확도가 올라가지만, MVP에서는 과잉입니다.
+
+### Compaction Boundary
+
+`LoadHistory()`가 히스토리를 로드할 때, `[COMPACTION SUMMARY]`를 포함한 system 메시지를 만나면 **항상 포함하고 거기서 멈춥니다**. 이렇게 해야 요약 이후 맥락이 유지됩니다.
+
+## 실습
+
+### 9-1. `RewriteMessages` — Atomic Write
+
+기존 `AppendMessage`는 한 줄 추가이지만, compaction은 전체를 교체합니다.
+
+**`internal/session/transcript.go`에 추가:**
+
+```go
+func RewriteMessages(path string, messages []Message) error {
+    tmp := path + ".tmp"
+    f, err := os.Create(tmp)
+    // ... 임시 파일에 쓰기 ...
+    return os.Rename(tmp, path)  // atomic 교체
+}
+```
+
+포인트:
+- **Atomic write** — 임시 파일에 쓰고 `os.Rename`으로 교체. 중간에 실패해도 원본이 안 깨짐
+- `json.NewEncoder`의 `Encode`는 자동으로 `\n`을 붙여줌 (JSONL 형식 유지)
+
+### 9-2. `CompactTranscript` — 압축 실행
+
+**`internal/session/compaction.go`** 핵심 흐름:
+
+```go
+const (
+    DefaultKeepRecentTokens = 12000
+    MinKeepRecentMessages   = 5
+    CompactionThreshold     = 20000
+)
+
+func CompactTranscript(path string, keepRecentTokens int) (CompactResult, error) {
+    all := ReadMessages(path)
+
+    // 1. 전체 토큰 계산 — threshold 미만이면 중단
+    // 2. 뒤에서부터 보존 범위 계산 (12K 토큰, 최소 5개)
+    // 3. 오래된 메시지를 BuildCompactionSummary로 요약
+    // 4. [요약 메시지] + [최근 메시지]로 RewriteMessages
+}
+```
+
+### 9-3. `BuildCompactionSummary` — 규칙 기반 요약
+
+```go
+func BuildCompactionSummary(messages []Message) string {
+    // "[COMPACTION SUMMARY]\nSummarized N messages.\n"
+    // + 각 메시지의 role과 앞 200자 나열
+}
+```
+
+나중에 LLM 요약으로 교체 가능합니다 — 함수 시그니처가 `func([]Message) string`이므로, LLM 호출 버전으로 바꿔끼우면 됩니다.
+
+### 9-4. 채팅 핸들러에서 호출
+
+**`internal/server/handler_chat.go`** — assistant 응답 저장 후:
+
+```go
+// 9.5 compaction 체크
+session.CompactTranscript(transcriptPath, 0)
+```
+
+에러를 무시합니다 — compaction 실패가 채팅을 막으면 안 됩니다.
+
+## 체크포인트
+
+- [x] 토큰 예산 초과 시 자동으로 compaction이 발생한다
+- [x] compaction 이후에도 `[COMPACTION SUMMARY]`를 통해 맥락이 유지된다
+- [x] `RewriteMessages`가 atomic write로 파일 안전성을 보장한다
+
+## 배운 패턴
+
+- **Atomic write** — 임시 파일 + `os.Rename`으로 중간 실패 시 원본 보호
+- **토큰 추정 `len/4`** — 정밀하지 않지만 실용적, MVP에 충분
+- **Compaction boundary** — 요약 메시지를 항상 포함해서 맥락 유지
+- **실패해도 계속** — compaction 실패가 핵심 기능(채팅)을 막지 않음

--- a/docs/tutorials/10-file-memory.md
+++ b/docs/tutorials/10-file-memory.md
@@ -1,0 +1,121 @@
+# Step 10. 파일 기반 Memory
+
+> 학습 목표: LLM이 장기 기억을 저장하고 검색하는 도구 구현, Markdown 기반 메모리 패턴 이해
+
+## 원본 코드 분석 (TARS)
+
+TARS의 메모리 시스템은 여러 소스로 구성됩니다:
+
+```
+memory/MEMORY.md        ← 영구 사실/선호도
+memory/YYYY-MM-DD.md    ← 일별 로그
+memory/experiences.jsonl ← 구조화된 경험 (카테고리, 태그, 중요도)
+```
+
+최소 버전에서는 **단일 `memory/MEMORY.md` 파일**에 append하고 검색하는 것으로 시작합니다.
+
+### 핵심 설계: 왜 Markdown인가
+
+- **사람이 읽을 수 있음** — 에디터로 직접 열어서 편집 가능
+- **LLM이 이해하기 쉬움** — 별도 파싱 없이 프롬프트에 주입 가능
+- **Append-friendly** — JSONL transcript과 같은 패턴
+- OpenClaw도 같은 선택 — `MEMORY.md` Markdown 파일에 메모리 저장
+
+### 두 가지 도구
+
+| 도구 | 역할 | 파라미터 |
+|------|------|----------|
+| `memory_save` | 기억 저장 | `content` (필수) |
+| `memory_search` | 기억 검색 | `query` (필수) |
+
+## 실습
+
+### 10-1. `memory_save` 도구
+
+**`internal/tool/memory_save.go`**
+
+```go
+func NewMemorySaveTool(workspaceDir string) Tool {
+    Execute: func(_ context.Context, params json.RawMessage) (Result, error) {
+        // 1. content 파싱
+        // 2. memory/ 디렉터리 생성 (MkdirAll)
+        // 3. MEMORY.md에 타임스탬프 + 내용 append
+    }
+}
+```
+
+저장 형식:
+```markdown
+## 2026-03-22T14:30:00Z
+
+사용자는 Go 언어를 주로 사용합니다.
+```
+
+`## 타임스탬프` 형식이라 나중에 날짜별로 구분하기 쉽습니다.
+
+### 10-2. `memory_search` 도구
+
+**`internal/tool/memory_search.go`**
+
+```go
+func NewMemorySearchTool(workspaceDir string, semantic *memory.Service) Tool {
+    Execute: func(ctx context.Context, params json.RawMessage) (Result, error) {
+        // 1. semantic 검색 시도 (있으면)
+        if semantic != nil {
+            hits, _ := semantic.Search(ctx, query, 10)
+            if len(hits) > 0 { return hits }
+        }
+        // 2. fallback: 텍스트 검색
+        // - 대소문자 무시 substring 매칭
+        // - 최대 10개 결과
+    }
+}
+```
+
+포인트:
+- **Semantic-first, text fallback** — semantic service가 있으면 먼저 사용, 없거나 실패하면 텍스트 검색
+- `*memory.Service`가 `nil`이면 텍스트 검색만 동작 — core를 깨지 않는 optional layer
+- 파일이 없으면 "no memories found" (에러가 아님)
+
+### 10-3. 서버에 등록
+
+**`internal/server/server.go`:**
+
+```go
+var semanticSvc *memory.Service  // nil — 아직 embedding 미설정
+
+registry.Register(tool.NewMemorySaveTool(cfg.WorkspaceDir))
+registry.Register(tool.NewMemorySearchTool(cfg.WorkspaceDir, semanticSvc))
+```
+
+## 테스트
+
+```bash
+go run ./cmd/tars/ serve
+
+# 기억 저장 유도
+curl -N -X POST http://localhost:8080/v1/chat \
+  -H "Content-Type: application/json" \
+  -d '{"message":"내가 Go 개발자라는 걸 기억해줘"}'
+
+# 기억 검색 유도
+curl -N -X POST http://localhost:8080/v1/chat \
+  -H "Content-Type: application/json" \
+  -d '{"message":"내가 어떤 언어를 쓰는지 기억나?"}'
+
+# 직접 파일 확인
+cat .workspace/memory/MEMORY.md
+```
+
+## 체크포인트
+
+- [x] 저장한 기억을 다음 대화에서 검색할 수 있다
+- [x] semantic service 없이도 텍스트 검색이 동작한다
+- [x] `memory/MEMORY.md` 파일을 사람이 직접 읽고 편집할 수 있다
+
+## 배운 패턴
+
+- **Markdown 메모리** — 사람과 LLM 모두 읽기 쉬운 포맷
+- **Optional dependency** — `nil` 체크로 없는 서비스를 graceful하게 처리
+- **Semantic-first fallback** — 고급 기능이 없으면 기본 기능으로 자동 전환
+- **도구 = 메모리 인터페이스** — LLM이 `memory_save`/`memory_search` 도구를 통해 자율적으로 기억을 관리

--- a/docs/tutorials/11-semantic-memory.md
+++ b/docs/tutorials/11-semantic-memory.md
@@ -1,0 +1,195 @@
+# Step 11. Semantic Memory (Embedding 기반)
+
+> 학습 목표: 텍스트 검색을 벡터 유사도 검색으로 업그레이드하고, optional layer 설계 이해
+
+## 원본 코드 분석 (TARS)
+
+TARS의 `internal/memory/` 패키지:
+
+```
+semantic.go       ← Service (인덱싱, 검색, 코사인 유사도)
+gemini_embed.go   ← Gemini embedding API adapter
+experience.go     ← 경험 구조체, JSONL 저장
+workspace.go      ← 워크스페이스 초기화, 일별 로그
+```
+
+### 핵심: 텍스트 검색 vs Semantic 검색
+
+| | 텍스트 검색 | Semantic 검색 |
+|--|------------|--------------|
+| "Go 개발자" 검색 | "Go"가 포함된 줄만 매칭 | "Golang", "프로그래밍 언어" 등도 매칭 |
+| 원리 | 문자열 substring 비교 | 벡터 공간에서 코사인 유사도 |
+| 외부 의존 | 없음 | Embedding API 필요 |
+| 비용 | 무료 | API 호출당 비용 발생 |
+
+### Embedding이란?
+
+텍스트를 고차원 벡터(숫자 배열)로 변환하는 것입니다:
+
+```
+"Go 개발자" → [0.12, -0.45, 0.78, ..., 0.33]  (768차원)
+"Golang 프로그래머" → [0.11, -0.44, 0.79, ..., 0.32]  (비슷한 벡터!)
+"오늘 날씨" → [0.89, 0.23, -0.11, ..., -0.67]  (전혀 다른 벡터)
+```
+
+의미가 비슷한 텍스트는 벡터도 비슷합니다. 두 벡터의 유사도를 **코사인 유사도**로 측정합니다.
+
+### 코사인 유사도
+
+```
+similarity = dot(a, b) / (|a| × |b|)
+```
+
+- 1.0 = 완전히 같은 방향 (의미 일치)
+- 0.0 = 직교 (무관)
+- -1.0 = 반대 방향
+
+## 실습
+
+### 11-1. Embedder 인터페이스
+
+**`internal/memory/semantic.go`**
+
+```go
+type Embedder interface {
+    Embed(ctx context.Context, text string) ([]float64, error)
+}
+```
+
+이 인터페이스 하나로 Gemini, OpenAI, 로컬 모델 등 어떤 embedding 서비스든 갈아끼울 수 있습니다. Phase 2에서 배운 `Client` 인터페이스와 같은 adapter 패턴이에요.
+
+### 11-2. Service — 인덱싱과 검색
+
+```go
+type Service struct {
+    embedder Embedder
+    entries  []Entry  // 인메모리 저장
+}
+
+// 텍스트를 임베딩해서 메모리에 추가
+func (s *Service) Index(ctx, id, content, source) error {
+    vec := s.embedder.Embed(ctx, content)
+    s.entries = append(s.entries, Entry{..., Embedding: vec})
+}
+
+// 쿼리와 유사한 메모리를 찾음
+func (s *Service) Search(ctx, query, limit) ([]SearchHit, error) {
+    queryVec := s.embedder.Embed(ctx, query)
+    // 모든 entry와 코사인 유사도 계산
+    // 점수 내림차순 정렬
+    // 상위 N개 반환
+}
+```
+
+최소 버전에서는 **인메모리 저장**입니다. TARS 원본은 `entries.jsonl` 파일에 영속화하고, SHA256 해시로 중복 인덱싱을 방지합니다.
+
+### 11-3. 코사인 유사도 구현
+
+```go
+func cosineSimilarity(a, b []float64) float64 {
+    if len(a) != len(b) || len(a) == 0 {
+        return 0
+    }
+    var dot, normA, normB float64
+    for i := range a {
+        dot += a[i] * b[i]
+        normA += a[i] * a[i]
+        normB += b[i] * b[i]
+    }
+    denom := math.Sqrt(normA) * math.Sqrt(normB)
+    if denom == 0 {
+        return 0
+    }
+    return dot / denom
+}
+```
+
+길이가 다르거나 비어있으면 0을 반환합니다. 0으로 나누는 것도 방어합니다.
+
+### 11-4. Gemini Embedding Adapter
+
+**`internal/memory/gemini.go`**
+
+```go
+type GeminiEmbedder struct {
+    baseURL, apiKey, model string
+    client *http.Client
+}
+
+func (g *GeminiEmbedder) Embed(ctx, text) ([]float64, error) {
+    // POST {baseURL}/{model}:embedContent?key={apiKey}
+    // body: { model, content: { parts: [{ text }] } }
+    // response: { embedding: { values: [float64...] } }
+}
+```
+
+포인트:
+- `models/` 접두사 자동 추가 — 사용자가 `text-embedding-004`만 쓰면 `models/text-embedding-004`로 변환
+- 타임아웃 20초 — embedding 호출은 빠르지만 안전장치
+- API 키를 URL 파라미터로 전달 (`?key=`) — Gemini API 컨벤션
+
+### 11-5. Optional Layer 연결
+
+**`internal/server/server.go`:**
+
+```go
+var semanticSvc *memory.Service  // nil = embedding 미설정
+
+registry.Register(tool.NewMemorySearchTool(cfg.WorkspaceDir, semanticSvc))
+```
+
+**`internal/tool/memory_search.go`:**
+
+```go
+if semantic != nil {
+    hits, err := semantic.Search(ctx, query, 10)
+    if err == nil && len(hits) > 0 {
+        return hits  // semantic 결과 사용
+    }
+}
+// fallback: 텍스트 검색
+```
+
+`semanticSvc`가 `nil`이면 텍스트 검색만 동작합니다. **core chat path를 깨지 않는 optional layer** — Phase 1이 항상 동작해야 한다는 원칙을 지킵니다.
+
+## 체크포인트
+
+- [x] "비슷한 의미"의 기억을 찾을 수 있다 (embedding 서비스 활성 시)
+- [x] embedding 서비스가 비활성화돼도 기존 파일 검색이 동작한다
+- [x] `Embedder` 인터페이스로 provider를 교체할 수 있다
+
+## 최종 구조 (Phase 3 완료)
+
+```
+tars/
+├── internal/
+│   ├── memory/                     ← Phase 3 신규 패키지
+│   │   ├── semantic.go             ← Service, Entry, SearchHit, cosineSimilarity
+│   │   └── gemini.go              ← GeminiEmbedder (Gemini API adapter)
+│   ├── session/
+│   │   ├── message.go
+│   │   ├── session.go
+│   │   ├── transcript.go          ← + RewriteMessages, LoadHistory
+│   │   ├── compaction.go          ← CompactTranscript, BuildCompactionSummary
+│   │   └── session_test.go
+│   ├── tool/
+│   │   ├── memory_save.go         ← MEMORY.md에 기억 저장
+│   │   ├── memory_search.go       ← semantic-first + text fallback 검색
+│   │   └── ...
+│   └── server/
+│       ├── server.go              ← semantic service optional 연결
+│       └── handler_chat.go        ← compaction 체크 추가
+└── docs/
+    └── lessons/
+        ├── 09-transcript-compaction.md
+        ├── 10-file-memory.md
+        └── 11-semantic-memory.md
+```
+
+## 배운 패턴
+
+- **Embedder 인터페이스** — `Client` 인터페이스와 같은 adapter 패턴을 embedding에도 적용
+- **코사인 유사도** — 벡터 공간에서 의미적 유사성 측정, 구현은 10줄
+- **Optional layer** — `nil` 체크로 없는 서비스를 graceful하게 처리, core를 깨지 않음
+- **Semantic-first fallback** — 고급 기능이 실패하면 기본 기능으로 자동 전환
+- **인메모리 → 영속화 경로** — 먼저 인메모리로 동작을 확인하고, 나중에 파일 저장 추가

--- a/docs/tutorials/12-skill-loader.md
+++ b/docs/tutorials/12-skill-loader.md
@@ -1,0 +1,134 @@
+# Step 12. Skill 로더
+
+> 학습 목표: SKILL.md 기반 확장 포맷 이해, frontmatter 파싱, 프롬프트 주입 패턴
+
+## 원본 코드 분석 (TARS)
+
+TARS의 `internal/skill/` 패키지:
+
+```
+types.go        ← Definition, Snapshot, Source 타입
+frontmatter.go  ← YAML frontmatter 파서 (라이브러리 없이 직접 구현)
+loader.go       ← WalkDir로 SKILL.md 발견, 머지, 정렬
+prompt.go       ← XML 형식 skill 목록 생성
+mirror.go       ← 런타임 경로에 skill 복사
+```
+
+### 업계 비교: OpenClaw, Gemini CLI, TARS
+
+| | OpenClaw | Gemini CLI | TARS |
+|--|----------|------------|------|
+| 포맷 | SKILL.md (YAML frontmatter) | SKILL.md (동일) | SKILL.md (동일) |
+| 발견 | `skills/` 워킹 | `skills/` 워킹 | `skills/` 워킹 |
+| 우선순위 | workspace > user > bundled | extension > project > global | workspace > user > bundled |
+| 사용자 호출 | `user-invocable: true` → `/skill` | `activate_skill` 도구 | `user-invocable: true` → `/skill` |
+| 게이팅 | `requires.bins`, `requires.env`, OS 필터 | `excludeTools` 설정 | 없음 |
+
+**핵심:** SKILL.md 포맷은 사실상 업계 표준. 세 프로젝트 모두 Markdown + YAML frontmatter를 사용합니다.
+
+### SKILL.md 포맷
+
+```markdown
+---
+name: greeting
+description: 사용자에게 인사하는 스킬
+user-invocable: true
+---
+# Greeting Skill
+
+사용자가 인사하면 친근하게 답변하세요.
+```
+
+`---` 사이가 frontmatter (YAML 메타데이터), 나머지가 content (LLM에 전달되는 지시).
+
+## 실습
+
+### 12-1. Definition 타입
+
+```go
+type Definition struct {
+    Name          string `json:"name"`
+    Description   string `json:"description"`
+    UserInvocable bool   `json:"user_invocable"`
+    FilePath      string `json:"file_path"`
+    Content       string `json:"content,omitempty"`
+}
+```
+
+TARS 원본의 `RecommendedTools`, `WakePhases` 등 고급 필드는 생략 — 최소 버전에 충분.
+
+### 12-2. Load — SKILL.md 탐색
+
+```go
+func Load(dir string) ([]Definition, error) {
+    filepath.WalkDir(dir, func(path string, d os.DirEntry, ...) error {
+        if !strings.EqualFold(filepath.Base(path), "SKILL.md") {
+            return nil
+        }
+        // 파일 읽기 → parseSkill → 목록에 추가
+    })
+}
+```
+
+포인트:
+- `strings.EqualFold`로 대소문자 무시 매칭
+- 파싱 실패는 skip (에러가 아님) — core를 깨지 않는 optional layer
+- 결과를 이름순 정렬
+
+### 12-3. Frontmatter 파싱
+
+TARS는 YAML 라이브러리 없이 **직접 key: value 파싱**합니다:
+
+```go
+func parseSkill(path, raw string) (Definition, error) {
+    if strings.HasPrefix(normalized, "---\n") {
+        // "---" 사이의 메타 블록 추출
+        // key: value 줄별 파싱 (name, description, user-invocable)
+    }
+    // frontmatter 없으면 전체를 content로 사용
+    // 이름 없으면 디렉터리 이름에서 추론
+    // 설명 없으면 첫 번째 텍스트 줄에서 추론
+}
+```
+
+### 12-4. FormatAvailableSkills — 프롬프트 생성
+
+```go
+func FormatAvailableSkills(skills []Definition) string {
+    // <available_skills>
+    //   <skill>
+    //     <name>greeting</name>
+    //     <description>...</description>
+    //     <content>실제 skill 본문</content>  ← 핵심!
+    //   </skill>
+    // </available_skills>
+}
+```
+
+**중요:** `<content>` 블록에 skill 본문을 포함해야 LLM이 skill 지시를 따릅니다. 목록(이름+설명)만 주입하면 LLM은 "skill이 있다"는 것만 알고 내용은 모릅니다.
+
+### 12-5. 프롬프트 빌더 연결
+
+`BuildOptions`에 `Skills string` 필드 추가, 시스템 프롬프트 끝에 skill XML 주입.
+
+채팅 핸들러에서:
+```go
+skills, _ := skill.Load(filepath.Join(h.workspaceDir, "skills"))
+systemPrompt := prompt.Build(prompt.BuildOptions{
+    WorkspaceDir: h.workspaceDir,
+    Skills:       skill.FormatAvailableSkills(skills),
+})
+```
+
+## 체크포인트
+
+- [x] `skills/` 폴더에 SKILL.md를 넣으면 자동 인식
+- [x] LLM이 skill 내용을 참고해 답변
+- [x] skill이 없어도 기존 채팅이 정상 동작
+
+## 배운 패턴
+
+- **SKILL.md = 업계 표준** — OpenClaw, Gemini CLI, TARS 모두 같은 포맷
+- **Frontmatter 직접 파싱** — YAML 라이브러리 없이 key: value로 충분
+- **이름/설명 추론** — frontmatter가 없어도 디렉터리명, 첫 줄에서 유추
+- **Content 주입 필수** — skill 목록만이 아니라 본문까지 프롬프트에 넣어야 동작

--- a/docs/tutorials/13-plugin-mcp.md
+++ b/docs/tutorials/13-plugin-mcp.md
@@ -1,0 +1,169 @@
+# Step 13. Plugin 로더 + MCP 클라이언트
+
+> 학습 목표: JSON 매니페스트 기반 플러그인 시스템과 MCP (Model Context Protocol) stdio 통신 구현
+
+## 원본 코드 분석 (TARS)
+
+### Plugin 시스템
+
+```
+internal/plugin/
+├── types.go     ← Manifest, Definition, Snapshot
+├── manifest.go  ← JSON 파싱, 서버 검증
+└── loader.go    ← WalkDir, 머지, skill dir/MCP 수집
+```
+
+### MCP 클라이언트
+
+```
+internal/mcp/
+├── client.go              ← pooledSession, 프로세스 관리, 세션 풀링
+├── protocol_transport.go  ← RPC 프로토콜 (Content-Length + JSONLine)
+└── client_api.go          ← ListTools, BuildTools, CallTool
+```
+
+### 업계 비교: Plugin 시스템
+
+| | OpenClaw | Gemini CLI | TARS |
+|--|----------|------------|------|
+| 매니페스트 | `openclaw.plugin.json` | `gemini-extension.json` | `tars.plugin.json` |
+| 런타임 | **In-process** TypeScript 모듈 | Content-only (MCP 위임) | Content-only (MCP 위임) |
+| capability | provider, channel, tool 등 7종 | MCP tools, commands | skills, mcp_servers |
+| 배포 | npm 패키지 | GitHub URL | 로컬 디렉터리 |
+
+OpenClaw은 런타임 플러그인(코드 실행), Gemini CLI/TARS는 선언형 플러그인(설정만 선언).
+
+### 업계 비교: MCP 클라이언트
+
+| | OpenClaw | Gemini CLI | TARS |
+|--|----------|------------|------|
+| 트랜스포트 | stdio, SSE, HTTP, WS | stdio, SSE, Streamable HTTP | stdio (Content-Length + JSONLine) |
+| 네이밍 | `mcp__plugin_server__tool` | `mcp_{server}_{tool}` | `mcp.{server}.{tool}` |
+| RPC 모드 | SDK 표준 | SDK 표준 | **자체 구현** (두 모드 지원) |
+
+TARS는 MCP SDK 없이 자체 RPC를 구현 — Content-Length/JSONLine 모드 전환과 서버별 자동 감지.
+
+## 실습
+
+### 13-A. Plugin 로더
+
+**`internal/plugin/plugin.go`**
+
+매니페스트 (`tars.plugin.json`) 예시:
+```json
+{
+  "id": "demo",
+  "name": "Demo Plugin",
+  "skills": ["skills"],
+  "mcp_servers": [
+    {"name": "echo", "command": "node", "args": ["/path/to/server.js"]}
+  ]
+}
+```
+
+핵심 흐름:
+```go
+func Load(dir string) (Snapshot, error) {
+    // 1. WalkDir로 tars.plugin.json 탐색
+    // 2. JSON 파싱, ID 검증
+    // 3. ID 기준 중복 제거 (나중 것이 이김)
+    // 4. collectSkillDirs — 플러그인 제공 skill 디렉터리 수집
+    // 5. collectMCPServers — 플러그인 선언 MCP 서버 수집
+}
+```
+
+포인트:
+- `MCPServer` 타입을 plugin 패키지에 직접 정의 — config 의존 없이 독립적
+- 파싱 실패는 skip — graceful degradation
+
+### 13-B. MCP 클라이언트
+
+**`internal/mcp/client.go`**
+
+MCP는 JSON-RPC 2.0 기반 프로토콜입니다. 두 가지 전송 모드:
+
+#### Content-Length 모드 (기본)
+```
+→ Content-Length: 155\r\n\r\n{"jsonrpc":"2.0","id":1,...}
+← Content-Length: 200\r\n\r\n{"jsonrpc":"2.0","id":1,"result":{...}}
+```
+
+#### JSONLine 모드 (sequential-thinking 등)
+```
+→ {"jsonrpc":"2.0","id":1,...}\n
+← {"jsonrpc":"2.0","id":1,"result":{...}}\n
+```
+
+#### 세션 라이프사이클
+
+```
+getOrStart(server)     ← 프로세스 시작, stdin/stdout 파이프
+  ↓
+initialize(ctx, sess)  ← "initialize" RPC → 서버 capabilities 확인
+  ↓                       "notifications/initialized" 전송
+buildToolsForServer()  ← "tools/list" RPC → 도구 목록 수집
+  ↓
+callTool()             ← "tools/call" RPC → 실행 시간에 도구 호출
+```
+
+#### RPC 모드 자동 감지
+
+```go
+func inferRPCMode(server plugin.MCPServer) rpcMode {
+    // sequential-thinking → JSONLine
+    // 나머지 → Content-Length
+}
+```
+
+TARS 원본은 Content-Length 실패 시 JSONLine으로 자동 폴백하는 기능도 있습니다.
+
+#### Notification 건너뛰기
+
+MCP 서버는 응답 외에 notification을 보낼 수 있습니다. 응답 읽기 루프에서 요청 ID와 일치하는 메시지만 반환:
+
+```go
+go func() {
+    for {
+        d, e := readMessage(sess.reader, sess.mode)
+        var resp rpcResponse
+        json.Unmarshal(d, &resp)
+        if resp.ID == id {  // 요청 ID 매칭
+            ch <- readResult{d, nil}
+            return
+        }
+        // notification은 건너뛰기
+    }
+}()
+```
+
+### 13-C. 서버 연결
+
+```go
+// server.go에서
+pluginSnap, _ := plugin.Load(filepath.Join(cfg.WorkspaceDir, "plugins"))
+
+if len(pluginSnap.MCPServers) > 0 {
+    mcpClient = mcp.NewClient(pluginSnap.MCPServers)
+    mcpTools, _ := mcpClient.BuildTools(ctx)
+    for _, t := range mcpTools {
+        registry.Register(t)  // MCP 도구를 기존 registry에 등록
+    }
+}
+```
+
+MCP 도구는 기존 내장 도구와 동일한 `tool.Tool` 인터페이스. LLM은 차이를 모릅니다.
+
+## 체크포인트
+
+- [x] MCP 서버의 도구가 채팅에서 사용 가능하다
+- [x] MCP 서버가 실패해도 나머지 기능은 정상 동작한다
+- [x] JSONLine/Content-Length 두 모드를 지원한다
+
+## 배운 패턴
+
+- **선언형 플러그인** — JSON 매니페스트로 skill과 MCP만 선언, 런타임 코드 없음
+- **두 가지 RPC 모드** — Content-Length (HTTP 스타일) vs JSONLine (스트림 스타일)
+- **자동 모드 감지** — 서버 이름/인자로 RPC 모드 추론
+- **Notification 건너뛰기** — 요청 ID 매칭으로 비동기 메시지 필터링
+- **Graceful degradation** — MCP 실패가 전체 서버를 막지 않음
+- **단일 write** — 헤더+바디를 한 번에 전송해야 파이프 전달이 확실

--- a/docs/tutorials/14-skill-hub.md
+++ b/docs/tutorials/14-skill-hub.md
@@ -1,0 +1,191 @@
+# Step 14. Skill Hub (원격 설치)
+
+> 학습 목표: 원격 registry에서 skill을 검색/설치하는 패키지 매니저 패턴
+
+## 원본 코드 분석 (TARS)
+
+TARS의 `internal/skillhub/` 패키지:
+
+```
+types.go     ← RegistryIndex, RegistryEntry, InstalledSkill 타입
+registry.go  ← GitHub raw content에서 인덱스 조회, 검색, SKILL.md 다운로드
+install.go   ← 설치/삭제/업데이트, skillhub.json DB 관리
+mcp.go       ← MCP 패키지 매니페스트 파싱, checksum 검증
+```
+
+### 아키텍처
+
+```
+GitHub Repository (tars-skills)
+├── registry.json        ← 스킬 인덱스 (이름, 설명, 버전, 태그)
+├── skills/
+│   ├── greeting/
+│   │   └── SKILL.md
+│   └── code-review/
+│       └── SKILL.md
+└── plugins/
+    └── ...
+
+    ↓ HTTP GET (raw.githubusercontent.com)
+
+Local Workspace
+├── skills/              ← 설치된 skill
+│   └── greeting/
+│       └── SKILL.md
+└── skillhub.json        ← 설치 상태 DB
+```
+
+### 핵심 설계: 왜 GitHub Raw Content인가
+
+- **인프라 불필요** — GitHub 리포지토리가 곧 registry
+- **버전 관리** — git으로 skill 이력 추적
+- **PR 기반 기여** — 누구나 PR로 skill 추가 가능
+- **캐싱 무료** — GitHub CDN이 처리
+
+OpenClaw의 ClawHub는 전용 웹사이트, npm은 전용 레지스트리가 필요하지만, TARS는 GitHub 하나로 충분합니다.
+
+## 실습
+
+### 14-1. Registry — 원격 인덱스 조회
+
+**`internal/skillhub/hub.go`**
+
+`registry.json` 형식:
+```json
+{
+  "version": 1,
+  "skills": [
+    {
+      "name": "greeting",
+      "description": "친근한 인사 스킬",
+      "version": "0.1.0",
+      "author": "devlikebear",
+      "tags": ["chat", "greeting"],
+      "path": "skills/greeting",
+      "user_invocable": true
+    }
+  ]
+}
+```
+
+```go
+type Registry struct {
+    RegistryURL  string       // registry.json URL
+    SkillBaseURL string       // SKILL.md 다운로드 베이스 URL
+    HTTPClient   *http.Client // 30초 타임아웃
+}
+
+func (r *Registry) FetchIndex(ctx) (*RegistryIndex, error)
+func (r *Registry) Search(ctx, query) ([]RegistryEntry, error)
+func (r *Registry) FindByName(ctx, name) (*RegistryEntry, error)
+func (r *Registry) FetchSkillContent(ctx, entry) ([]byte, error)
+```
+
+검색은 이름, 설명, 태그에 대한 **대소문자 무시 substring 매칭**. 매우 단순하지만 소규모 레지스트리에 충분합니다.
+
+### 14-2. Installer — 설치/삭제/업데이트
+
+```go
+type Installer struct {
+    WorkspaceDir string
+    Registry     *Registry
+}
+
+func (inst *Installer) Install(ctx, name) error
+func (inst *Installer) Uninstall(name) error
+func (inst *Installer) List() ([]InstalledSkill, error)
+func (inst *Installer) Update(ctx) ([]string, error)
+```
+
+설치 흐름:
+```
+Install("greeting")
+  ↓ FindByName → RegistryEntry
+  ↓ FetchSkillContent → SKILL.md 내용
+  ↓ os.MkdirAll → .workspace/skills/greeting/
+  ↓ os.WriteFile → SKILL.md 저장
+  ↓ addToDB → skillhub.json 업데이트
+```
+
+TARS 원본은 companion files, plugin 의존성 체크, checksum 검증이 있지만, 최소 버전에서는 SKILL.md 하나만 다운로드.
+
+### 14-3. 설치 상태 DB
+
+**`skillhub.json`:**
+```json
+{
+  "skills": [
+    {
+      "name": "greeting",
+      "version": "0.1.0",
+      "dir": ".workspace/skills/greeting"
+    }
+  ]
+}
+```
+
+Update 시 registry 버전과 로컬 버전을 비교, 다르면 재다운로드.
+
+### 14-4. CLI 서브커맨드
+
+**`cmd/tars/skill_main.go`:**
+
+```
+tars skill search [query]     ← 레지스트리 검색
+tars skill install <name>     ← 스킬 설치
+tars skill uninstall <name>   ← 스킬 삭제
+tars skill list               ← 설치된 스킬 목록
+tars skill update             ← 전체 업데이트
+```
+
+각 커맨드는 `Installer`를 생성하고 해당 메서드를 호출하는 얇은 래퍼.
+
+### 14-5. 설치 → 즉시 사용
+
+skill이 `.workspace/skills/` 에 설치되고, 채팅 핸들러가 같은 경로를 읽으므로:
+
+```
+tars skill install greeting
+→ .workspace/skills/greeting/SKILL.md 생성
+→ 다음 채팅 요청에서 skill.Load() 가 자동 감지
+→ 프롬프트에 주입 → LLM이 바로 사용
+```
+
+서버 재시작 없이 설치 즉시 사용 가능.
+
+## 체크포인트
+
+- [x] 원격에서 skill을 검색하고 설치할 수 있다
+- [x] 설치된 skill이 즉시 채팅에서 사용 가능하다
+- [x] `skillhub.json`으로 설치 상태를 추적한다
+
+## 최종 구조 (Phase 4 완료)
+
+```
+tars/
+├── internal/
+│   ├── skill/
+│   │   └── skill.go             ← Load, parseSkill, FormatAvailableSkills
+│   ├── plugin/
+│   │   └── plugin.go            ← Load, parseManifest, collectSkillDirs/MCPServers
+│   ├── mcp/
+│   │   └── client.go            ← Client, session, RPC (Content-Length + JSONLine)
+│   ├── skillhub/
+│   │   └── hub.go               ← Registry, Installer, InstalledDB
+│   └── ...
+├── cmd/tars/
+│   ├── main.go                  ← + skill 커맨드 등록
+│   └── skill_main.go            ← search/install/uninstall/list/update
+└── docs/lessons/
+    ├── 12-skill-loader.md
+    ├── 13-plugin-mcp.md
+    └── 14-skill-hub.md
+```
+
+## 배운 패턴
+
+- **GitHub as Registry** — 별도 인프라 없이 raw content로 패키지 매니저 구현
+- **설치 = 파일 복사** — SKILL.md를 다운로드해서 skills/ 디렉터리에 놓으면 끝
+- **JSON DB** — `skillhub.json`으로 설치 상태 추적, 간단하지만 충분
+- **런타임/배포 분리** — Step 12(런타임 로딩)와 Step 14(원격 배포)가 독립적 계층
+- **즉시 사용** — 설치 경로 = 로딩 경로이므로 서버 재시작 불필요

--- a/docs/tutorials/15-terminal-chat.md
+++ b/docs/tutorials/15-terminal-chat.md
@@ -1,0 +1,240 @@
+# Step 15. 터미널 채팅 클라이언트
+
+> 학습 목표: SSE 스트리밍 응답을 파싱하는 대화형 REPL 클라이언트 구현
+
+## 왜 채팅 클라이언트가 필요한가
+
+Phase 1~4까지 우리는 서버를 만들었습니다. `/v1/chat` 엔드포인트가 있고, LLM이 연결되어 있고, 도구도 있습니다. 그런데 **대화할 방법이 없습니다.** curl로 POST를 보낼 수는 있지만, SSE 스트리밍 응답을 실시간으로 읽기엔 불편합니다.
+
+```bash
+# 이렇게 해야 했다
+curl -N -X POST http://localhost:8080/v1/chat \
+  -H "Content-Type: application/json" \
+  -d '{"message":"안녕"}'
+```
+
+터미널 채팅 클라이언트가 있으면:
+- 자연어로 AI와 대화할 수 있다
+- 도구 호출 결과를 바로 확인할 수 있다
+- 세션을 유지하면서 연속 대화가 가능하다
+- 앞으로 "프로젝트 만들어줘"같은 자연어 명령의 기반이 된다
+
+## 서버 API 복습
+
+Step 4에서 구현한 채팅 API:
+
+```
+POST /v1/chat
+Content-Type: application/json
+
+{"session_id": "abc123", "message": "안녕하세요"}
+```
+
+응답은 JSON이 아니라 **SSE(Server-Sent Events)** 스트림:
+
+```
+HTTP/1.1 200 OK
+Content-Type: text/event-stream
+X-Session-ID: abc123
+
+event: status
+data: {"session_id":"abc123","status":"stream_open","message":"connected"}
+
+event: delta
+data: {"session_id":"abc123","text":"안녕"}
+
+event: delta
+data: {"session_id":"abc123","text":"하세요!"}
+
+event: done
+data: {"session_id":"abc123","usage":{"input_tokens":15,"output_tokens":8}}
+```
+
+핵심:
+- `event:` 줄이 이벤트 타입, `data:` 줄이 JSON 페이로드
+- `delta` 이벤트가 토큰 단위로 반복 전송됨
+- `done` 이벤트로 스트림 종료
+- `X-Session-ID` 헤더로 세션 ID 전달
+
+## 실습
+
+### 15-1. Cobra 서브커맨드 등록
+
+**`cmd/tars/main.go`** — `chat` 커맨드 추가:
+
+```go
+cmd.AddCommand(newChatCommand(stdout, os.Stderr))
+```
+
+실행: `tars chat --server http://localhost:8080`
+
+### 15-2. REPL 루프
+
+**`cmd/tars/chat.go`**
+
+가장 단순한 대화형 루프: stdin에서 한 줄 읽고 → 서버에 전송 → 응답 출력 → 반복.
+
+```go
+func runChat(stdout, stderr io.Writer, serverURL, sessionID string) error {
+    scanner := bufio.NewScanner(os.Stdin)
+    scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+    for {
+        fmt.Fprint(stdout, "you> ")
+        if !scanner.Scan() {
+            break
+        }
+        input := strings.TrimSpace(scanner.Text())
+        if input == "" {
+            continue
+        }
+
+        newSID, err := sendMessage(stdout, serverURL, sessionID, input)
+        if err != nil {
+            fmt.Fprintf(stderr, "error: %v\n", err)
+            continue
+        }
+        if newSID != "" {
+            sessionID = newSID
+        }
+    }
+    return scanner.Err()
+}
+```
+
+**설계 포인트:**
+- `bufio.Scanner` 기본 버퍼는 64KB. 긴 코드를 붙여넣을 수 있도록 1MB로 확장
+- `sessionID`를 루프 밖에서 유지 — 첫 응답의 `X-Session-ID`를 저장하면 이후 대화가 같은 세션에서 이어짐
+- 에러가 나도 루프가 끊기지 않음 — 서버 재시작해도 채팅 계속 가능
+
+### 15-3. SSE 스트림 파싱
+
+서버 응답은 일반 JSON이 아니라 SSE 형식입니다. 별도 라이브러리 없이 줄 단위로 파싱합니다:
+
+```go
+func sendMessage(stdout io.Writer, serverURL, sessionID, message string) (string, error) {
+    body := map[string]string{"session_id": sessionID, "message": message}
+    payload, _ := json.Marshal(body)
+
+    resp, err := http.Post(serverURL+"/v1/chat", "application/json",
+        strings.NewReader(string(payload)))
+    if err != nil {
+        return "", fmt.Errorf("connection failed: %w", err)
+    }
+    defer resp.Body.Close()
+
+    newSessionID := resp.Header.Get("X-Session-ID")
+
+    // SSE 파싱: "event: xxx\ndata: yyy\n\n" 패턴
+    fmt.Fprint(stdout, "ai> ")
+    scanner := bufio.NewScanner(resp.Body)
+    var eventType string
+
+    for scanner.Scan() {
+        line := scanner.Text()
+        if strings.HasPrefix(line, "event: ") {
+            eventType = strings.TrimPrefix(line, "event: ")
+        } else if strings.HasPrefix(line, "data: ") {
+            data := strings.TrimPrefix(line, "data: ")
+            handleEvent(stdout, eventType, data)
+            eventType = ""
+        }
+    }
+    return newSessionID, nil
+}
+```
+
+**SSE 파싱 규칙:**
+1. `event:` 줄 → 이벤트 타입 저장
+2. `data:` 줄 → 저장된 타입과 함께 처리
+3. 빈 줄 → 이벤트 구분자 (무시해도 됨, 이미 data에서 처리했으므로)
+
+### 15-4. 이벤트별 처리
+
+```go
+func handleEvent(stdout io.Writer, eventType, data string) {
+    switch eventType {
+    case "delta":
+        var d struct{ Text string `json:"text"` }
+        if json.Unmarshal([]byte(data), &d) == nil {
+            fmt.Fprint(stdout, d.Text) // 줄바꿈 없이 이어붙임
+        }
+    case "error":
+        var e struct{ Error string `json:"error"` }
+        if json.Unmarshal([]byte(data), &e) == nil {
+            fmt.Fprintf(stdout, "\n[error] %s", e.Error)
+        }
+    case "done":
+        // 토큰 사용량 표시 (선택적)
+    case "status":
+        // stream_open — 무시
+    }
+}
+```
+
+**핵심:** `delta` 이벤트의 텍스트를 `fmt.Fprint`로 출력합니다. `Println`이 아닙니다.
+토큰이 하나씩 오기 때문에 줄바꿈 없이 이어붙여야 자연스러운 스트리밍 출력이 됩니다:
+
+```
+you> 안녕하세요
+ai> 안녕하세요! 무엇을 도와드릴까요?
+[tokens: in=15 out=12]
+```
+
+### 15-5. 세션 명령어
+
+대화 중 사용할 수 있는 몇 가지 내장 명령어:
+
+```go
+if input == "/quit" || input == "/exit" {
+    fmt.Fprintln(stdout, "bye!")
+    return nil
+}
+if input == "/session" {
+    fmt.Fprintf(stdout, "session: %s\n", sessionID)
+    continue
+}
+if input == "/new" {
+    sessionID = ""
+    fmt.Fprintln(stdout, "(new session)")
+    continue
+}
+```
+
+- `/session` — 현재 세션 ID 확인
+- `/new` — 세션 초기화 (다음 메시지에서 새 세션 생성)
+- `/quit` — 종료
+
+## 전체 구조
+
+```
+cmd/tars/
+├── main.go          ← newChatCommand 등록
+├── chat.go          ← REPL + SSE 파싱
+├── serve.go
+└── skill_main.go
+```
+
+데이터 흐름:
+
+```
+stdin → bufio.Scanner
+    → "you> " 프롬프트
+    → http.Post /v1/chat (JSON body)
+    → SSE 스트림 수신
+        → event: delta → fmt.Fprint (실시간 출력)
+        → event: done  → 토큰 표시, 루프 복귀
+    → "ai> ..." 출력 완료
+    → 다음 "you> " 대기
+```
+
+## 체크포인트
+
+- [ ] `tars chat`으로 서버에 연결, 대화가 가능하다
+- [ ] LLM 응답이 스트리밍으로 한 글자씩 출력된다
+- [ ] 도구 호출 결과가 대화에 반영된다
+- [ ] `/session`으로 세션 ID 확인, `/new`로 새 세션 시작
+
+## 다음 단계
+
+터미널에서 AI와 대화할 수 있게 되었습니다. Step 16에서는 프로젝트 Store를 만들고, 이 채팅 인터페이스를 통해 "프로젝트 만들어줘"같은 자연어 명령으로 프로젝트를 관리하는 기반을 만듭니다.

--- a/docs/tutorials/16-project-store.md
+++ b/docs/tutorials/16-project-store.md
@@ -1,0 +1,417 @@
+# Step 16. 프로젝트 Store + Kanban
+
+> 학습 목표: 파일 기반 영속화와 YAML frontmatter 패턴으로 프로젝트/태스크를 관리하는 저장소 구현
+
+## 왜 프로젝트 Store인가
+
+Step 15에서 AI와 대화할 수 있게 되었습니다. 하지만 대화는 흘러가는 것이고, **작업을 구조화**하려면 프로젝트와 태스크라는 단위가 필요합니다.
+
+```
+"소나기 스타일 단편소설 써줘"
+    → 프로젝트 생성 (이름, 목표)
+    → 태스크 분해 (자료조사, 개요 작성, 본문 집필, 퇴고)
+    → 진행 상태 추적 (todo → in_progress → done)
+    → 활동 로그 기록
+```
+
+이 Step에서는 **순수 CRUD를 중심으로** 구현합니다. 자동 실행(Autopilot)은 Phase 6 범위입니다.
+
+> 현재 코드베이스에는 이후 Step에서 재사용할 `Phase` 필드와 project tool 브리지가 일부 먼저 들어와 있습니다. 이 문서에서는 **저장소 구조와 CRUD, REST API**에만 집중합니다.
+
+## 설계: 왜 파일 기반인가
+
+데이터베이스 대신 **Markdown + JSON 파일**을 사용합니다:
+
+| 파일 | 역할 | 형식 |
+|------|------|------|
+| `PROJECT.md` | 프로젝트 메타데이터 | YAML frontmatter + Markdown 본문 |
+| `KANBAN.md` | 태스크 보드 | YAML frontmatter + 구조화된 목록 |
+| `ACTIVITY.jsonl` | 활동 로그 | JSON Lines (한 줄에 하나씩) |
+
+```
+.workspace/projects/
+├── 단편-소설-a1b2c3/
+│   ├── PROJECT.md
+│   ├── KANBAN.md
+│   └── ACTIVITY.jsonl
+└── api-서버-d4e5f6/
+    ├── PROJECT.md
+    ├── KANBAN.md
+    └── ACTIVITY.jsonl
+```
+
+**이유:**
+- git으로 버전 관리 가능
+- 사람이 직접 읽고 편집 가능
+- 외부 의존성(DB) 불필요
+- TARS 원본도 동일한 패턴
+
+## 원본 코드 분석 (TARS)
+
+TARS의 `internal/project/` 패키지:
+
+```
+store.go           ← 프로젝트 CRUD + 보드 + 활동 로그
+kanban.go          ← 칸반 보드 파싱/직렬화
+activity.go        ← JSONL 활동 로그
+workflow_policy.go ← 상태 전이 규칙
+```
+
+TARS에서는 이를 **`store.go` 하나로 통합**합니다. 학습 단계에서는 파일을 나누는 것보다 전체 흐름을 한 눈에 보는 것이 더 중요합니다.
+
+현재 저장소의 `store.go`에는 Phase 6에서 사용할 `SetPhase`, `Deliverable` 관련 코드도 같이 들어 있습니다. 하지만 Step 16에서 꼭 이해해야 하는 핵심은 다음 3가지입니다:
+
+1. `PROJECT.md` 파싱/직렬화
+2. `KANBAN.md` 읽기/쓰기
+3. `ACTIVITY.jsonl` append
+
+## 실습
+
+### 16-1. 데이터 모델
+
+**`internal/project/store.go`**
+
+```go
+type Project struct {
+    ID        string
+    Name      string
+    Status    string // active, paused, completed, archived, cancelled
+    Phase     string // planning, awaiting_approval, executing, reviewing, ...
+    Objective string
+    Body      string // markdown 본문
+    CreatedAt time.Time
+    UpdatedAt time.Time
+    Path      string
+}
+
+type BoardTask struct {
+    ID     string
+    Title  string
+    Status string // todo, in_progress, review, done
+}
+
+type Board struct {
+    ProjectID string
+    UpdatedAt time.Time
+    Columns   []string // ["todo","in_progress","review","done"]
+    Tasks     []BoardTask
+    Path      string
+}
+
+type Activity struct {
+    ID        string
+    ProjectID string
+    Kind      string // project_created, board_task_updated, ...
+    Message   string
+    Timestamp time.Time
+}
+```
+
+**설계 포인트:**
+- `Project.Status`는 사용자 설정값 (active/archived)
+- `Project.Phase`는 이후 상태 머신 확장을 위한 필드지만, Step 16에서는 기본값 `planning`만 사용
+- `BoardTask.Status`는 고정 4단계: todo → in_progress → review → done
+
+### 16-2. YAML Frontmatter 파싱
+
+PROJECT.md의 형식:
+
+```markdown
+---
+id: 단편-소설-a1b2c3
+name: 단편 소설
+status: active
+phase: planning
+objective: 소나기 스타일 단편소설 작성
+created_at: 2026-03-25T10:00:00Z
+updated_at: 2026-03-25T10:00:00Z
+---
+
+프로젝트 설명이나 메모를 여기에 작성합니다.
+```
+
+파싱 함수:
+
+```go
+func splitFrontmatter(raw string) (map[string]string, string) {
+    meta := make(map[string]string)
+    if !strings.HasPrefix(raw, "---\n") {
+        return meta, raw
+    }
+    rest := raw[4:]
+    idx := strings.Index(rest, "\n---")
+    if idx < 0 {
+        return meta, raw
+    }
+    header := rest[:idx]
+    body := strings.TrimSpace(rest[idx+4:])
+
+    for _, line := range strings.Split(header, "\n") {
+        k, v, ok := strings.Cut(line, ":")
+        if !ok {
+            continue
+        }
+        meta[strings.TrimSpace(k)] = strings.TrimSpace(v)
+    }
+    return meta, body
+}
+```
+
+**왜 YAML 라이브러리를 안 쓰나?** frontmatter는 `key: value` 한 줄씩이라 `strings.Cut`으로 충분합니다. 중첩 구조가 없으므로 외부 의존성을 추가할 필요가 없습니다.
+
+### 16-3. 프로젝트 CRUD
+
+**Create** — ID는 이름 slug + 3바이트 랜덤 hex:
+
+```go
+func newProjectID(name string) string {
+    slug := strings.ToLower(strings.TrimSpace(name))
+    slug = strings.ReplaceAll(slug, " ", "-")
+    b := make([]byte, 3)
+    rand.Read(b)
+    return fmt.Sprintf("%s-%x", slug, b)
+}
+```
+
+예: `"단편 소설"` → `"단편-소설-a1b2c3"`
+
+프로젝트 생성 시 자동으로:
+1. 프로젝트 디렉토리 생성
+2. `PROJECT.md` 작성 (frontmatter + 빈 본문)
+3. 기본 `KANBAN.md` 생성 (빈 보드, 4개 컬럼)
+4. 활동 로그 기록 (`project_created`)
+
+**List** — `projects/` 하위 디렉토리를 순회:
+
+```go
+func (s *Store) List() ([]*Project, error) {
+    base := filepath.Join(s.workspaceDir, "projects")
+    entries, err := os.ReadDir(base)
+    // ...
+    for _, e := range entries {
+        if !e.IsDir() { continue }
+        p, err := s.Get(e.Name())
+        if err != nil { continue } // 손상된 프로젝트 건너뛰기
+        projects = append(projects, p)
+    }
+    // UpdatedAt 기준 최신순 정렬
+    sort.Slice(projects, func(i, j int) bool {
+        return projects[i].UpdatedAt.After(projects[j].UpdatedAt)
+    })
+    return projects, nil
+}
+```
+
+### 16-4. 칸반 보드
+
+KANBAN.md 형식:
+
+```markdown
+---
+project_id: 단편-소설-a1b2c3
+updated_at: 2026-03-25T10:00:00Z
+columns: [todo, in_progress, review, done]
+---
+
+- id: task-1
+  title: 소나기 원작 분석
+  status: done
+- id: task-2
+  title: 등장인물 설정
+  status: in_progress
+```
+
+**상태 정규화** — 다양한 입력을 표준 값으로:
+
+```go
+func normalizeStatus(s string) string {
+    switch strings.ToLower(s) {
+    case "backlog":
+        return "todo"
+    case "doing", "in progress", "in-progress":
+        return "in_progress"
+    default:
+        return strings.ToLower(s)
+    }
+}
+```
+
+사용자가 "doing"이라고 적어도 "in_progress"로 통일됩니다.
+
+### 16-5. 활동 로그 (JSONL)
+
+한 줄에 하나의 JSON 객체를 append하는 패턴:
+
+```go
+func (s *Store) AppendActivity(projectID, kind, message string) error {
+    now := time.Now().UTC()
+    a := Activity{
+        ID:        fmt.Sprintf("act_%s_%03d", now.Format("20060102T150405"), now.Nanosecond()%1000),
+        ProjectID: projectID,
+        Kind:      kind,
+        Message:   message,
+        Timestamp: now,
+    }
+    data, _ := json.Marshal(a)
+    f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+    if err != nil { return err }
+    defer f.Close()
+    _, err = fmt.Fprintf(f, "%s\n", data)
+    return err
+}
+```
+
+**왜 JSONL인가:**
+- Append-only — 동시성 문제 없음
+- 한 줄 손상되어도 나머지 읽기 가능
+- `tail -f`로 실시간 모니터링 가능
+- DB 없이 시계열 데이터 저장
+
+### 16-6. REST API
+
+**`internal/server/handler_dashboard.go`**
+
+| Method | Path | 동작 |
+|--------|------|------|
+| GET | `/api/projects` | 프로젝트 목록 |
+| POST | `/api/projects` | 프로젝트 생성 |
+| GET | `/api/projects/{id}` | 프로젝트 상세 |
+| PUT | `/api/projects/{id}` | 프로젝트 수정 |
+| DELETE | `/api/projects/{id}` | 프로젝트 아카이브 |
+| GET | `/api/projects/{id}/board` | 보드 조회 |
+| PUT | `/api/projects/{id}/board` | 보드 업데이트 |
+| GET | `/api/projects/{id}/activity` | 활동 로그 |
+
+실제 핸들러에는 Autopilot/Approve/Reject 같은 후속 Step용 경로도 같이 들어 있지만, Step 16에서는 위 8개만 보면 됩니다.
+
+라우팅은 `net/http`의 `ServeMux`만으로 구현합니다. 경로 파싱:
+
+```go
+func (h *DashboardHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+    path := strings.TrimPrefix(r.URL.Path, "/api/projects")
+    path = strings.TrimPrefix(path, "/")
+
+    switch r.Method {
+    case http.MethodGet:
+        h.handleGet(w, r, path)
+    case http.MethodPost:
+        h.handlePost(w, r, path)
+    // ...
+    }
+}
+```
+
+`/api/projects/abc123/board` → `path = "abc123/board"` → `SplitN("/", 2)` → `["abc123", "board"]`
+
+**JSON null 방어:** Go의 nil slice는 JSON으로 `null`이 됩니다. Swift 등 클라이언트가 decode에 실패하지 않도록 빈 배열로 강제합니다:
+
+```go
+if board.Tasks == nil {
+    board.Tasks = []project.BoardTask{}
+}
+```
+
+### 16-7. 채팅과 연결되는 지점
+
+Step 15에서 만든 터미널 채팅 클라이언트가 Step 16의 저장소를 쓰려면, 저장소를 **LLM tool**로 노출해야 합니다.
+
+**`internal/tool/project.go`**
+
+- `project_create`
+- `project_list`
+- `project_get`
+- `project_add_task`
+
+예를 들어 사용자가 이렇게 말하면:
+
+```text
+소나기 스타일 단편소설 프로젝트 만들어줘
+```
+
+LLM은 `project_create`를 호출할 수 있고, 이 도구는 내부에서 `store.Create()`를 실행합니다.
+
+```
+자연어 요청
+  → ChatHandler
+  → agent loop
+  → project_create tool
+  → Store.Create()
+  → PROJECT.md / KANBAN.md / ACTIVITY.jsonl 생성
+```
+
+이 흐름 덕분에 Step 16의 파일 기반 저장소가 Step 15의 채팅 인터페이스와 자연스럽게 이어집니다.
+
+## 전체 구조
+
+```
+internal/project/
+└── store.go          ← Project, Board, Activity + Store CRUD
+
+internal/tool/
+└── project.go        ← project_create / list / get / add_task
+
+internal/server/
+├── handler_dashboard.go  ← REST API 핸들러
+├── handler_chat.go       ← 채팅 요청 처리
+└── server.go             ← Store + Tool + Handler 연결
+
+.workspace/projects/
+└── {project-id}/
+    ├── PROJECT.md
+    ├── KANBAN.md
+    └── ACTIVITY.jsonl
+```
+
+## 체크포인트
+
+- [x] API로 프로젝트 생성/조회/수정이 가능하다
+- [x] 태스크를 추가하고 상태를 변경할 수 있다
+- [x] 활동 로그가 JSONL로 누적된다
+- [x] `PROJECT.md`를 직접 열어 사람이 읽을 수 있다
+- [x] 채팅에서 자연어 요청이 `project_create` tool로 연결된다
+
+### curl로 테스트
+
+```bash
+# 프로젝트 생성
+curl -s -X POST http://localhost:8080/api/projects \
+  -H "Content-Type: application/json" \
+  -d '{"name":"단편소설","objective":"소나기 스타일 단편소설 작성"}' | jq
+
+# 프로젝트 목록
+curl -s http://localhost:8080/api/projects | jq
+
+# 보드 조회
+curl -s http://localhost:8080/api/projects/{id}/board | jq
+
+# 활동 로그
+curl -s http://localhost:8080/api/projects/{id}/activity | jq
+
+# 채팅에서 자연어로 프로젝트 생성
+curl -N -X POST http://localhost:8080/v1/chat \
+  -H "Content-Type: application/json" \
+  -d '{"message":"소나기 스타일 단편소설 프로젝트 만들어줘"}'
+```
+
+### 자동 테스트
+
+현재 코드베이스에는 Step 16 흐름을 고정하는 테스트가 추가되어 있습니다:
+
+- `internal/project/store_test.go`
+  - 프로젝트 생성 시 `PROJECT.md`, `KANBAN.md`, `ACTIVITY.jsonl`이 생성되는지 검증
+  - `PROJECT.md`가 사람이 읽을 수 있는 frontmatter 문서인지 검증
+- `internal/server/handler_dashboard_test.go`
+  - `/api/projects`, `/board`, `/activity` CRUD 경로 검증
+  - 빈 slice가 JSON `null`이 아니라 배열로 내려가는지 검증
+- `internal/server/handler_chat_test.go`
+  - 자연어 요청이 `project_create` tool 호출로 이어지고 실제 프로젝트가 생성되는지 검증
+
+실행:
+
+```bash
+go test ./...
+```
+
+## 다음 단계
+
+프로젝트와 태스크를 저장하고 조회하는 기반이 만들어졌습니다. 다음 Step에서는 macOS 메뉴바 대시보드를 만들어 이 데이터를 시각적으로 확인하고, 그 다음 Step에서 Autopilot과 승인 흐름이 같은 저장소 위에 올라가게 됩니다.

--- a/docs/tutorials/17-macos-dashboard.md
+++ b/docs/tutorials/17-macos-dashboard.md
@@ -1,0 +1,256 @@
+# Step 17. macOS 대시보드
+
+> 학습 목표: SwiftUI MenuBarExtra 앱으로 프로젝트 목록, 상세, 태스크 편집 UI를 구현
+
+## 왜 macOS 대시보드가 필요한가
+
+Step 16에서 프로젝트 저장소와 REST API를 만들었지만, 아직은 `curl`이나 터미널로만 데이터를 확인할 수 있습니다.
+
+이번 Step에서는 메뉴바에서 바로 열리는 작은 macOS 앱을 만들어:
+
+- 서버 연결 상태를 확인하고
+- 프로젝트 목록을 보고
+- 프로젝트 상세 보드와 활동 로그를 열고
+- 프로젝트 생성과 태스크 추가/수정/삭제를 UI에서 처리합니다.
+
+핵심은 “예쁜 앱”보다 **파일 기반 프로젝트 시스템을 눈으로 확인하고 조작하는 최소 대시보드**를 만드는 것입니다.
+
+## 범위
+
+Step 17에서는 다음까지만 다룹니다:
+
+- `MenuBarExtra(.window)` 기반 macOS 앱
+- 서버 연결/해제
+- 프로젝트 목록/상세 조회
+- 프로젝트 생성
+- 태스크 추가/수정/삭제/상태 변경
+
+다음 Step에서 붙는 것:
+
+- Autopilot 시작/중지
+- 승인/거절
+- 실시간 SSE 고도화
+- 산출물(deliverables) 표시 확장
+
+현재 코드베이스에는 후속 Step UI 일부가 이미 같은 화면에 들어가 있습니다. 이 문서에서는 **프로젝트 대시보드의 기본 골격**에 집중합니다.
+
+## 전체 구조
+
+```text
+dashboard/
+├── Package.swift
+└── Sources/
+    ├── App.swift
+    ├── APIClient.swift
+    ├── Models.swift
+    ├── ProjectListView.swift
+    ├── CreateProjectView.swift
+    ├── ProjectDetailView.swift
+    ├── EditTaskSheet.swift
+    └── BoardEditing.swift
+```
+
+역할 분리는 이렇게 잡습니다:
+
+- `App.swift`
+  - 연결 화면 / 목록 화면 / 상세 화면 전환
+- `APIClient.swift`
+  - `/health`, `/api/projects`, `/api/projects/{id}/board`, `/activity` 호출
+- `ProjectListView.swift`
+  - 목록과 생성 진입
+- `ProjectDetailView.swift`
+  - 보드, 활동 로그, 보조 패널
+- `EditTaskSheet.swift`
+  - 태스크 추가/수정/삭제
+- `BoardEditing.swift`
+  - 상태 전이와 배열 편집 같은 순수 로직
+
+## 17-1. MenuBarExtra 앱 골격
+
+**`dashboard/Sources/App.swift`**
+
+메뉴바 앱의 화면은 3개면 충분합니다.
+
+```swift
+enum AppScreen {
+    case connect
+    case list
+    case detail(String)
+}
+```
+
+- `connect`
+  - 서버 주소 입력
+- `list`
+  - 프로젝트 목록
+- `detail`
+  - 특정 프로젝트의 보드/활동
+
+SwiftUI의 `MenuBarExtra(...).menuBarExtraStyle(.window)`를 쓰면 메뉴처럼 접히지 않고 작은 독립 창처럼 열립니다. Step 17의 대시보드에는 이 방식이 가장 단순합니다.
+
+## 17-2. 서버 API 클라이언트
+
+**`dashboard/Sources/APIClient.swift`**
+
+대시보드는 결국 REST API 클라이언트입니다. 우선 필요한 호출은 5개입니다:
+
+- `checkConnection()`
+- `fetchProjects()`
+- `fetchBoard(projectID:)`
+- `fetchActivity(projectID:)`
+- `createProject(name:objective:)`
+
+태스크 편집은 별도 엔드포인트를 만들지 않고 **보드 전체를 PUT** 하는 방식으로 충분합니다.
+
+```swift
+func updateBoard(projectID: String, tasks: [BoardTask]) async {
+    let body = tasks.map { ["ID": $0.id, "Title": $0.title, "Status": $0.status] }
+    ...
+}
+```
+
+왜 전체 보드를 다시 보내나?
+
+- 서버 구현이 단순합니다
+- Step 16의 파일 저장 구조와 잘 맞습니다
+- “태스크 하나 수정”도 결국 `KANBAN.md` 전체를 다시 쓰는 작업입니다
+
+## 17-3. 프로젝트 목록과 생성
+
+**`dashboard/Sources/ProjectListView.swift`**
+
+목록 화면은 다음 3가지만 있으면 됩니다:
+
+- 새로고침 버튼
+- 프로젝트 생성 버튼
+- 프로젝트 행 탭으로 상세 이동
+
+생성 팝오버는 별도 뷰로 분리합니다.
+
+**`dashboard/Sources/CreateProjectView.swift`**
+
+입력값:
+
+- `name`
+- `objective`
+
+생성 성공 시:
+
+1. `createProject()`
+2. `fetchProjects()`
+3. 팝오버 닫기
+4. 생성된 프로젝트 상세 화면으로 이동
+
+이 흐름 덕분에 사용자는 “만들고 나서 다시 목록에서 찾는” 단계를 건너뛸 수 있습니다.
+
+## 17-4. 프로젝트 상세와 보드
+
+**`dashboard/Sources/ProjectDetailView.swift`**
+
+상세 화면의 핵심은 `BoardSection`입니다.
+
+표시 요소:
+
+- 현재 phase badge
+- 칸반 컬럼별 태스크 개수
+- 태스크 행 목록
+- 최근 활동 로그
+
+Step 17에서 태스크 편집 UX는 두 동작으로 나눕니다:
+
+1. 왼쪽 상태 아이콘 클릭
+   - `todo → in_progress → review → done` 순환
+2. 연필 버튼 클릭
+   - 제목/상태 수정
+   - 삭제 가능
+
+이렇게 하면 “빠른 상태 전이”와 “명시적 편집”을 분리할 수 있습니다.
+
+## 17-5. 태스크 편집 Sheet
+
+**`dashboard/Sources/EditTaskSheet.swift`**
+
+이 뷰는 “추가”와 “수정”을 하나로 합칩니다.
+
+```swift
+init(client: APIClient, projectID: String, task: BoardTask? = nil, isPresented: Binding<Bool>)
+```
+
+- `task == nil`
+  - 새 태스크 추가 모드
+- `task != nil`
+  - 기존 태스크 수정 모드
+
+필드:
+
+- `title`
+- `status`
+
+버튼:
+
+- `Add` 또는 `Save`
+- `Delete` (수정 모드에서만 표시)
+
+이 패턴의 장점:
+
+- 팝오버 UI를 재사용할 수 있음
+- 추가/수정 로직이 같은 `updateBoard()`로 합쳐짐
+- 상태 picker 덕분에 한 번에 원하는 컬럼으로 이동 가능
+
+## 17-6. 순수 로직 분리
+
+**`dashboard/Sources/BoardEditing.swift`**
+
+UI 코드 안에 배열 수정 로직이 흩어지기 시작하면 금방 지저분해집니다. 그래서 순수 로직을 따로 뺍니다:
+
+```swift
+enum BoardEditing {
+    static func nextStatus(after status: String) -> String
+    static func upsert(tasks: [BoardTask], task: BoardTask) -> [BoardTask]
+    static func delete(tasks: [BoardTask], id: String) -> [BoardTask]
+}
+```
+
+이렇게 빼 두면 좋은 점:
+
+- SwiftUI 뷰가 단순해짐
+- 테스트를 먼저 쓸 수 있음
+- Step 17 범위에서 “UI와 상태 변경 규칙”을 분리해 설명 가능
+
+## 17-7. 테스트
+
+Step 17은 SwiftUI 화면 자체를 스냅샷 테스트하지는 않지만, **보드 편집 규칙은 자동 테스트로 고정**합니다.
+
+**`dashboard/Tests/BoardEditingTests.swift`**
+
+검증 항목:
+
+- 상태가 올바른 순서로 순환하는지
+- 새 태스크가 append 되는지
+- 기존 태스크 수정 시 같은 위치에서 교체되는지
+- 삭제가 정확한 `id`에만 적용되는지
+
+실행:
+
+```bash
+cd dashboard
+swift test
+```
+
+서버 쪽 회귀 검증까지 같이 하려면:
+
+```bash
+go test ./...
+```
+
+## 체크포인트
+
+- [x] 메뉴바에서 서버 연결 후 프로젝트 목록이 보인다
+- [x] 프로젝트 상세에서 보드/활동이 표시된다
+- [x] 대시보드에서 프로젝트를 생성할 수 있다
+- [x] 대시보드에서 태스크를 추가/수정/삭제할 수 있다
+- [x] 상태 아이콘으로 태스크 상태를 순환 변경할 수 있다
+
+## 다음 단계
+
+이제 파일 기반 프로젝트 저장소를 메뉴바 앱에서 직접 다룰 수 있습니다. 다음 Step에서는 같은 대시보드 위에 Autopilot 상태, 승인/거절, 실시간 업데이트를 붙여서 “감독 화면”으로 확장합니다.

--- a/docs/tutorials/18-autopilot.md
+++ b/docs/tutorials/18-autopilot.md
@@ -1,0 +1,218 @@
+# Step 18. 상태 머신 + Autopilot
+
+> 학습 목표: phase 기반 상태 머신과 LLM 콜백으로 자율 실행 루프를 구현
+
+## 왜 상태 머신인가
+
+Step 16에서 프로젝트와 태스크를 저장하는 Store를 만들었습니다. 하지만 태스크를 사람이 직접 만들고, 직접 상태를 바꿔야 합니다. AI 에이전트라면 이 과정을 자동화해야 합니다:
+
+```
+목표 입력 → 태스크 자동 생성 → 하나씩 실행 → 목표 달성 평가 → 완료 or 재계획
+```
+
+이걸 무작정 루프로 돌리면 상태 관리가 엉망이 됩니다. "지금 뭘 하고 있는지"를 명확히 하려면 **상태 머신**이 필요합니다.
+
+## Phase 상태 전이도
+
+```
+planning ──→ awaiting_approval ──→ executing ──→ reviewing ──→ completed
+    ↑                                               │
+    └───────────────── re-planning ←────────────────┘
+                    (goal not met)
+
+어디서든 → paused (Resume으로 복귀)
+어디서든 → cancelled (종료)
+```
+
+각 phase에서 Autopilot이 하는 일:
+
+| Phase | 동작 |
+|-------|------|
+| `planning` | LLM에게 태스크+산출물 계획 요청 |
+| `awaiting_approval` | 대기 (사용자 승인/거절) |
+| `executing` | todo 태스크를 하나씩 실행 |
+| `reviewing` | LLM에게 목표 달성 여부 평가 |
+| `completed` | 루프 종료 |
+| `paused` | 대기 (사용자 Resume) |
+| `cancelled` | 루프 종료 |
+
+## 핵심 설계: 콜백 패턴
+
+Autopilot은 **LLM을 직접 호출하지 않습니다.** 대신 3개의 콜백을 주입받습니다:
+
+```go
+type PlanGenerator func(ctx context.Context, project *Project) (*PlanResult, error)
+type TaskRunner    func(ctx context.Context, projectID string, task BoardTask, deliverables []Deliverable) error
+type GoalEvaluator func(ctx context.Context, project *Project, completedTasks []BoardTask) (done bool, reason string, err error)
+```
+
+**왜 콜백인가?**
+- Autopilot은 "상태 전이 규칙"만 알면 됨
+- LLM 호출 방법은 서버(`server.go`)가 결정
+- 테스트 시 Mock 콜백을 주입할 수 있음
+- Provider가 바뀌어도 Autopilot 코드를 수정할 필요 없음
+
+## 실습
+
+### 18-1. AutopilotRun 영속화
+
+```go
+type AutopilotRun struct {
+    ProjectID  string `json:"project_id"`
+    Status     string `json:"status"`     // running, blocked, done, failed
+    Phase      string `json:"phase"`
+    Message    string `json:"message,omitempty"`
+    Iterations int    `json:"iterations"`
+    StartedAt  string `json:"started_at,omitempty"`
+    UpdatedAt  string `json:"updated_at,omitempty"`
+}
+```
+
+`AUTOPILOT.json`에 매 상태 변경마다 저장합니다. 서버가 재시작해도 마지막 상태를 확인할 수 있습니다.
+
+### 18-2. 메인 루프
+
+```go
+func (a *Autopilot) loop(ctx context.Context, projectID string) {
+    for iteration := 1; ; iteration++ {
+        if ctx.Err() != nil { return }
+
+        p, _ := a.store.Get(projectID)
+        if p.Phase == "awaiting_approval" || p.Phase == "paused" {
+            // 대기 상태: 로그 없이 2초마다 체크
+            a.step(ctx, projectID, iteration)
+            time.Sleep(2 * time.Second)
+            continue
+        }
+
+        // 활성 상태: 로그 출력 + 10초 간격
+        stop := a.step(ctx, projectID, iteration)
+        if stop { return }
+        time.Sleep(a.interval)
+    }
+}
+```
+
+**대기 상태 최적화:** `awaiting_approval`과 `paused`에서는 iteration 로그를 출력하지 않습니다. 초기 구현에서 이 처리가 없어 "Waiting for human approval..." 로그가 수백 줄 찍히는 문제가 있었습니다.
+
+### 18-3. step 함수 — phase별 디스패치
+
+```go
+func (a *Autopilot) step(ctx context.Context, projectID string, iteration int) bool {
+    p, _ := a.store.Get(projectID)
+    switch p.Phase {
+    case "planning":
+        return a.stepPlanning(ctx, p, iteration)
+    case "awaiting_approval":
+        // 상태 메시지 1회만 출력
+        return false
+    case "executing":
+        return a.stepExecuting(ctx, p, iteration)
+    case "reviewing":
+        return a.stepReviewing(ctx, p, iteration)
+    case "completed", "cancelled":
+        return true // 루프 종료
+    }
+}
+```
+
+`step`이 `true`를 반환하면 루프가 종료됩니다.
+
+### 18-4. stepPlanning — 계획 생성
+
+```go
+plan, err := a.planner(ctx, p)
+// plan.Tasks → board에 저장
+// plan.Deliverables → DELIVERABLES.json에 저장
+// phase → "awaiting_approval"
+```
+
+PlanGenerator가 반환하는 `PlanResult`에는 태스크와 산출물 명세가 함께 들어있습니다. (산출물 상세는 Step 19에서)
+
+### 18-5. stepExecuting — 태스크 실행
+
+```go
+for i, task := range board.Tasks {
+    if task.Status != "todo" { continue }
+
+    board.Tasks[i].Status = "in_progress"
+    err := a.runner(ctx, p.ID, task, taskDeliverables)
+
+    if err != nil {
+        // 재시도 카운터 증가
+        // 3회 실패 시 스킵
+        return false
+    }
+
+    board.Tasks[i].Status = "done"
+    return false // 다음 iteration에서 다음 태스크
+}
+```
+
+**한 iteration에 한 태스크만 실행합니다.** 이유:
+- LLM 호출이 오래 걸릴 수 있음
+- 중간에 pause/cancel 체크 가능
+- SSE로 진행 상태를 실시간 전파 가능
+
+**실패 재시도:** 같은 태스크가 3번 연속 실패하면 "done"으로 스킵 처리하고 `task_skipped` 활동 로그를 남깁니다. 초기 구현에서 API 에러가 나면 무한 재시도하는 문제가 있었습니다.
+
+### 18-6. stepReviewing — 목표 평가
+
+```go
+done, reason, err := a.evaluator(ctx, p, completed)
+if done {
+    // phase → "completed"
+    return true
+}
+// phase → "planning" (재계획)
+return false
+```
+
+GoalEvaluator가 `false`를 반환하면 다시 `planning`으로 돌아갑니다. 이것이 **재계획 루프**입니다.
+
+### 18-7. LLM 콜백 구현 (server.go)
+
+**PlanGenerator:**
+
+```go
+func newLLMPlanGenerator(client llm.Client) project.PlanGenerator {
+    return func(ctx context.Context, p *project.Project) (*project.PlanResult, error) {
+        prompt := "You are a project planner..."
+        resp, _ := client.Chat(ctx, messages, llm.ChatOptions{})
+        // JSON 파싱 → PlanResult
+    }
+}
+```
+
+**TaskRunner:** agent loop을 사용합니다.
+
+```go
+func newLLMTaskRunner(...) project.TaskRunner {
+    return func(ctx context.Context, projectID string, task project.BoardTask, deliverables []project.Deliverable) error {
+        loop := agent.NewLoop(client, registry)
+        resp, err := loop.Run(ctx, messages, agent.RunOptions{Tools: registry.Schemas()})
+        // transcript에 결과 저장
+    }
+}
+```
+
+TaskRunner는 단순 Chat이 아니라 **Agent Loop**을 사용합니다. 도구를 호출하면서 태스크를 수행하기 때문입니다.
+
+## 디버깅 팁
+
+Autopilot 디버깅 시 서버 로그의 `[autopilot]` 프리픽스를 grep하면 상태 전이를 추적할 수 있습니다:
+
+```bash
+go run ./cmd/tars/ serve --config ... 2>&1 | grep "\[autopilot\]"
+```
+
+## 체크포인트
+
+- [x] autopilot이 planning → awaiting_approval로 전이한다
+- [x] 승인 후 executing에서 태스크를 자동 실행한다
+- [x] 3회 연속 실패 시 태스크를 스킵한다
+- [x] reviewing에서 목표 미달 시 re-planning이 동작한다
+
+## 다음 단계
+
+상태 머신이 돌아가지만, `awaiting_approval`에서 승인할 방법이 API뿐입니다. Step 19에서 Human-in-the-loop 제어와 산출물 시스템을 만듭니다.

--- a/docs/tutorials/19-human-in-the-loop.md
+++ b/docs/tutorials/19-human-in-the-loop.md
@@ -1,0 +1,184 @@
+# Step 19. Human-in-the-loop + 산출물
+
+> 학습 목표: 사용자 승인 게이트와 LLM 기반 산출물 명세 시스템을 구현
+
+## 왜 Human-in-the-loop인가
+
+Step 18에서 Autopilot이 자동으로 계획하고 실행하는 루프를 만들었습니다. 하지만 AI가 만든 계획을 **검토 없이 바로 실행하면 위험**합니다:
+
+- 엉뚱한 태스크를 만들 수 있음
+- 의도하지 않은 파일을 생성할 수 있음
+- API 비용이 낭비될 수 있음
+
+그래서 `planning → executing` 사이에 **`awaiting_approval` 게이트**를 둡니다. 사용자가 계획을 확인하고 Approve/Reject를 결정합니다.
+
+## 제어 API
+
+5개의 POST 엔드포인트:
+
+| 엔드포인트 | 전이 | 조건 |
+|-----------|------|------|
+| `POST /api/projects/{id}/approve` | awaiting_approval → executing | phase == awaiting_approval |
+| `POST /api/projects/{id}/reject` | awaiting_approval → planning | phase == awaiting_approval |
+| `POST /api/projects/{id}/pause` | * → paused | phase != completed/cancelled |
+| `POST /api/projects/{id}/resume` | paused → executing | phase == paused |
+| `POST /api/projects/{id}/cancel` | * → cancelled | 언제든 |
+
+### Approve
+
+```go
+func (a *Autopilot) Approve(projectID string) error {
+    p, _ := a.store.Get(projectID)
+    if p.Phase != "awaiting_approval" {
+        return fmt.Errorf("cannot approve: phase is %s", p.Phase)
+    }
+    a.store.SetPhase(projectID, "executing")
+    a.emit("phase_changed", ...)
+    return nil
+}
+```
+
+### Reject
+
+```go
+func (a *Autopilot) Reject(projectID string) error {
+    // 보드 초기화 (기존 태스크 삭제)
+    a.store.UpdateBoard(projectID, []BoardTask{})
+    // planning으로 되돌림 → LLM이 다시 계획 생성
+    a.store.SetPhase(projectID, "planning")
+    return nil
+}
+```
+
+Reject 시 보드를 **완전히 초기화**합니다. LLM이 처음부터 다시 계획을 세우게 됩니다.
+
+## 산출물 (Deliverables)
+
+### 문제: 프로젝트마다 산출물이 다르다
+
+- 소설 프로젝트 → `story.md`, `outline.md`
+- 코딩 프로젝트 → `main.go`, `handler.go`, `README.md`
+- 이미지 프로젝트 → `concept.md`, `prompt.txt`
+
+산출물의 개수, 파일명, 포맷을 하드코딩할 수 없습니다. **LLM이 계획 단계에서 결정**하게 합니다.
+
+### Deliverable 타입
+
+```go
+type Deliverable struct {
+    ID          string `json:"id"`
+    Path        string `json:"path"`        // output/ 기준 상대경로
+    Format      string `json:"format"`      // md, go, py, png, ...
+    Description string `json:"description"` // 설명
+    TaskID      string `json:"task_id"`     // 어떤 태스크가 생성하는지
+}
+```
+
+### 계획 단계에서 생성
+
+PlanGenerator가 태스크와 산출물을 **함께** 생성합니다:
+
+```go
+type PlanResult struct {
+    Tasks        []BoardTask   `json:"tasks"`
+    Deliverables []Deliverable `json:"deliverables"`
+}
+```
+
+LLM 프롬프트:
+
+```
+Generate 3-7 actionable tasks AND a list of deliverables.
+Respond in JSON:
+{
+  "tasks": [...],
+  "deliverables": [
+    {"id":"d-1","path":"outline.md","format":"md",
+     "description":"소설 구성 개요","task_id":"task-2"}
+  ]
+}
+```
+
+### 승인 화면에서 확인
+
+사용자는 `awaiting_approval` 상태에서 태스크 목록 **+ 산출물 명세**를 함께 봅니다:
+
+```
+Tasks:
+  - task-1: 소나기 원작 분석
+  - task-2: 개요 작성
+  - task-3: 본문 집필
+
+Deliverables:
+  📄 outline.md — 소설 구성 개요 (md)
+  📄 story.md — 완성된 단편소설 (md)
+```
+
+이 정보를 보고 Approve/Reject를 결정합니다.
+
+### 실행 시 산출물 경로 전달
+
+TaskRunner에 해당 태스크의 산출물 목록을 전달합니다:
+
+```go
+// stepExecuting에서
+deliverables, _ := a.store.GetDeliverables(p.ID)
+var taskDeliverables []Deliverable
+for _, d := range deliverables {
+    if d.TaskID == task.ID {
+        taskDeliverables = append(taskDeliverables, d)
+    }
+}
+a.runner(ctx, p.ID, task, taskDeliverables)
+```
+
+TaskRunner의 시스템 프롬프트에 산출물 경로가 포함됩니다:
+
+```
+Deliverables to produce:
+- d-2: 소설 구성 개요 (format: md)
+  → write to: .workspace/projects/{id}/output/outline.md
+
+IMPORTANT: Use the write_file tool to save each deliverable.
+```
+
+### 저장 구조
+
+```
+.workspace/projects/{id}/
+├── PROJECT.md
+├── KANBAN.md
+├── ACTIVITY.jsonl
+├── DELIVERABLES.json      ← 산출물 명세
+├── AUTOPILOT.json         ← 실행 상태
+└── output/                ← 산출물 파일
+    ├── outline.md
+    └── story.md
+```
+
+## 전체 흐름
+
+```
+1. 사용자가 Autopilot Start
+2. planning: LLM이 tasks + deliverables 생성
+3. awaiting_approval: 대시보드에서 확인
+   ├─ Approve → executing
+   └─ Reject → planning (보드 초기화, 재계획)
+4. executing: 태스크별로 실행, deliverable 경로를 프롬프트에 포함
+5. reviewing: 목표 달성 평가
+   ├─ done → completed
+   └─ not done → planning (재계획)
+```
+
+## 체크포인트
+
+- [x] 대시보드에서 Approve/Reject 버튼이 표시된다
+- [x] 승인 화면에서 산출물 명세를 확인할 수 있다
+- [x] Reject 시 태스크가 초기화되고 re-planning이 진행된다
+- [ ] 실행 완료 후 output/ 디렉토리에 산출물 파일이 존재한다
+
+> output/ 파일 생성은 LLM이 `write_file` 도구를 올바르게 호출하는지에 의존합니다. 경로를 프롬프트에 명시했지만, 모델에 따라 도구 호출을 건너뛸 수 있습니다.
+
+## 다음 단계
+
+승인/거절과 산출물 시스템이 완성되었습니다. Step 20에서는 이 모든 상태 변경을 대시보드에 **실시간으로** 전달하는 SSE 이벤트 시스템을 만듭니다.

--- a/docs/tutorials/20-sse-realtime.md
+++ b/docs/tutorials/20-sse-realtime.md
@@ -1,0 +1,232 @@
+# Step 20. SSE 실시간 이벤트
+
+> 학습 목표: Server-Sent Events로 서버 상태를 클라이언트에 실시간 푸시
+
+## 왜 SSE인가
+
+Step 18-19에서 Autopilot이 상태를 바꾸고, 사용자가 승인/거절을 합니다. 하지만 대시보드가 이 변화를 **알 방법이 없습니다.** 폴링(5초마다 API 호출)으로 해결할 수 있지만:
+
+- 불필요한 API 호출이 많음
+- 5초 지연이 생김
+- 서버 부하 증가
+
+**SSE(Server-Sent Events)**는 HTTP 연결을 열어두고 서버가 **이벤트를 푸시**하는 프로토콜입니다. WebSocket보다 단순하고, 단방향(서버→클라이언트) 통신에 적합합니다.
+
+## SSE 프로토콜
+
+```
+GET /api/stream
+→ 200 OK
+→ Content-Type: text/event-stream
+
+event: phase_changed
+data: {"project_id":"abc","phase":"executing"}
+
+event: board_updated
+data: {"project_id":"abc"}
+
+event: autopilot_status
+data: {"project_id":"abc","status":"running","phase":"executing","message":"Executing: task-1"}
+```
+
+규칙:
+- `event:` 줄이 이벤트 타입
+- `data:` 줄이 JSON 페이로드
+- 빈 줄이 이벤트 구분자
+- 연결은 클라이언트가 끊을 때까지 유지
+
+## 실습
+
+### 20-1. SSEBroker — Go 서버
+
+**`internal/server/sse_broker.go`**
+
+Pub/Sub 패턴: 클라이언트가 Subscribe, Autopilot이 Broadcast.
+
+```go
+type SSEEvent struct {
+    Type string `json:"type"`
+    Data any    `json:"data"`
+}
+
+type SSEBroker struct {
+    mu      sync.RWMutex
+    clients map[chan SSEEvent]struct{}
+}
+```
+
+**Subscribe:** HTTP 핸들러가 채널을 등록하고 이벤트를 기다립니다.
+
+```go
+func (b *SSEBroker) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+    w.Header().Set("Content-Type", "text/event-stream")
+    w.Header().Set("Cache-Control", "no-cache")
+
+    ch := make(chan SSEEvent, 16)
+    b.subscribe(ch)
+    defer b.unsubscribe(ch)
+
+    for {
+        select {
+        case <-r.Context().Done():
+            return
+        case event := <-ch:
+            data, _ := json.Marshal(event.Data)
+            fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event.Type, data)
+            flusher.Flush()
+        }
+    }
+}
+```
+
+**Broadcast:** 모든 클라이언트 채널에 이벤트를 보냅니다.
+
+```go
+func (b *SSEBroker) Broadcast(event SSEEvent) {
+    b.mu.RLock()
+    defer b.mu.RUnlock()
+    for ch := range b.clients {
+        select {
+        case ch <- event:
+        default: // 채널이 가득 차면 스킵
+        }
+    }
+}
+```
+
+채널 버퍼(16)가 가득 차면 이벤트를 버립니다. 느린 클라이언트 때문에 서버가 블록되는 걸 방지합니다.
+
+### 20-2. Autopilot → SSEBroker 연결
+
+```go
+autopilot.SetEmitter(func(eventType string, data any) {
+    sseBroker.Broadcast(SSEEvent{Type: eventType, Data: data})
+})
+```
+
+Autopilot은 `EventEmitter` 콜백만 호출합니다. SSE 프로토콜을 알 필요가 없습니다.
+
+### 20-3. 이벤트 종류
+
+| 이벤트 | 발생 시점 | 클라이언트 동작 |
+|--------|----------|----------------|
+| `phase_changed` | phase 전이 | 프로젝트 목록 새로고침 |
+| `board_updated` | 태스크 변경 | 보드 새로고침 |
+| `activity` | 태스크 완료 등 | 활동 로그 새로고침 |
+| `autopilot_status` | 상태 변경마다 | Autopilot 상태 업데이트 |
+
+### 20-4. Swift SSE 클라이언트
+
+**`dashboard/Sources/APIClient.swift`**
+
+`URLSession`으로 SSE 스트림을 읽습니다.
+
+```swift
+private let sseSession: URLSession = {
+    let config = URLSessionConfiguration.default
+    config.timeoutIntervalForRequest = 3600  // 1시간
+    config.timeoutIntervalForResource = 3600
+    return URLSession(configuration: config)
+}()
+```
+
+**핵심:** `URLSession.shared`의 기본 타임아웃은 60초입니다. SSE처럼 데이터가 간헐적으로 오는 long-lived 연결에서는 타임아웃됩니다. 전용 세션을 만들어 1시간으로 설정합니다.
+
+```swift
+private func listenSSE() async {
+    let (bytes, _) = try await sseSession.bytes(from: url)
+
+    var eventType = ""
+    for try await line in bytes.lines {
+        if line.hasPrefix("event: ") {
+            eventType = String(line.dropFirst(7))
+        } else if line.hasPrefix("data: ") {
+            let data = String(line.dropFirst(6))
+            handleSSEEvent(type: eventType, data: data)
+            eventType = ""
+        }
+    }
+}
+```
+
+SSE 파싱은 Step 15의 터미널 채팅 클라이언트와 **동일한 패턴**입니다. `event:` → `data:` → 처리.
+
+### 20-5. 이벤트 처리 — 데이터 새로고침
+
+```swift
+private func handleSSEEvent(type: String, data: String) {
+    switch type {
+    case "phase_changed", "board_updated", "activity":
+        Task {
+            await fetchProjects()
+            if let board = currentBoard {
+                await fetchBoard(projectID: board.projectID)
+            }
+        }
+    default:
+        break
+    }
+}
+```
+
+이벤트를 받으면 관련 데이터를 다시 fetch합니다. 이벤트 페이로드에 전체 데이터를 넣지 않고 **"변경됐다"는 신호만** 보내는 것이 핵심입니다.
+
+### 20-6. 자동 재연결
+
+```swift
+} catch {
+    if !Task.isCancelled {
+        try? await Task.sleep(for: .seconds(3))
+        if !Task.isCancelled {
+            await listenSSE() // 재귀 호출로 재연결
+        }
+    }
+}
+```
+
+연결이 끊기면 3초 후 자동 재연결합니다.
+
+### 20-7. Stale 데이터 문제와 해결
+
+Phase 5에서 겪은 주요 버그: 대시보드의 프로젝트 상세 화면이 **navigation 시점의 스냅샷**을 보여주고, SSE 이벤트로 데이터가 갱신되어도 화면이 바뀌지 않았습니다.
+
+**원인:**
+```swift
+// App.swift
+case .detail(let project):  // ← project는 navigation 시점의 복사본
+    ProjectDetailView(project: project, ...)
+```
+
+**해결:** project 객체 대신 **ID만 저장**하고, 매번 최신 데이터에서 조회:
+
+```swift
+case .detail(let projectID):
+    if let project = client.projects.first(where: { $0.id == projectID }) {
+        ProjectDetailView(project: project, ...)
+    }
+```
+
+이렇게 하면 SSE 이벤트로 `client.projects`가 갱신될 때 SwiftUI가 자동으로 뷰를 다시 렌더링합니다.
+
+## 전체 데이터 흐름
+
+```
+Autopilot (상태 변경)
+    → EventEmitter 콜백
+    → SSEBroker.Broadcast()
+    → 연결된 모든 클라이언트 채널
+    → HTTP text/event-stream 응답
+    → Swift URLSession.bytes.lines
+    → handleSSEEvent → fetchProjects/fetchBoard
+    → SwiftUI @Observable → 뷰 갱신
+```
+
+## 체크포인트
+
+- [x] 서버 이벤트가 대시보드에 실시간 반영된다
+- [x] 연결 끊김 시 자동 재연결된다
+- [x] SSE 연결이 60초 이상 안정적으로 유지된다
+
+## 다음 단계
+
+Phase 6이 완성되었습니다. 프로젝트를 생성하고, AI가 자율적으로 계획/실행하며, 사용자가 대시보드에서 실시간으로 감독할 수 있습니다. Phase 7에서는 인증, 비동기 실행, TUI 클라이언트 등 운영 환경에 필요한 기능을 추가합니다.

--- a/docs/tutorials/21-auth-middleware.md
+++ b/docs/tutorials/21-auth-middleware.md
@@ -1,0 +1,271 @@
+# Step 21. 인증 미들웨어
+
+> 학습 목표: Bearer token 기반 인증 미들웨어를 구현하고, 경로별 접근 제어를 적용
+
+## 왜 인증이 필요한가
+
+Phase 1-6까지 TARS 서버는 **누구나 접근 가능**했습니다. 로컬 개발에서는 괜찮지만, 운영 환경에서는:
+
+- 외부에서 LLM API 호출을 악용할 수 있음 (비용 발생)
+- `write_file`, `exec` 도구로 서버 파일 시스템을 조작할 수 있음
+- Autopilot을 무단으로 시작/중단할 수 있음
+
+**Bearer token 인증**은 가장 단순하면서 효과적인 API 인증 방식입니다.
+
+## Bearer Token 인증 흐름
+
+```
+클라이언트                             서버
+    │                                   │
+    │ GET /v1/chat                      │
+    │ Authorization: Bearer <token>     │
+    │ ─────────────────────────────────→│
+    │                                   │ token 검증
+    │                     200 OK        │
+    │ ←─────────────────────────────────│
+    │                                   │
+    │ GET /v1/chat (토큰 없음)           │
+    │ ─────────────────────────────────→│
+    │                                   │ 401 Unauthorized
+    │ ←─────────────────────────────────│
+```
+
+## 실습
+
+### 21-1. 보안 원칙: 토큰 비교
+
+토큰을 비교할 때 두 가지 보안 원칙을 지켜야 합니다:
+
+**1. 원문 저장 금지 — SHA-256 해싱**
+
+```go
+tokenHash := sha256.Sum256([]byte(token))
+```
+
+메모리에 토큰 원문을 들고 있으면 메모리 덤프에 노출될 수 있습니다. 서버 시작 시 해시만 저장합니다.
+
+**2. Timing attack 방지 — constant-time 비교**
+
+```go
+// ❌ 위험: 일반 비교 (앞에서부터 틀린 바이트에서 즉시 반환)
+if providedToken == expectedToken { ... }
+
+// ✅ 안전: constant-time 비교 (항상 전체를 비교)
+providedHash := sha256.Sum256([]byte(provided))
+if subtle.ConstantTimeCompare(providedHash[:], tokenHash[:]) != 1 {
+    // 거부
+}
+```
+
+일반 `==` 비교는 첫 번째 다른 바이트에서 즉시 반환합니다. 공격자가 응답 시간을 측정하면 한 바이트씩 토큰을 추론할 수 있습니다. `crypto/subtle.ConstantTimeCompare`는 입력에 관계없이 항상 동일한 시간이 걸립니다.
+
+### 21-2. 미들웨어 구조
+
+**`internal/auth/middleware.go`**
+
+```go
+type Options struct {
+    Mode       string   // off, required
+    Token      string   // Bearer token 원문
+    SkipPaths  []string // 인증 건너뛰는 경로 (예: /health)
+    AdminPaths []string // admin 전용 경로 (예: /v1/admin/*)
+}
+
+type middleware struct {
+    mode       string
+    tokenHash  [32]byte   // SHA-256 해시만 저장
+    hasToken   bool
+    skipPaths  pathMatcher
+    adminPaths pathMatcher
+}
+```
+
+핵심 설계:
+- `Options`는 외부 설정 (원문 포함)
+- `middleware`는 내부 상태 (해시만 보유)
+- 생성 시점에 해싱하고, 원문은 GC에 의해 회수됨
+
+### 21-3. 인증 체크 로직
+
+```go
+func (m *middleware) check(r *http.Request) *authError {
+    path := r.URL.Path
+
+    // 1. skip paths → 무조건 통과
+    if m.skipPaths.match(path) {
+        return nil
+    }
+
+    // 2. mode off → 통과
+    if m.mode == ModeOff {
+        return nil
+    }
+
+    // 3. 토큰 미설정 + required → 서버 설정 오류
+    if !m.hasToken {
+        return &authError{Status: 401, Code: "no_token_configured", ...}
+    }
+
+    // 4. Authorization 헤더 파싱
+    provided := parseBearerToken(r.Header.Get("Authorization"))
+    if provided == "" {
+        return &authError{Status: 401, Code: "missing_token", ...}
+    }
+
+    // 5. constant-time 비교
+    providedHash := sha256.Sum256([]byte(provided))
+    if subtle.ConstantTimeCompare(providedHash[:], m.tokenHash[:]) != 1 {
+        return &authError{Status: 401, Code: "invalid_token", ...}
+    }
+
+    return nil
+}
+```
+
+순서가 중요합니다:
+1. **skip paths 먼저** — `/health` 같은 헬스체크는 인증 없이 통과
+2. **mode 체크** — off면 전체 통과
+3. **토큰 설정 여부** — required인데 토큰이 없으면 서버 설정 문제
+4. **헤더 파싱** — `Bearer ` 접두사 제거, case-insensitive
+5. **비교** — SHA-256 + constant-time
+
+### 21-4. 경로 매칭 (Path Matcher)
+
+```go
+type pathMatcher struct {
+    exact    map[string]struct{}  // /health → 정확히 일치
+    prefixes []string             // /public/* → 접두사 매칭
+}
+```
+
+`compilePaths`가 경로를 분류합니다:
+- `*`로 끝나면 → prefix 매칭 (`/public/*` → `/public/docs/readme` 매칭)
+- 그 외 → 정확한 일치 (`/health` → `/health`만 매칭)
+
+`strings.CutSuffix`를 사용하면 `HasSuffix` + `TrimSuffix`를 한 번에 처리할 수 있습니다:
+
+```go
+if prefix, ok := strings.CutSuffix(p, "*"); ok {
+    m.prefixes = append(m.prefixes, prefix)
+} else {
+    m.exact[p] = struct{}{}
+}
+```
+
+### 21-5. Bearer 파싱
+
+```go
+func parseBearerToken(header string) string {
+    if len(header) < 7 {
+        return ""
+    }
+    if !strings.EqualFold(header[:7], "bearer ") {
+        return ""
+    }
+    return strings.TrimSpace(header[7:])
+}
+```
+
+`strings.EqualFold`로 case-insensitive 비교합니다. RFC 6750에 따르면 "Bearer"는 case-insensitive입니다.
+
+### 21-6. 에러 응답
+
+```go
+func writeAuthError(w http.ResponseWriter, e *authError) {
+    if e.Status == http.StatusUnauthorized {
+        w.Header().Set("WWW-Authenticate", "Bearer")
+    }
+    w.Header().Set("Content-Type", "application/json")
+    w.WriteHeader(e.Status)
+    json.NewEncoder(w).Encode(map[string]string{
+        "error": e.Message,
+        "code":  e.Code,
+    })
+}
+```
+
+401 응답에는 반드시 `WWW-Authenticate: Bearer` 헤더를 포함해야 합니다 (RFC 6750).
+
+### 21-7. 서버 연결
+
+**설정 (config.go)**
+
+```go
+type Config struct {
+    // ...
+    AuthMode  string `yaml:"auth_mode"`  // off, required (default: off)
+    AuthToken string `yaml:"auth_token"` // Bearer token
+}
+```
+
+환경 변수로도 설정 가능:
+
+```bash
+MYCLAW_AUTH_MODE=required MYCLAW_AUTH_TOKEN=my-secret-token tars serve
+```
+
+**미들웨어 적용 (server.go)**
+
+```go
+authOpts := auth.Options{
+    Mode:      cfg.AuthMode,
+    Token:     cfg.AuthToken,
+    SkipPaths: []string{"/health"},
+}
+handler := auth.NewMiddleware(authOpts, mux)
+```
+
+`/health`는 로드밸런서/모니터링이 인증 없이 사용하므로 skip 경로에 등록합니다.
+
+### 21-8. 테스트
+
+```go
+func TestModeOff(t *testing.T) {
+    h := NewMiddleware(Options{Mode: ModeOff}, okHandler())
+    req := httptest.NewRequest("GET", "/v1/chat", nil)
+    rec := httptest.NewRecorder()
+    h.ServeHTTP(rec, req)
+    if rec.Code != 200 { t.Fatalf("expected 200, got %d", rec.Code) }
+}
+
+func TestRequiredWithValidToken(t *testing.T) {
+    h := NewMiddleware(Options{Mode: ModeRequired, Token: "secret"}, okHandler())
+    req := httptest.NewRequest("GET", "/v1/chat", nil)
+    req.Header.Set("Authorization", "Bearer secret")
+    rec := httptest.NewRecorder()
+    h.ServeHTTP(rec, req)
+    if rec.Code != 200 { t.Fatalf("expected 200, got %d", rec.Code) }
+}
+```
+
+테스트할 시나리오:
+1. **mode off** → 모든 요청 통과
+2. **required + 토큰 없음** → 401
+3. **required + 유효 토큰** → 200
+4. **required + 잘못된 토큰** → 401
+5. **skip path** → 인증 없이 통과
+6. **wildcard skip** → 접두사 매칭 통과
+7. **Bearer 대소문자** → case-insensitive
+8. **토큰 미설정 + required** → 401
+
+## TARS 원본과의 차이
+
+| 항목 | TARS | TARS |
+|------|------|--------|
+| 토큰 종류 | Bearer + User + Admin (3종) | Bearer 1종 |
+| 인증 모드 | off, required, external-required | off, required |
+| 로깅 | zerolog | fmt 출력 |
+| loopback 감지 | 127.0.0.1 자동 통과 | 미구현 |
+
+TARS는 최소 버전으로, 단일 토큰만 사용합니다. 향후 user/admin 토큰 분리는 `check()` 메서드의 6번 단계에서 확장할 수 있습니다.
+
+## 체크포인트
+
+- [x] `MYCLAW_AUTH_MODE=required` 설정 시 토큰 없는 요청이 401로 거부된다
+- [x] 유효한 Bearer 토큰을 보내면 200으로 통과한다
+- [x] `/health` 경로는 인증 없이 접근 가능하다
+- [x] 8개 테스트 케이스가 모두 통과한다
+
+## 다음 단계
+
+Step 22에서는 Gateway (비동기 실행)를 구현합니다. 장시간 실행되는 작업을 백그라운드에서 처리하고, 실행 상태를 관리하는 시스템입니다.

--- a/docs/tutorials/22-gateway.md
+++ b/docs/tutorials/22-gateway.md
@@ -1,0 +1,308 @@
+# Step 22. Gateway (비동기 실행)
+
+> 학습 목표: 비동기 Run 라이프사이클을 관리하는 Gateway 런타임을 구현
+
+## 왜 Gateway인가
+
+지금까지 TARS의 채팅(`/v1/chat`)은 **동기 SSE** 방식입니다. 클라이언트가 요청을 보내고, LLM 응답이 끝날 때까지 연결을 유지합니다. 이 방식은:
+
+- 긴 작업(Autopilot 등)에서 HTTP 타임아웃 위험
+- 클라이언트가 연결을 끊으면 작업이 중단됨
+- 여러 작업을 동시에 실행할 수 없음
+
+**Gateway**는 작업을 **비동기 Run**으로 관리합니다:
+
+```
+클라이언트                              Gateway
+    │ POST /v1/agent/runs               │
+    │ {"prompt":"분석해줘"}              │
+    │ ──────────────────────────────────→│
+    │                                    │ Run 생성 (accepted)
+    │ ← 202 {"id":"run_1", ...}         │
+    │                                    │ goroutine에서 실행 (running)
+    │ GET /v1/agent/runs/run_1          │
+    │ ──────────────────────────────────→│
+    │ ← 200 {"status":"completed",...}  │
+```
+
+클라이언트가 연결을 끊어도 Run은 서버에서 계속 실행됩니다.
+
+## 핵심 개념
+
+### Run 라이프사이클
+
+```
+accepted → running → completed
+                   → failed
+                   → canceled
+```
+
+- **accepted**: Spawn 직후, goroutine 시작 전
+- **running**: executor 실행 중
+- **completed**: 성공 (response 포함)
+- **failed**: 에러 발생 (error 포함)
+- **canceled**: Cancel API 또는 context 취소
+
+### 구성 요소
+
+```
+Runtime (상태 관리)
+    ├── runs map[string]*runState     ← 모든 Run 추적
+    ├── executors map[string]Executor ← 실행기 등록
+    └── channelMsgs                   ← 채널 메시지
+
+AgentExecutor (인터페이스)
+    └── PromptExecutor               ← agent.Loop 기반
+
+Handler (HTTP API)
+    ├── POST /v1/agent/runs          ← Spawn
+    ├── GET  /v1/agent/runs          ← List
+    ├── GET  /v1/agent/runs/{id}     ← Get
+    └── POST /v1/agent/runs/{id}/cancel ← Cancel
+```
+
+## 실습
+
+### 22-1. Run 타입
+
+```go
+type Run struct {
+    ID          string    `json:"id"`
+    Status      RunStatus `json:"status"`
+    SessionID   string    `json:"session_id"`
+    ProjectID   string    `json:"project_id,omitempty"`
+    Agent       string    `json:"agent"`
+    Prompt      string    `json:"prompt"`
+    Response    string    `json:"response,omitempty"`
+    Error       string    `json:"error,omitempty"`
+    CreatedAt   time.Time `json:"created_at"`
+    StartedAt   time.Time `json:"started_at,omitzero"`
+    CompletedAt time.Time `json:"completed_at,omitzero"`
+}
+```
+
+`omitzero`를 사용합니다. `omitempty`는 `time.Time` 같은 struct 타입에서는 zero value도 포함시키지만, `omitzero`(Go 1.24+)는 zero value를 생략합니다.
+
+### 22-2. 런타임 내부 상태
+
+```go
+type runState struct {
+    run    Run
+    cancel context.CancelFunc  // 취소용
+    done   chan struct{}        // 완료 신호
+    closed bool
+}
+```
+
+각 Run은 세 가지 동기화 수단을 가집니다:
+- **cancel**: `context.WithCancel`에서 받은 취소 함수
+- **done**: 실행 완료 시 닫히는 채널 (Wait에서 사용)
+- **closed**: done 중복 close 방지 플래그
+
+### 22-3. Spawn — 비동기 실행
+
+```go
+func (rt *Runtime) Spawn(ctx context.Context, req SpawnRequest) (*Run, error) {
+    // 1. 동시 실행 제한 확인
+    // 2. executor 선택
+    // 3. Run 생성 (accepted)
+    // 4. goroutine 시작
+    // 5. Run 즉시 반환
+}
+```
+
+**동시 실행 제한**은 서버 리소스 보호를 위해 필수입니다:
+
+```go
+active := 0
+for _, rs := range rt.runs {
+    if rs.run.Status == RunStatusAccepted || rs.run.Status == RunStatusRunning {
+        active++
+    }
+}
+if active >= maxConcurrentRuns {
+    return nil, fmt.Errorf("too many concurrent runs")
+}
+```
+
+**Run ID는 atomic counter**로 생성합니다:
+
+```go
+seq := rt.runSeq.Add(1)  // lock-free
+runID := fmt.Sprintf("run_%d", seq)
+```
+
+`sync/atomic`은 mutex보다 가볍고, ID 생성처럼 단순한 카운터에 적합합니다.
+
+### 22-4. 실행 goroutine
+
+```go
+func (rt *Runtime) executeRun(ctx context.Context, rs *runState, exec AgentExecutor) {
+    defer func() {
+        if !rs.closed {
+            rs.closed = true
+            close(rs.done)  // Wait() 해제
+        }
+    }()
+
+    // running 상태로 전이
+    rt.mu.Lock()
+    rs.run.Status = RunStatusRunning
+    rs.run.StartedAt = time.Now().UTC()
+    rt.mu.Unlock()
+
+    // 실행
+    resp, err := exec.Execute(ctx, ...)
+
+    // 결과에 따라 completed/failed/canceled
+    rt.mu.Lock()
+    if ctx.Err() != nil {
+        rs.run.Status = RunStatusCanceled
+    } else if err != nil {
+        rs.run.Status = RunStatusFailed
+    } else {
+        rs.run.Status = RunStatusCompleted
+        rs.run.Response = resp
+    }
+    rt.mu.Unlock()
+}
+```
+
+**핵심**: `ctx.Err()`를 먼저 체크합니다. Cancel이 호출되면 executor도 에러를 반환하지만, 이 경우 `failed`가 아니라 `canceled`로 분류해야 합니다.
+
+### 22-5. Cancel과 Wait
+
+```go
+func (rt *Runtime) Cancel(runID string) error {
+    rs.cancel()  // context 취소 → executor에 전파
+    return nil
+}
+
+func (rt *Runtime) Wait(runID string) (*Run, error) {
+    <-rs.done    // goroutine이 close(done)할 때까지 블록
+    return &rs.run, nil
+}
+```
+
+Go의 context 취소가 goroutine까지 전파되는 흐름:
+
+```
+Cancel() → rs.cancel() → ctx 취소
+                            ↓
+                    executor의 select {
+                    case <-ctx.Done(): return ctx.Err()
+                    }
+                            ↓
+                    executeRun에서 ctx.Err() != nil
+                            ↓
+                    status = RunStatusCanceled
+                            ↓
+                    close(rs.done)
+                            ↓
+                    Wait()의 <-rs.done 해제
+```
+
+### 22-6. AgentExecutor 인터페이스
+
+```go
+type AgentExecutor interface {
+    Name() string
+    Execute(ctx context.Context, req ExecuteRequest) (string, error)
+}
+```
+
+**PromptExecutor**는 기존 `agent.Loop`를 래핑합니다:
+
+```go
+func (e *PromptExecutor) Execute(ctx context.Context, req ExecuteRequest) (string, error) {
+    messages := []llm.ChatMessage{
+        {Role: "system", Content: systemPrompt},
+        {Role: "user", Content: req.Prompt},
+    }
+    loop := agent.NewLoop(e.client, e.registry)
+    resp, err := loop.Run(ctx, messages, agent.RunOptions{Tools: e.registry.Schemas()})
+    return resp.Message.Content, err
+}
+```
+
+인터페이스를 사용하면 향후 다른 실행기(외부 명령어, HTTP 프록시 등)를 쉽게 추가할 수 있습니다.
+
+### 22-7. 채널 메시지
+
+```go
+func (rt *Runtime) MessageSend(channelID, text string) (*ChannelMessage, error) {
+    msg := ChannelMessage{
+        ID:        fmt.Sprintf("msg_%d", seq),
+        ChannelID: channelID,
+        Direction: "outbound",
+        Source:    "local",
+        Text:      text,
+        Timestamp: time.Now().UTC(),
+    }
+    // 채널당 최대 100개, 초과 시 오래된 것 제거
+    msgs = append(msgs, msg)
+    if len(msgs) > maxChannelMessages {
+        msgs = msgs[len(msgs)-maxChannelMessages:]
+    }
+}
+```
+
+채널 메시지는 에이전트가 외부 시스템에 메시지를 보낼 때 사용합니다. 현재는 `local` 소스만 지원하며, 향후 webhook/Telegram 등을 추가할 수 있습니다.
+
+### 22-8. HTTP 핸들러
+
+```go
+// POST /v1/agent/runs — 새 Run 생성
+func (h *Handler) spawnRun(w http.ResponseWriter, r *http.Request) {
+    var req SpawnRequest
+    json.NewDecoder(r.Body).Decode(&req)
+    run, err := h.rt.Spawn(r.Context(), req)
+    writeJSON(w, http.StatusAccepted, run)  // 202 Accepted
+}
+```
+
+**202 Accepted**를 반환합니다. 200이 아닌 이유: 요청을 수락했지만 아직 처리가 완료되지 않았기 때문입니다. REST API에서 비동기 작업의 표준 응답 코드입니다.
+
+### 22-9. 메모리 관리 — Run 트리밍
+
+```go
+func (rt *Runtime) trimRunsLocked() {
+    if len(rt.runOrder) <= maxRuns {
+        return
+    }
+    // 완료된 Run부터 삭제 (활성 Run은 유지)
+    for _, id := range rt.runOrder {
+        if removed < target && !isActive(rs) {
+            delete(rt.runs, id)
+            removed++
+        }
+    }
+}
+```
+
+메모리에만 상태를 유지하므로, maxRuns(200)을 초과하면 완료된 오래된 Run부터 제거합니다. 활성(accepted/running) Run은 절대 제거하지 않습니다.
+
+## TARS 원본과의 차이
+
+| 항목 | TARS | TARS |
+|------|------|--------|
+| 실행기 | PromptExecutor + CommandExecutor | PromptExecutor만 |
+| 채널 | local + webhook + Telegram | local만 |
+| 영속화 | runs.json + channels.json 파일 | 인메모리만 |
+| 세션 라우팅 | caller/new/fixed 모드 | 미구현 |
+| Sub-agent | 계층 구조 (parent/root/depth) | 미구현 |
+| 도구 정책 | executor + project 정책 병합 | 미구현 |
+| 아카이브 | JSONL 일별 로테이션 | 미구현 |
+
+TARS는 핵심 패턴(비동기 Spawn/Wait, Run 라이프사이클, executor 인터페이스)만 구현합니다.
+
+## 체크포인트
+
+- [x] Run을 비동기로 생성하고 완료를 기다릴 수 있다
+- [x] 동시 실행 제한이 동작한다 (4개 초과 시 거부)
+- [x] Cancel API로 실행 중인 Run을 취소할 수 있다
+- [x] 14개 테스트 케이스가 모두 통과한다
+
+## 다음 단계
+
+Step 23에서는 Bubble Tea 기반 TUI 클라이언트를 구현합니다. Gateway API를 사용해서 터미널에서 세션을 선택하고, 실시간 스트리밍을 확인하는 풍부한 인터페이스를 만듭니다.

--- a/docs/tutorials/23-tui-client.md
+++ b/docs/tutorials/23-tui-client.md
@@ -1,0 +1,280 @@
+# Step 23. TUI 클라이언트
+
+> 학습 목표: Bubble Tea로 터미널 기반 대화형 채팅 인터페이스 구현
+
+## 왜 TUI인가
+
+Step 15에서 만든 REPL 채팅 클라이언트는 `fmt` + `bufio`로 최소 동작합니다. 하지만:
+
+- 화면 스크롤이 불가능 (터미널 히스토리에 의존)
+- 스트리밍 중 입력 불가능 (동기 방식)
+- 상태 표시 없음 (세션 ID, 스트리밍 상태)
+- 비주얼 구분 없음 (사용자/AI/시스템 메시지)
+
+**Bubble Tea**는 Go의 가장 인기 있는 TUI 프레임워크로, **Elm Architecture**(Model-Update-View)를 기반으로 합니다.
+
+## Elm Architecture
+
+```
+                ┌───────────────┐
+                │     Model     │ ← 상태
+                └───────┬───────┘
+                        │
+            ┌───────────▼───────────┐
+            │        View()         │ → 문자열 (화면)
+            └───────────────────────┘
+                        ▲
+            ┌───────────┴───────────┐
+            │      Update(msg)      │ ← 이벤트 처리
+            └───────────────────────┘
+                        ▲
+                  KeyMsg, WindowSizeMsg,
+                  커스텀 메시지 ...
+```
+
+1. **Model**: 앱의 전체 상태를 보유하는 struct
+2. **Update**: 메시지를 받아 상태를 변경하고, 다음 명령(Cmd)을 반환
+3. **View**: 현재 상태를 문자열로 렌더링
+
+상태는 **불변적으로** 관리됩니다. Update가 새 상태를 반환하면, Bubble Tea가 View를 다시 호출합니다.
+
+## 실습
+
+### 23-1. 모델 구조
+
+```go
+type Model struct {
+    ctx    context.Context
+    cancel context.CancelFunc
+
+    client    *chatClient
+    sessionID string
+
+    width, height int          // 터미널 크기
+    input         textinput.Model  // 텍스트 입력 컴포넌트
+
+    chatLines    []string      // 채팅 로그
+    scrollOffset int           // 스크롤 위치
+
+    history      []string      // 명령어 히스토리
+    historyPos   int
+    historyDraft string        // 히스토리 탐색 중 현재 입력 보존
+
+    inflight       bool        // 스트리밍 중 여부
+    inflightCancel context.CancelFunc
+
+    asyncCh chan tea.Msg        // 비동기 메시지 채널
+}
+```
+
+**핵심 설계:**
+- `asyncCh`: goroutine에서 Bubble Tea로 메시지를 전달하는 채널 (버퍼 256)
+- `inflight` + `inflightCancel`: 스트리밍 중 Esc로 취소 가능
+- `historyDraft`: ↑키로 히스토리를 탐색할 때 현재 입력을 보존
+
+### 23-2. 비동기 메시지 패턴
+
+Bubble Tea는 **동기 이벤트 루프**입니다. 비동기 작업(HTTP 요청, SSE 스트리밍)은 goroutine에서 실행하고, 결과를 `tea.Msg`로 전달합니다.
+
+```go
+// 커스텀 메시지 타입
+type chatDeltaMsg struct{ chunk string }
+type chatDoneMsg struct { sessionID string; err error }
+
+// asyncCh에서 메시지를 대기하는 Cmd
+func waitAsync(ch <-chan tea.Msg) tea.Cmd {
+    return func() tea.Msg {
+        msg, ok := <-ch
+        if !ok { return nil }
+        return msg
+    }
+}
+```
+
+**흐름:**
+```
+goroutine (SSE 스트리밍)
+    │
+    │ asyncCh <- chatDeltaMsg{chunk: "Hello"}
+    │
+    ▼
+waitAsync() ─── chatDeltaMsg ───→ Update()
+    │                                │
+    │                     appendToLast("Hello")
+    │                                │
+    ▼                                ▼
+waitAsync() (다음 메시지 대기)     View() (화면 갱신)
+```
+
+`waitAsync`가 체인처럼 연결됩니다. Update에서 메시지를 처리한 후, 다시 `waitAsync`를 반환하면 Bubble Tea가 다음 메시지를 기다립니다.
+
+### 23-3. SSE 스트리밍 통합
+
+```go
+func (m *Model) handleSubmit() tea.Cmd {
+    // ...
+    reqCtx, reqCancel := context.WithCancel(m.ctx)
+    m.inflightCancel = reqCancel
+
+    go func() {
+        newSID, err := client.stream(reqCtx, sessionID, text,
+            func(evt chatEvent) {
+                switch evt.Type {
+                case "delta":
+                    // JSON 파싱 → asyncCh에 전송
+                    select {
+                    case asyncCh <- chatDeltaMsg{chunk: d.Text}:
+                    case <-reqCtx.Done():  // 취소되면 무시
+                    }
+                }
+            },
+        )
+        asyncCh <- chatDoneMsg{sessionID: newSID, err: err}
+    }()
+
+    return nil
+}
+```
+
+**`select` + `ctx.Done()`**: 요청이 취소되면 채널 전송을 건너뜁니다. 이게 없으면 취소된 goroutine이 asyncCh에 계속 쓰려고 블록될 수 있습니다.
+
+### 23-4. 키 입력 처리
+
+```go
+func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+    switch msg.Type {
+    case tea.KeyCtrlC:
+        if m.inflight {
+            m.inflightCancel()  // 스트리밍 취소
+            return m, waitAsync(m.asyncCh)
+        }
+        return m, tea.Quit  // 종료
+
+    case tea.KeyEscape:
+        if m.inflight {
+            m.inflightCancel()  // 스트리밍 취소
+        } else {
+            m.input.SetValue("")  // 입력 지우기
+        }
+
+    case tea.KeyEnter:
+        return m, m.handleSubmit()
+
+    case tea.KeyUp:
+        m.navigateHistory(-1)  // 이전 명령어
+    case tea.KeyDown:
+        m.navigateHistory(1)   // 다음 명령어
+
+    case tea.KeyPgUp:
+        m.scroll(m.chatAreaHeight())   // 페이지 위로
+    case tea.KeyPgDown:
+        m.scroll(-m.chatAreaHeight())  // 페이지 아래로
+    }
+}
+```
+
+### 23-5. 히스토리 탐색
+
+```go
+func (m *Model) navigateHistory(dir int) bool {
+    // 현재 위치가 끝(새 입력 중)이면 현재 입력을 저장
+    if m.historyPos == len(m.history) {
+        m.historyDraft = m.input.Value()
+    }
+
+    newPos := m.historyPos + dir
+    if newPos < 0 || newPos > len(m.history) {
+        return false
+    }
+
+    m.historyPos = newPos
+    if newPos == len(m.history) {
+        m.input.SetValue(m.historyDraft)  // 저장해둔 입력 복원
+    } else {
+        m.input.SetValue(m.history[newPos])
+    }
+    m.input.CursorEnd()
+    return true
+}
+```
+
+`historyDraft`가 핵심입니다. 사용자가 "hello"를 입력 중에 ↑키를 누르면 "hello"를 보존하고, ↓키로 돌아오면 "hello"가 복원됩니다.
+
+### 23-6. 스크롤
+
+```go
+func (m *Model) scroll(delta int) {
+    m.scrollOffset += delta
+    m.scrollOffset = max(m.scrollOffset, 0)
+    maxScroll := max(len(m.chatLines)-m.chatAreaHeight(), 0)
+    if m.scrollOffset > maxScroll {
+        m.scrollOffset = maxScroll
+    }
+}
+```
+
+- `scrollOffset = 0`: 화면 최하단 (최신 메시지)
+- 양수: 위로 스크롤
+- 새 메시지 수신 시 자동으로 `scrollOffset = 0`으로 리셋
+
+### 23-7. 뷰 렌더링
+
+```go
+func (m *Model) View() string {
+    // 1. 헤더 (1줄)
+    header := headerStyle.Width(m.width).Render(" TARS")
+
+    // 2. 채팅 영역 (height - 3줄)
+    chatView := m.renderChat(m.chatAreaHeight())
+
+    // 3. 상태바 (1줄) — 세션 ID, 스트리밍 상태, 스크롤 위치
+    statusBar := m.renderStatusBar()
+
+    // 4. 입력 (1줄)
+    m.input.Width = m.width - 2
+    inputView := m.input.View()
+
+    return header + "\n" + chatView + statusBar + "\n" + inputView
+}
+```
+
+**lipgloss**로 스타일을 적용합니다:
+- 사용자 메시지: 하늘색
+- AI 응답: 녹색
+- 시스템: 회색
+- 에러: 빨간색
+- 도구: 주황색
+
+### 23-8. 서버 연결
+
+```go
+// cmd/tars/chat.go
+model := tui.New(serverURL, apiToken, sessionID)
+p := tea.NewProgram(model, tea.WithAltScreen())
+p.Run()
+```
+
+`tea.WithAltScreen()`은 alternate screen buffer를 사용합니다. TUI 종료 시 이전 터미널 내용이 복원됩니다.
+
+## TARS 원본과의 차이
+
+| 항목 | TARS | TARS |
+|------|------|--------|
+| 패널 | 3개 (채팅, 상태, 알림) | 1개 (채팅) |
+| 레이아웃 | 반응형 (좁으면 세로, 넓으면 가로) | 단일 컬럼 |
+| 알림 | SSE 이벤트 구독, 알림 센터 | 미구현 |
+| 슬래시 명령어 | /trace, /gateway, /project 등 | /help, /session, /new, /clear |
+| 세션 복구 | stale 세션 자동 복구 | 수동 /new |
+| 탭 완성 | 슬래시 명령어 자동완성 | 미구현 |
+
+## 체크포인트
+
+- [x] `tars chat`으로 TUI가 실행된다
+- [x] LLM 응답이 실시간 스트리밍된다
+- [x] Page Up/Down으로 채팅 스크롤이 가능하다
+- [x] ↑/↓ 키로 명령어 히스토리를 탐색할 수 있다
+- [x] Esc로 스트리밍을 취소할 수 있다
+
+## 다음 단계
+
+Step 24에서는 브라우저 자동화를 구현합니다. Playwright 기반 브라우저 제어로 AI가 웹 페이지를 조작할 수 있게 합니다.

--- a/docs/tutorials/99-roadmap.md
+++ b/docs/tutorials/99-roadmap.md
@@ -1,0 +1,261 @@
+# Go AI 에이전트 런타임 만들기 — 로드맵
+
+> TARS 프로젝트를 기반으로 단계적으로 기능을 확장하는 전체 학습 계획
+
+---
+
+## 전체 페이즈 구조
+
+```
+Phase 1 ✅  최소 동작 버전 (MVP)
+Phase 2 ✅  실전 LLM 연동 + 실용 도구
+Phase 3 ✅  메모리와 컨텍스트 관리
+Phase 4 ✅  확장 시스템 (Skill/Plugin/MCP)
+Phase 5 ✅  채팅 인터페이스 + 프로젝트 기반
+Phase 6 ✅  자율 실행 + 감독 대시보드
+Phase 7 ✅  외부 경계와 배포
+```
+
+각 페이즈는 독립적으로 학습 가능하지만, 순서대로 진행하는 것을 권장합니다.
+
+---
+
+## Phase 1 — 최소 동작 버전 (MVP) ✅ 완료
+
+> 목표: Mock LLM으로 전체 파이프라인이 동작하는 최소 서버
+
+| Step | 주제 | 상태 |
+|------|------|------|
+| 1 | 얇은 CLI (Cobra) | ✅ |
+| 2 | 세션 + Transcript (JSONL) | ✅ |
+| 3 | 프롬프트 빌더 + 도구 Registry | ✅ |
+| 4 | HTTP/SSE 채팅 + Agent Loop | ✅ |
+
+**결과물:** `go run ./cmd/tars/ serve`로 Mock 채팅 서버가 동작
+
+---
+
+## Phase 2 — 실전 LLM 연동 + 실용 도구 ✅ 완료
+
+> 목표: 실제 LLM API를 연결하고, 실용적인 도구를 추가
+
+| Step | 주제 | 상태 |
+|------|------|------|
+| 5 | OpenAI 호환 Provider Adapter | ✅ |
+| 6 | 설정 시스템 (Config) | ✅ |
+| 7 | 실용 도구 (read_file, write_file, exec) | ✅ |
+| 8 | Anthropic Provider Adapter | ✅ |
+
+**결과물:** OpenAI/Anthropic 실제 LLM으로 채팅 + 파일/명령 도구 사용 가능
+
+---
+
+## Phase 3 — 메모리와 컨텍스트 관리 ✅ 완료
+
+> 목표: 대화가 길어져도 맥락을 유지하는 메모리 시스템
+
+| Step | 주제 | 상태 |
+|------|------|------|
+| 9 | Transcript Compaction | ✅ |
+| 10 | 파일 기반 Memory (save/search) | ✅ |
+| 11 | Semantic Memory (Embedding) | ✅ |
+
+**결과물:** 토큰 예산 기반 자동 압축 + Markdown 메모리 저장/검색 + Embedding 유사도 검색 (optional)
+
+---
+
+## Phase 4 — 확장 시스템 (Skill/Plugin/MCP) ✅ 완료
+
+> 목표: 외부 기능을 동적으로 로딩하는 확장 구조
+
+| Step | 주제 | 상태 |
+|------|------|------|
+| 12 | Skill 로더 (SKILL.md 파싱 + 프롬프트 주입) | ✅ |
+| 13 | Plugin 로더 + MCP 클라이언트 (JSON-RPC stdio) | ✅ |
+| 14 | Skill Hub (원격 검색/설치/업데이트) | ✅ |
+
+**결과물:** SKILL.md 자동 인식 + MCP 서버 도구 연동 + 원격 skill 설치 CLI
+
+---
+
+## Phase 5 — 채팅 인터페이스 + 프로젝트 기반
+
+> 목표: **사용자가 자연어로 AI와 대화하고, 대화를 통해 프로젝트를 생성/관리할 수 있다**
+>
+> 종료 조건: 터미널에서 "소나기 스타일 단편소설 프로젝트 만들어줘"라고 치면 프로젝트가 생성되고, 대시보드에서 확인된다.
+
+### Step 15. 터미널 채팅 클라이언트
+
+서버의 `/v1/chat` 엔드포인트에 연결하는 대화형 터미널 클라이언트.
+
+- stdin/stdout 기반 REPL (최소 버전)
+- SSE 스트리밍 응답 표시
+- 세션 유지 (세션 ID 기반)
+
+**범위 제한:** Bubble Tea 같은 TUI 프레임워크는 사용하지 않음. 순수 Go `fmt` + `bufio`로 충분.
+
+**체크포인트:**
+- [x] `tars chat`으로 서버에 연결, 대화가 가능하다
+- [x] LLM 응답이 스트리밍으로 한 글자씩 출력된다
+- [x] 도구 호출 결과가 대화에 반영된다
+
+### Step 16. 프로젝트 Store + Kanban ✅ 구현됨
+
+워크스페이스에 프로젝트를 만들고 태스크를 관리하는 저장소.
+
+- `PROJECT.md` (YAML frontmatter), `KANBAN.md`, `ACTIVITY.jsonl`
+- 태스크 상태: `todo → in_progress → review → done`
+- REST API: CRUD + board + activity
+
+**범위 제한:** 상태 머신/자율 실행 없음. 순수 CRUD만.
+
+**구현 파일:**
+- `internal/project/store.go`
+- `internal/server/handler_dashboard.go`
+
+**체크포인트:**
+- [x] API로 프로젝트 생성/조회/수정이 가능하다
+- [x] 태스크를 추가하고 상태를 변경할 수 있다
+- [x] 채팅에서 자연어로 프로젝트를 생성할 수 있다 (← Step 15 이후)
+
+### Step 17. macOS 대시보드 ✅ 구현됨
+
+프로젝트 상태를 확인하는 macOS 메뉴바 앱.
+
+- SwiftUI MenuBarExtra (.window 스타일)
+- 서버 연결/해제, 프로젝트 목록, 상세 화면
+- 프로젝트 생성/태스크 관리 UI
+
+**범위 제한:** 읽기 + 기본 CRUD만. 채팅 패널과 자율 실행 감독은 Phase 6.
+
+**구현 파일:**
+- `dashboard/Sources/*.swift`
+
+**체크포인트:**
+- [x] 메뉴바에서 서버 연결 후 프로젝트 목록이 보인다
+- [x] 프로젝트 상세에서 보드/활동이 표시된다
+- [x] 대시보드에서 프로젝트를 생성하고 태스크를 편집할 수 있다
+
+---
+
+## Phase 6 — 자율 실행 + 감독 대시보드
+
+> 목표: **AI가 프로젝트를 자율적으로 계획/실행하고, 사용자가 대시보드에서 승인/감독한다**
+>
+> 종료 조건: 프로젝트에 Autopilot Start → LLM이 태스크+산출물 계획 → 사용자 승인 → 자동 실행 → output/ 디렉토리에 산출물 파일이 생성된다.
+
+### Step 18. 상태 머신 + Autopilot ✅ 구현됨
+
+프로젝트 phase 기반 상태 머신과 자율 실행 루프.
+
+- Phase: `planning → awaiting_approval → executing → reviewing → completed`
+- LLM 콜백: PlanGenerator (태스크+산출물 생성), TaskRunner (태스크 실행), GoalEvaluator (목표 평가)
+- 실패 재시도 (최대 3회), 대기 상태 루프 최적화
+
+**구현 파일:**
+- `internal/project/autopilot.go`
+- `internal/server/server.go` (LLM 콜백 구현)
+
+**체크포인트:**
+- [x] autopilot이 planning → awaiting_approval로 전이한다
+- [x] 승인 후 executing에서 태스크를 자동 실행한다
+- [x] 3회 연속 실패 시 태스크를 스킵한다
+- [x] reviewing에서 목표 미달 시 re-planning이 동작한다
+
+### Step 19. Human-in-the-loop + 산출물 ✅ 구현됨
+
+사용자 승인 게이트와 산출물 명세 시스템.
+
+- Approve/Reject/Pause/Resume/Cancel API
+- Deliverables: 계획 단계에서 산출물 파일명/포맷/설명을 정의
+- TaskRunner에 산출물 경로를 프롬프트로 전달 → `write_file`로 output/ 에 저장
+- `DELIVERABLES.json` 영속화
+
+**구현 파일:**
+- `internal/project/store.go` (Deliverable 타입, SaveDeliverables/GetDeliverables)
+- `internal/server/handler_dashboard.go` (approve/reject/pause/resume/cancel 엔드포인트)
+
+**체크포인트:**
+- [x] 대시보드에서 Approve/Reject 버튼이 표시된다
+- [x] 승인 화면에서 산출물 명세를 확인할 수 있다
+- [ ] 실행 완료 후 output/ 디렉토리에 산출물 파일이 존재한다
+- [x] Reject 시 태스크가 초기화되고 re-planning이 진행된다
+
+### Step 20. SSE 실시간 이벤트 ✅ 구현됨
+
+서버 → 대시보드 실시간 이벤트 스트리밍.
+
+- Go SSEBroker: Subscribe/Unsubscribe/Broadcast 패턴
+- 이벤트: phase_changed, board_updated, activity, autopilot_status
+- Swift SSE 클라이언트: 전용 URLSession (긴 타임아웃), 자동 재연결
+
+**구현 파일:**
+- `internal/server/sse_broker.go`
+- `dashboard/Sources/APIClient.swift` (listenSSE)
+
+**체크포인트:**
+- [x] 서버 이벤트가 대시보드에 실시간 반영된다
+- [x] 연결 끊김 시 자동 재연결된다
+- [x] SSE 연결이 60초 이상 안정적으로 유지된다
+
+---
+
+## Phase 7 — 외부 경계와 배포
+
+> 목표: **실제 운영 환경에서 안전하게 쓸 수 있는 수준으로 강화**
+>
+> 종료 조건: 인증된 사용자만 API에 접근, 장시간 작업을 비동기로 실행, 터미널 TUI로 서버와 대화가 가능하다.
+
+### Step 21. 인증 미들웨어 ✅ 구현됨
+
+- Bearer token 인증 (SHA-256 + constant-time compare)
+- 경로별 권한 분기 (admin path, skip path)
+
+**구현 파일:**
+- `internal/auth/middleware.go`
+- `internal/config/config.go` (AuthMode, AuthToken)
+
+### Step 22. Gateway (비동기 실행) ✅ 구현됨
+
+- Run lifecycle: `accepted → running → completed/failed/canceled`
+- PromptExecutor (agent.Loop 래핑)
+- 동시 실행 제한, Cancel/Wait, 채널 메시지 (local)
+
+**구현 파일:**
+- `internal/gateway/runtime.go`
+- `internal/gateway/executor.go`
+- `internal/gateway/handler.go`
+
+### Step 23. TUI 클라이언트 ✅ 구현됨
+
+- Bubble Tea 기반 TUI (Model-Update-View)
+- SSE 스트리밍 + 비동기 채널 패턴
+- 스크롤, 히스토리, 취소 기능
+
+**구현 파일:**
+- `internal/tui/model.go`, `update.go`, `view.go`, `client.go`
+- `cmd/tars/chat.go`
+
+---
+
+## 페이즈별 난이도와 예상 학습 시간
+
+| Phase | 난이도 | 예상 시간 | 핵심 키워드 |
+|-------|--------|-----------|-------------|
+| 1 ✅ | ★☆☆☆☆ | 2-3시간 | CLI, JSONL, SSE, Agent Loop |
+| 2 ✅ | ★★☆☆☆ | 4-6시간 | 실제 API 연동, Config, Provider Adapter |
+| 3 ✅ | ★★★☆☆ | 4-6시간 | Compaction, Embedding, 토큰 관리 |
+| 4 ✅ | ★★★☆☆ | 6-8시간 | Skill/Plugin/MCP, 동적 로딩 |
+| 5 ✅ | ★★★☆☆ | 4-6시간 | 터미널 채팅, 프로젝트 CRUD, macOS 대시보드 |
+| 6 ✅ | ★★★★☆ | 4-6시간 | 상태 머신, Autopilot, SSE, Human-in-the-loop |
+| 7 ✅ | ★★★★★ | 6-8시간 | 인증, 비동기, TUI |
+
+---
+
+## 원칙
+
+1. **각 페이즈가 끝나면 동작하는 상태여야 한다** — 중간에 깨지지 않게
+2. **확장 레이어는 core를 깨지 않고 optional로 붙인다** — Phase 1이 항상 동작
+3. **원본 코드를 먼저 읽고, 최소 버전을 구현한 뒤, 점진적으로 원본 수준으로 올린다**
+4. **테스트를 먼저 작성하고 구현한다** — 각 Step마다 검증 포인트 확인
+5. **종료 조건을 먼저 확인하고 작업한다** — 범위를 벗어나는 작업은 다음 Phase로 미룬다


### PR DESCRIPTION
## Summary
- Go AI 에이전트 런타임을 처음부터 만들어보는 단계별 튜토리얼 (23 Steps, 7 Phases)
- CLI, LLM 연동, 메모리, Skill/MCP, 프로젝트 관리, Autopilot, 인증, Gateway, TUI 클라이언트까지 전 과정 포함
- 25개 마크다운 문서 (개요 + 23개 Step 강좌 + 로드맵)

## Contents
| Phase | Steps | Topics |
|-------|-------|--------|
| 1. MVP | 01-04 | CLI, Session/JSONL, Prompt/Tool Registry, HTTP/SSE |
| 2. LLM+Tools | 05-08 | OpenAI Provider, Config, File/Exec Tools, Anthropic |
| 3. Memory | 09-11 | Compaction, File Memory, Semantic/Embedding |
| 4. Extensions | 12-14 | Skill Loader, Plugin/MCP, Skill Hub |
| 5. Chat+Project | 15-17 | Terminal Chat, Project Store, macOS Dashboard |
| 6. Autopilot | 18-20 | State Machine, Human-in-the-loop, SSE Realtime |
| 7. Production | 21-23 | Auth Middleware, Gateway, TUI Client |