### PR TITLE
fix: add dev-console make target and grant admin role in auth-off mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ RELEASE_STAGE_DIR ?= $(DIST_DIR)/release-$(RELEASE_GOOS)-$(RELEASE_GOARCH)
 	install install-server install-assistant uninstall uninstall-server uninstall-assistant reinstall \
 	restart restart-server restart-assistant reload-config reload-server-config reload-assistant-config \
 	logs logs-server logs-server-err logs-assistant logs-assistant-err \
-	dev-serve dev-serve-once dev-serve-loop dev-chat dev-heartbeat dev-tars \
+	dev-serve dev-serve-once dev-serve-loop dev-chat dev-heartbeat dev-tars dev-console \
 	api-status api-sessions api-compact api-chat api-heartbeat smoke-auth \
 	vault-up vault-down vault-logs security-scan \
 	run-serve
@@ -110,6 +110,7 @@ help:
 	@echo "  make dev-serve     - run server via tars serve (API mode)"
 	@echo "  make dev-serve-once - run one heartbeat via tars serve"
 	@echo "  make dev-serve-loop - run heartbeat loop via tars serve"
+	@echo "  make dev-console   - run Go server + Vite dev server (hot-reload, no build needed)"
 	@echo "  make dev-chat      - run Go client (cmd/tars)"
 	@echo "  make dev-tars      - run Go client (cmd/tars)"
 	@echo "  make dev-heartbeat - call heartbeat run-once via API"
@@ -284,6 +285,21 @@ dev-serve-once:
 
 dev-serve-loop:
 	$(GO) run ./cmd/tars serve --verbose --run-loop $(if $(TARS_CONFIG),--config $(TARS_CONFIG),) --heartbeat-interval $(HEARTBEAT_INTERVAL) --max-heartbeats $(MAX_HEARTBEATS) --workspace-dir $(WORKSPACE_DIR) $(ARGS)
+
+dev-console: console-install
+	@echo "Starting Vite dev server (hot-reload) + Go API server..."
+	@echo "  Console: http://$(API_ADDR)/console"
+	@echo "  Vite:    http://127.0.0.1:5173 (proxied via Go server)"
+	@echo ""
+	@cd frontend/console && npm run dev &
+	@sleep 2
+	TARS_CONSOLE_DEV_URL=http://127.0.0.1:5173 \
+	TARS_API_AUTH_MODE=off \
+	TARS_DASHBOARD_AUTH_MODE=off \
+	TARS_API_ALLOW_INSECURE_LOCAL_AUTH=true \
+	$(GO) run ./cmd/tars serve --verbose --serve-api \
+		$(if $(TARS_CONFIG),--config $(TARS_CONFIG),) \
+		--workspace-dir $(WORKSPACE_DIR) --api-addr $(API_ADDR) $(ARGS)
 
 dev-chat:
 	$(GO) run ./cmd/tars --server-url $(SERVER_URL) $(if $(SESSION),--session $(SESSION),) $(ARGS)

--- a/internal/serverauth/middleware.go
+++ b/internal/serverauth/middleware.go
@@ -178,6 +178,9 @@ func NewMiddleware(opts Options, logOut io.Writer) func(http.Handler) http.Handl
 			req = withDebugWorkspaceHeader(req)
 			requirement := compiled.requirementForRequest(r)
 			if compiled.mode == ModeOff || requirement.skip {
+				if compiled.mode == ModeOff {
+					req = withRole(req, RoleAdmin)
+				}
 				next.ServeHTTP(w, req)
 				return
 			}

--- a/internal/tarsserver/handler_auth_test.go
+++ b/internal/tarsserver/handler_auth_test.go
@@ -52,7 +52,7 @@ func TestAuthWhoamiAPI_ReturnsRole(t *testing.T) {
 	}
 }
 
-func TestAuthWhoamiAPI_OffModeReturnsAnonymous(t *testing.T) {
+func TestAuthWhoamiAPI_OffModeGrantsAdminRole(t *testing.T) {
 	cfg := config.Config{
 		APIConfig: config.APIConfig{
 			APIAuthMode: "off",
@@ -76,11 +76,11 @@ func TestAuthWhoamiAPI_OffModeReturnsAnonymous(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("decode whoami response: %v", err)
 	}
-	if body.Authenticated {
-		t.Fatalf("expected authenticated=false, got %+v", body)
+	if !body.Authenticated {
+		t.Fatalf("expected authenticated=true in off mode, got %+v", body)
 	}
-	if body.AuthRole != "" {
-		t.Fatalf("expected empty auth_role, got %+v", body)
+	if body.AuthRole != "admin" {
+		t.Fatalf("expected admin role in off mode, got %+v", body)
 	}
 	if body.AuthMode != "off" {
 		t.Fatalf("expected auth_mode off, got %+v", body)


### PR DESCRIPTION
## Summary
- Add `make dev-console` target: runs Vite dev server + Go API server concurrently with `TARS_CONSOLE_DEV_URL` proxy — enables frontend hot-reload without building/embedding assets
- Fix `api_auth_mode=off` granting admin role so handler-level admin checks (e.g. `/v1/admin/sessions`) pass without token
- Update whoami test to reflect new off-mode behavior

## Test plan
- [ ] `make dev-console` starts both Vite and Go servers, console accessible at `http://127.0.0.1:43180/console`
- [ ] Frontend hot-reload works when editing `.svelte` files
- [ ] `/console/sessions` no longer returns 403 in auth-off mode
- [ ] `go test ./internal/serverauth/ ./internal/tarsserver/ -run 'TestMiddleware|TestAuth'` passes