### PR TITLE
feat: add SSE real-time updates to Home and global health

### DIFF
--- a/frontend/console/src/App.svelte
+++ b/frontend/console/src/App.svelte
@@ -1,12 +1,16 @@
 <script lang="ts">
-  import { onMount } from 'svelte'
+  import { onMount, onDestroy } from 'svelte'
   import Shell from './components/Shell.svelte'
   import Home from './components/Home.svelte'
   import ProjectView from './components/ProjectView.svelte'
   import { resolveRoute, type Route } from './lib/router'
+  import { getEventsHistory, streamEvents } from './lib/api'
 
   let currentPath = $state('/console')
   let route: Route = $state({ view: 'home' })
+  let serverHealth = $state('connecting')
+  let unreadCount = $state(0)
+  let stopGlobalStream: (() => void) | null = null
 
   function navigate(path: string) {
     if (path === currentPath) return
@@ -20,16 +24,45 @@
     route = resolveRoute(currentPath)
   }
 
+  function startGlobalStream() {
+    stopGlobalStream?.()
+    stopGlobalStream = streamEvents(
+      undefined,
+      () => {
+        unreadCount++
+      },
+      () => {
+        serverHealth = 'disconnected'
+      },
+      () => {
+        serverHealth = 'ok'
+      },
+    )
+  }
+
   onMount(() => {
     syncFromBrowser()
     const onPopState = () => syncFromBrowser()
     window.addEventListener('popstate', onPopState)
+
+    getEventsHistory(1)
+      .then((h) => { unreadCount = h.unread_count ?? 0 })
+      .catch(() => {})
+
+    startGlobalStream()
+
     return () => window.removeEventListener('popstate', onPopState)
+  })
+
+  onDestroy(() => {
+    stopGlobalStream?.()
   })
 </script>
 
 <Shell
   {currentPath}
+  {serverHealth}
+  {unreadCount}
   onNavigate={navigate}
 >
   {#if route.view === 'home'}

--- a/frontend/console/src/components/Home.svelte
+++ b/frontend/console/src/components/Home.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-  import { onMount } from 'svelte'
+  import { onMount, onDestroy } from 'svelte'
   import {
     getEventsHistory,
     listApprovals,
     listCronJobs,
     listProjects,
+    streamEvents,
   } from '../lib/api'
   import type {
     Approval,
@@ -28,6 +29,7 @@
 
   let loading = $state(true)
   let error = $state('')
+  let stopStream: (() => void) | null = null
 
   function fmt(value?: string): string {
     const text = value?.trim()
@@ -79,7 +81,35 @@
     }
   }
 
-  onMount(() => { void load() })
+  function startEventStream() {
+    stopStream?.()
+    stopStream = streamEvents(
+      undefined,
+      (event) => {
+        notifications = [event, ...notifications.filter((n) => n.id !== event.id)].slice(0, 10)
+        unreadCount++
+
+        if (event.category === 'cron' || event.category === 'watchdog') {
+          void listCronJobs().then((jobs) => { cronJobs = jobs })
+        }
+        if (event.category === 'ops') {
+          void listApprovals().then((list) => { approvals = list })
+        }
+        if (event.category === 'project') {
+          void listProjects().then((list) => { projects = list })
+        }
+      },
+    )
+  }
+
+  onMount(() => {
+    void load()
+    startEventStream()
+  })
+
+  onDestroy(() => {
+    stopStream?.()
+  })
 </script>
 
 <div class="home">

--- a/frontend/console/src/lib/api.ts
+++ b/frontend/console/src/lib/api.ts
@@ -101,11 +101,16 @@ export async function getEventsHistory(limit = 30): Promise<EventsHistoryInfo> {
 }
 
 export function streamEvents(
-  projectId: string,
+  projectId: string | undefined,
   onEvent: (event: NotificationMessage) => void,
   onError?: (message: string) => void,
+  onOpen?: () => void,
 ): () => void {
-  const stream = new EventSource(`/v1/events/stream?project_id=${encodeURIComponent(projectId)}`)
+  const params = projectId ? `?project_id=${encodeURIComponent(projectId)}` : ''
+  const stream = new EventSource(`/v1/events/stream${params}`)
+  stream.onopen = () => {
+    onOpen?.()
+  }
   stream.onmessage = (message) => {
     if (!message.data) {
       return
@@ -121,7 +126,7 @@ export function streamEvents(
     }
   }
   stream.onerror = () => {
-    onError?.('Project event stream disconnected')
+    onError?.('Event stream disconnected')
   }
   return () => {
     stream.close()


### PR DESCRIPTION
## Summary
- Global SSE event stream at App level drives Header connection status indicator (green/red dot)
- Home view subscribes to unfiltered event stream — notifications, approvals, cron jobs, and projects refresh live as events arrive
- `streamEvents` now accepts optional `projectId` (undefined = all events)
- Unread notification count tracked globally and displayed in Header badge

## Test plan
- [ ] Open `/console` — verify Header shows green "Connected" dot
- [ ] Trigger an event (e.g. cron run) — verify Home panels update without refresh
- [ ] Kill the server — verify Header shows red "Disconnected" dot
- [ ] Restart server — verify reconnection and green dot

Closes #169