### PR TITLE
chore: silence release homebrew cache warning

### DIFF
--- a/.github/workflows/release-on-version-bump.yml
+++ b/.github/workflows/release-on-version-bump.yml
@@ -174,6 +174,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: repo/go.mod
+          cache: false
 
       - name: Require tap token
         env:


### PR DESCRIPTION
## Summary

- Fixes #144
- Removes the noisy `actions/setup-go` cache restore warning from the release workflow `update-homebrew` job.
- This approach is correct because that job only runs a single `go run` in the checked out repo subdirectory and does not benefit meaningfully from Go module/build cache restore.

## Changes

- Set `cache: false` on the `actions/setup-go@v6` step inside `update-homebrew`.
- Keep the rest of the release workflow unchanged.
- API, config, or compatibility changes: none.

## Validation

- [ ] `make test`
- [x] `make security-scan`
- [x] Additional manual verification, if needed
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-on-version-bump.yml")'`
- Reviewed the last successful release run log and confirmed the warning source in `update-homebrew`.
- `make test` not rerun because this PR only changes workflow metadata and the current local environment still lacks the Node `playwright` package needed by existing browser tests.

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [ ] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [ ] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level: low
- Rollback plan: remove `cache: false` from the `update-homebrew` `setup-go` step if cache reuse becomes necessary later.