### PR TITLE
fix: build console assets before release binary

### DIFF
--- a/.github/workflows/release-on-version-bump.yml
+++ b/.github/workflows/release-on-version-bump.yml
@@ -78,6 +78,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - name: Build console assets
+        run: make console-install console-build
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/Makefile
+++ b/Makefile
@@ -157,10 +157,10 @@ build-bins:
 console-install:
 	cd frontend/console && npm install
 
-console-build:
+console-build: console-install
 	cd frontend/console && npm run build
 
-release-asset:
+release-asset: console-build
 	mkdir -p "$(DIST_DIR)"
 	rm -rf "$(RELEASE_STAGE_DIR)"
 	mkdir -p "$(RELEASE_STAGE_DIR)/share/tars"


### PR DESCRIPTION
## Summary
- Add Node.js setup + `console-install` + `console-build` steps to release workflow before Go build
- Make `release-asset` Makefile target depend on `console-build` → `console-install`
- Release binaries now embed the built Svelte SPA instead of serving the placeholder page

## Test plan
- [ ] `make console-build` — runs `npm install` then `npm run build`
- [ ] `make release-asset` — builds console assets first, then Go binary with embedded SPA
- [ ] Verify release workflow YAML has correct step ordering

Closes #173