### PR TITLE
chore: upgrade codecov action for node24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,8 @@ jobs:
         run: make test-cover
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
-          file: coverage.out
+          files: coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary

- Fixes #148
- Removes the remaining Node 20 deprecation warning from CI by upgrading the Codecov upload action.
- This approach is correct because the current Codecov action release train documents Node 24 support in `v6`, and the workflow only needs the standard coverage upload path.

## Changes

- Upgrade `codecov/codecov-action` from `v4` to `v6` in `.github/workflows/ci.yml`.
- Switch the upload input from `file` to `files` to match the current action interface.
- API, config, or compatibility changes: none outside GitHub Actions CI behavior.

## Validation

- [ ] `make test`
- [x] `make security-scan`
- [x] Additional manual verification, if needed
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- Verified the current Codecov action metadata and README for `v6` from the official repository.
- `make test` not rerun because this PR only updates GitHub Actions metadata and does not change application code.

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [ ] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [ ] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level: low
- Rollback plan: revert the Codecov step back to the previous action version if upload behavior regresses unexpectedly.