### PR TITLE
feat: make autopilot runtime rules configurable

### DIFF
--- a/internal/project/project_runner.go
+++ b/internal/project/project_runner.go
@@ -747,7 +747,7 @@ func (m *AutopilotManager) waitForNextTick(ctx context.Context) bool {
 }
 
 func (m *AutopilotManager) planningBlockExpired(projectID string) bool {
-	if m == nil || m.store == nil || m.planningBlockTimeout <= 0 {
+	if m == nil || m.store == nil {
 		return false
 	}
 	state, err := m.store.GetState(projectID)
@@ -764,11 +764,15 @@ func (m *AutopilotManager) planningBlockExpired(projectID string) bool {
 	if lastRunAt.IsZero() {
 		return false
 	}
-	return !m.store.nowFn().UTC().Before(lastRunAt.Add(m.planningBlockTimeout))
+	timeout := m.runtimePolicyForProject(projectID).PlanningBlockTimeout
+	if timeout <= 0 {
+		return false
+	}
+	return !m.store.nowFn().UTC().Before(lastRunAt.Add(timeout))
 }
 
 func (m *AutopilotManager) runExpired(item AutopilotRun) bool {
-	if m == nil || m.runRetention <= 0 {
+	if m == nil {
 		return false
 	}
 	if !isTerminalAutopilotRunStatus(item.Status) {
@@ -784,7 +788,37 @@ func (m *AutopilotManager) runExpired(item AutopilotRun) bool {
 	if lastTouched.IsZero() {
 		return false
 	}
-	return lastTouched.Before(m.store.nowFn().UTC().Add(-m.runRetention))
+	retention := m.runtimePolicyForProject(item.ProjectID).RunRetention
+	if retention <= 0 {
+		return false
+	}
+	return lastTouched.Before(m.store.nowFn().UTC().Add(-retention))
+}
+
+func (m *AutopilotManager) runtimePolicyForProject(projectID string) WorkflowRuntimePolicy {
+	policy := WorkflowRuntimePolicy{
+		PlanningBlockTimeout: m.planningBlockTimeout,
+		RunRetention:         m.runRetention,
+	}
+	if policy.PlanningBlockTimeout <= 0 {
+		policy.PlanningBlockTimeout = defaultPlanningBlockTimeout
+	}
+	if policy.RunRetention <= 0 {
+		policy.RunRetention = defaultAutopilotRunRetention
+	}
+	if m == nil || m.store == nil {
+		return policy
+	}
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return policy
+	}
+	project, err := m.store.Get(projectID)
+	if err != nil {
+		return policy
+	}
+	applyWorkflowRuntimeRuleOverrides(&policy, project.WorkflowRules)
+	return policy
 }
 
 func isTerminalAutopilotRunStatus(status AutopilotRunStatus) bool {

--- a/internal/project/project_runner_test.go
+++ b/internal/project/project_runner_test.go
@@ -483,13 +483,17 @@ func TestAutopilotManager_RestorePersistedRunsPrunesExpiredTerminalRuns(t *testi
 	store := NewStore(t.TempDir(), func() time.Time {
 		return time.Date(2026, 3, 20, 10, 0, 0, 0, time.UTC)
 	})
-	created, err := store.Create(CreateInput{Name: "Autopilot Expired"})
+	created, err := store.Create(CreateInput{
+		Name: "Autopilot Expired",
+		WorkflowRules: []WorkflowRule{
+			{Name: "run_retention", Params: map[string]string{"duration": "24h"}},
+		},
+	})
 	if err != nil {
 		t.Fatalf("create project: %v", err)
 	}
 
 	manager := NewAutopilotManager(store, stagedTaskRunner{}, func(context.Context) error { return nil }, nil)
-	manager.runRetention = 24 * time.Hour
 	manager.setRun(created.ID, func(item *AutopilotRun) {
 		item.ProjectID = created.ID
 		item.RunID = "autopilot-expired"
@@ -502,7 +506,6 @@ func TestAutopilotManager_RestorePersistedRunsPrunesExpiredTerminalRuns(t *testi
 	})
 
 	restarted := NewAutopilotManager(store, stagedTaskRunner{}, func(context.Context) error { return nil }, nil)
-	restarted.runRetention = 24 * time.Hour
 	if err := restarted.RestorePersistedRuns(); err != nil {
 		t.Fatalf("restore persisted runs: %v", err)
 	}
@@ -583,7 +586,12 @@ func TestAutopilotManager_EnsureActiveRunsEscalatesExpiredPlanningBlocker(t *tes
 	store := NewStore(t.TempDir(), func() time.Time {
 		return time.Date(2026, 3, 14, 21, 0, 0, 0, time.UTC)
 	})
-	created, err := store.Create(CreateInput{Name: "Autopilot Planning Timeout"})
+	created, err := store.Create(CreateInput{
+		Name: "Autopilot Planning Timeout",
+		WorkflowRules: []WorkflowRule{
+			{Name: "planning_block_timeout", Params: map[string]string{"duration": "5m"}},
+		},
+	})
 	if err != nil {
 		t.Fatalf("create project: %v", err)
 	}
@@ -603,7 +611,6 @@ func TestAutopilotManager_EnsureActiveRunsEscalatesExpiredPlanningBlocker(t *tes
 	}
 
 	manager := NewAutopilotManager(store, stagedTaskRunner{}, func(context.Context) error { return nil }, nil)
-	manager.planningBlockTimeout = 5 * time.Minute
 	if _, err := manager.EnsureActiveRuns(context.Background()); err != nil {
 		t.Fatalf("ensure active runs: %v", err)
 	}

--- a/internal/project/worker_profiles_test.go
+++ b/internal/project/worker_profiles_test.go
@@ -3,6 +3,7 @@ package project
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestResolveWorkerProfile_UsesExplicitWorkerAndRoleDefaults(t *testing.T) {
@@ -95,6 +96,33 @@ func TestResolveWorkerProfileForProject_UsesWorkflowProfileDefaultsAndOverrides(
 		}
 		if profile.Kind != WorkerKindClaudeCode {
 			t.Fatalf("expected %q, got %+v", WorkerKindClaudeCode, profile)
+		}
+	})
+}
+
+func TestResolveWorkflowRuntimePolicy_UsesDefaultsAndOverrides(t *testing.T) {
+	t.Run("defaults remain unchanged without rules", func(t *testing.T) {
+		policy := ResolveWorkflowRuntimePolicy(Project{})
+		if policy.PlanningBlockTimeout != defaultPlanningBlockTimeout {
+			t.Fatalf("expected default planning timeout %s, got %s", defaultPlanningBlockTimeout, policy.PlanningBlockTimeout)
+		}
+		if policy.RunRetention != defaultAutopilotRunRetention {
+			t.Fatalf("expected default run retention %s, got %s", defaultAutopilotRunRetention, policy.RunRetention)
+		}
+	})
+
+	t.Run("workflow rules override runtime settings", func(t *testing.T) {
+		policy := ResolveWorkflowRuntimePolicy(Project{
+			WorkflowRules: []WorkflowRule{
+				{Name: "planning_block_timeout", Params: map[string]string{"duration": "45m"}},
+				{Name: "run_retention", Params: map[string]string{"duration": "72h"}},
+			},
+		})
+		if policy.PlanningBlockTimeout != 45*time.Minute {
+			t.Fatalf("expected planning timeout override, got %s", policy.PlanningBlockTimeout)
+		}
+		if policy.RunRetention != 72*time.Hour {
+			t.Fatalf("expected run retention override, got %s", policy.RunRetention)
 		}
 	})
 }

--- a/internal/project/workflow_runtime_policy.go
+++ b/internal/project/workflow_runtime_policy.go
@@ -1,0 +1,53 @@
+package project
+
+import (
+	"strings"
+	"time"
+)
+
+type WorkflowRuntimePolicy struct {
+	PlanningBlockTimeout time.Duration
+	RunRetention         time.Duration
+}
+
+func ResolveWorkflowRuntimePolicy(project Project) WorkflowRuntimePolicy {
+	policy := WorkflowRuntimePolicy{
+		PlanningBlockTimeout: defaultPlanningBlockTimeout,
+		RunRetention:         defaultAutopilotRunRetention,
+	}
+	applyWorkflowRuntimeRuleOverrides(&policy, project.WorkflowRules)
+	return policy
+}
+
+func applyWorkflowRuntimeRuleOverrides(policy *WorkflowRuntimePolicy, rules []WorkflowRule) {
+	if policy == nil || len(rules) == 0 {
+		return
+	}
+	for _, rule := range rules {
+		duration, ok := workflowRuleDuration(rule.Params)
+		if !ok {
+			continue
+		}
+		switch strings.ToLower(strings.TrimSpace(rule.Name)) {
+		case "planning_block_timeout":
+			policy.PlanningBlockTimeout = duration
+		case "run_retention":
+			policy.RunRetention = duration
+		}
+	}
+}
+
+func workflowRuleDuration(params map[string]string) (time.Duration, bool) {
+	if len(params) == 0 {
+		return 0, false
+	}
+	raw := strings.TrimSpace(params["duration"])
+	if raw == "" {
+		return 0, false
+	}
+	duration, err := time.ParseDuration(raw)
+	if err != nil || duration <= 0 {
+		return 0, false
+	}
+	return duration, true
+}


### PR DESCRIPTION
## Summary

- Fixes #146
- Lets projects override autopilot planning timeout and terminal run retention through `workflow_rules`.
- This approach is correct because these are project-level execution concerns and should follow the same workflow rule surface already used for worker and verification policy.

## Changes

- Add `ResolveWorkflowRuntimePolicy` for `planning_block_timeout` and `run_retention` workflow rules.
- Apply per-project runtime settings when expiring stale planning blockers and pruning persisted terminal runs.
- Update project tests to cover both rule parsing and manager behavior.
- API, config, or compatibility changes: projects may now set `workflow_rules` like `{ "name": "planning_block_timeout", "params": { "duration": "5m" } }` and `{ "name": "run_retention", "params": { "duration": "24h" } }`.

## Validation

- [ ] `make test`
- [x] `make security-scan`
- [x] Additional manual verification, if needed
- `go test ./internal/project -run 'TestResolveWorkflowRuntimePolicy_UsesDefaultsAndOverrides|TestAutopilotManager_RestorePersistedRunsPrunesExpiredTerminalRuns|TestAutopilotManager_EnsureActiveRunsEscalatesExpiredPlanningBlocker'`
- `go test ./internal/project`
- `go test ./internal/project ./internal/tarsserver` currently fails in this environment due to the existing missing Node `playwright` package for browser-backed tests in `internal/tarsserver`; unrelated to this change.

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [ ] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [ ] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level: low
- Rollback plan: revert `internal/project/workflow_runtime_policy.go` and the manager wiring if project-specific runtime rules cause unexpected expiration behavior.