### PR TITLE
fix: stabilize browser relay attach test

### DIFF
--- a/internal/browserrelay/server_test.go
+++ b/internal/browserrelay/server_test.go
@@ -380,6 +380,8 @@ func TestRelayAttachAndCDPToken(t *testing.T) {
 	}
 	defer extConn.Close()
 
+	waitForRelayCDPReady(t, srv)
+
 	resp2, err := http.Get(versionURL + "?token=relay-token")
 	if err != nil {
 		t.Fatalf("get version after attach: %v", err)


### PR DESCRIPTION
## Summary

- Fixes #142
- Stabilizes the flaky browser relay attach test that could observe `/json/version` before the relay exposed the CDP websocket URL.
- This approach is correct because the relay only guarantees eventual readiness after the extension attaches, and the test now waits for that visible state before asserting.

## Changes

- Reuse the existing `waitForRelayCDPReady()` helper in `TestRelayAttachAndCDPToken`.
- Keep the change scoped to the flaky test without altering browser relay runtime behavior.
- API, config, or compatibility changes: none.

## Validation

- [ ] `make test`
- [x] `make security-scan`
- [x] Additional manual verification, if needed
- `go test ./internal/browserrelay -run TestRelayAttachAndCDPToken -count=200`
- `go test ./internal/browserrelay`
- `make test` currently fails in this environment due to missing Node `playwright` package for existing browser tests in `internal/gateway`, `internal/tarsserver`, and `internal/tool`; unrelated to this change.

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [ ] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [ ] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level: low
- Rollback plan: revert the test helper call in `internal/browserrelay/server_test.go` if it causes unexpected masking of a real regression.