### PR TITLE
feat: plugin system v2 Phase 1 — manifest v3, ToolProvider, LifecycleHooks

### DIFF
--- a/internal/extensions/lifecycle.go
+++ b/internal/extensions/lifecycle.go
@@ -1,0 +1,56 @@
+package extensions
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/devlikebear/tars/internal/plugin"
+)
+
+const defaultHookTimeout = 30 * time.Second
+
+// runLifecycleHooks executes lifecycle hook commands for all plugins that declare them.
+// hook must be "on_start" or "on_stop". Failures are collected as diagnostics, not fatal errors.
+func runLifecycleHooks(ctx context.Context, plugins []plugin.Definition, hook string, timeout time.Duration) []string {
+	if timeout <= 0 {
+		timeout = defaultHookTimeout
+	}
+	var diagnostics []string
+	for _, p := range plugins {
+		if p.Lifecycle == nil {
+			continue
+		}
+		var cmd string
+		switch hook {
+		case "on_start":
+			cmd = p.Lifecycle.OnStart
+		case "on_stop":
+			cmd = p.Lifecycle.OnStop
+		default:
+			continue
+		}
+		cmd = strings.TrimSpace(cmd)
+		if cmd == "" {
+			continue
+		}
+
+		hookCtx, cancel := context.WithTimeout(ctx, timeout)
+		c := exec.CommandContext(hookCtx, "sh", "-c", cmd)
+		c.Dir = p.RootDir
+		var stderr bytes.Buffer
+		c.Stderr = &stderr
+		if err := c.Run(); err != nil {
+			msg := fmt.Sprintf("plugin %q lifecycle %s failed: %v", p.ID, hook, err)
+			if s := strings.TrimSpace(stderr.String()); s != "" {
+				msg += ": " + s
+			}
+			diagnostics = append(diagnostics, msg)
+		}
+		cancel()
+	}
+	return diagnostics
+}

--- a/internal/extensions/lifecycle_test.go
+++ b/internal/extensions/lifecycle_test.go
@@ -1,0 +1,72 @@
+package extensions
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devlikebear/tars/internal/plugin"
+)
+
+func TestRunLifecycleHooks_OnStart(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "started.txt")
+
+	plugins := []plugin.Definition{
+		{
+			ID:      "test-plugin",
+			RootDir: dir,
+			Lifecycle: &plugin.Lifecycle{
+				OnStart: "echo hello > " + marker,
+			},
+		},
+	}
+
+	diags := runLifecycleHooks(context.Background(), plugins, "on_start", 5*time.Second)
+	if len(diags) > 0 {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	data, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("marker file not created: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "hello" {
+		t.Fatalf("expected hello, got %q", got)
+	}
+}
+
+func TestRunLifecycleHooks_Timeout(t *testing.T) {
+	dir := t.TempDir()
+	plugins := []plugin.Definition{
+		{
+			ID:      "slow-plugin",
+			RootDir: dir,
+			Lifecycle: &plugin.Lifecycle{
+				OnStart: "sleep 60",
+			},
+		},
+	}
+
+	diags := runLifecycleHooks(context.Background(), plugins, "on_start", 100*time.Millisecond)
+	if len(diags) == 0 {
+		t.Fatal("expected timeout diagnostic")
+	}
+	if !strings.Contains(diags[0], "slow-plugin") {
+		t.Fatalf("expected diagnostic to mention plugin id, got %q", diags[0])
+	}
+}
+
+func TestRunLifecycleHooks_NoHook(t *testing.T) {
+	plugins := []plugin.Definition{
+		{ID: "no-hooks", RootDir: t.TempDir()},
+		{ID: "nil-lifecycle", RootDir: t.TempDir(), Lifecycle: &plugin.Lifecycle{}},
+	}
+
+	diags := runLifecycleHooks(context.Background(), plugins, "on_start", 5*time.Second)
+	if len(diags) > 0 {
+		t.Fatalf("unexpected diagnostics for plugins without hooks: %v", diags)
+	}
+}

--- a/internal/extensions/manager.go
+++ b/internal/extensions/manager.go
@@ -104,6 +104,17 @@ func (m *Manager) Start(ctx context.Context) error {
 	if err := m.Reload(ctx); err != nil {
 		return err
 	}
+
+	// Run on_start lifecycle hooks (non-fatal)
+	m.mu.RLock()
+	plugins := append([]plugin.Definition(nil), m.snapshot.Plugins...)
+	m.mu.RUnlock()
+	if diags := runLifecycleHooks(ctx, plugins, "on_start", 0); len(diags) > 0 {
+		m.mu.Lock()
+		m.snapshot.Diagnostics = append(m.snapshot.Diagnostics, diags...)
+		m.mu.Unlock()
+	}
+
 	if !m.opts.WatchSkills && !m.opts.WatchPlugins {
 		return nil
 	}
@@ -130,6 +141,12 @@ func (m *Manager) Start(ctx context.Context) error {
 }
 
 func (m *Manager) Close() {
+	// Run on_stop lifecycle hooks before shutdown
+	m.mu.RLock()
+	plugins := append([]plugin.Definition(nil), m.snapshot.Plugins...)
+	m.mu.RUnlock()
+	_ = runLifecycleHooks(context.Background(), plugins, "on_stop", 0)
+
 	m.watcherMu.Lock()
 	defer m.watcherMu.Unlock()
 	if m.stopWatch != nil {
@@ -255,9 +272,17 @@ func (m *Manager) Reload(ctx context.Context) error {
 		Diagnostics: diagnostics,
 	}
 
+	// Collect tool provider tools (stub — Phase 2 will implement actual providers)
+	providerTools, providerDiags := m.collectToolProviderTools(ctx, plugins.Plugins)
+	if len(providerDiags) > 0 {
+		nextSnapshot.Diagnostics = append(nextSnapshot.Diagnostics, providerDiags...)
+	}
+
 	m.mu.Lock()
 	m.snapshot = nextSnapshot
-	m.chatTools = append([]tool.Tool(nil), mcpTools...)
+	allTools := append([]tool.Tool(nil), mcpTools...)
+	allTools = append(allTools, providerTools...)
+	m.chatTools = allTools
 	m.mu.Unlock()
 	return nil
 }
@@ -527,6 +552,26 @@ func formatDiagnostic(path string, message string) string {
 		return message
 	}
 	return fmt.Sprintf("%s: %s", path, message)
+}
+
+// collectToolProviderTools collects tools from plugins that declare a tools_provider.
+// Phase 1 stub: returns empty for all provider types. Phase 2 will implement actual providers.
+// mcp_server type is intentionally skipped here since those tools already flow through MCPRuntime.
+func (m *Manager) collectToolProviderTools(_ context.Context, plugins []plugin.Definition) ([]tool.Tool, []string) {
+	var tools []tool.Tool
+	var diagnostics []string
+	for _, p := range plugins {
+		if p.ToolsProvider == nil {
+			continue
+		}
+		switch p.ToolsProvider.Type {
+		case "mcp_server":
+			// Already handled by MCPRuntime — skip to avoid double-registration
+		case "go_plugin", "script":
+			diagnostics = append(diagnostics, fmt.Sprintf("plugin %q: tools_provider type %q not yet supported", p.ID, p.ToolsProvider.Type))
+		}
+	}
+	return tools, diagnostics
 }
 
 func uniqueStrings(values []string) []string {

--- a/internal/plugin/loader.go
+++ b/internal/plugin/loader.go
@@ -103,6 +103,9 @@ func loadSourcePlugins(source Source, dir string) ([]Definition, []Diagnostic, e
 				ToolsAllow: append([]string(nil), manifest.Policies.ToolsAllow...),
 				ToolsDeny:  append([]string(nil), manifest.Policies.ToolsDeny...),
 			},
+			ToolsProvider: manifest.ToolsProvider,
+			Lifecycle:     manifest.Lifecycle,
+			HTTPRoutes:    append([]HTTPRoute(nil), manifest.HTTPRoutes...),
 		}
 		priority := manifestPriority(path)
 		if currentPriority, ok := priorities[key]; !ok || priority >= currentPriority {

--- a/internal/plugin/manifest.go
+++ b/internal/plugin/manifest.go
@@ -26,12 +26,42 @@ func parseManifestFile(path string) (Manifest, error) {
 	if manifest.SchemaVersion == 0 {
 		manifest.SchemaVersion = 2
 	}
-	if manifest.SchemaVersion < 1 || manifest.SchemaVersion > 2 {
+	if manifest.SchemaVersion < 1 || manifest.SchemaVersion > 3 {
 		return Manifest{}, fmt.Errorf("unsupported plugin manifest schema_version %d", manifest.SchemaVersion)
 	}
 	if manifest.ID == "" {
 		return Manifest{}, fmt.Errorf("plugin id is required")
 	}
+
+	// v3 fields must not appear in v1/v2 manifests
+	if manifest.SchemaVersion < 3 {
+		if manifest.ToolsProvider != nil {
+			return Manifest{}, fmt.Errorf("tools_provider requires schema_version >= 3")
+		}
+		if manifest.Lifecycle != nil {
+			return Manifest{}, fmt.Errorf("lifecycle requires schema_version >= 3")
+		}
+		if len(manifest.HTTPRoutes) > 0 {
+			return Manifest{}, fmt.Errorf("http_routes requires schema_version >= 3")
+		}
+	}
+
+	// validate v3-specific fields
+	if manifest.ToolsProvider != nil {
+		manifest.ToolsProvider.Type = strings.TrimSpace(manifest.ToolsProvider.Type)
+		manifest.ToolsProvider.Entry = strings.TrimSpace(manifest.ToolsProvider.Entry)
+		switch manifest.ToolsProvider.Type {
+		case "mcp_server", "go_plugin", "script":
+		default:
+			return Manifest{}, fmt.Errorf("unsupported tools_provider type %q (must be mcp_server, go_plugin, or script)", manifest.ToolsProvider.Type)
+		}
+	}
+	if manifest.Lifecycle != nil {
+		manifest.Lifecycle.OnStart = strings.TrimSpace(manifest.Lifecycle.OnStart)
+		manifest.Lifecycle.OnStop = strings.TrimSpace(manifest.Lifecycle.OnStop)
+	}
+	manifest.HTTPRoutes = normalizeHTTPRoutes(manifest.HTTPRoutes)
+
 	manifest.Skills = normalizeList(manifest.Skills)
 	manifest.MCPServers = normalizeMCPServers(manifest.MCPServers)
 	manifest.Requires = Requires{
@@ -45,6 +75,21 @@ func parseManifestFile(path string) (Manifest, error) {
 		ToolsDeny:  normalizeList(manifest.Policies.ToolsDeny),
 	}
 	return manifest, nil
+}
+
+func normalizeHTTPRoutes(routes []HTTPRoute) []HTTPRoute {
+	out := make([]HTTPRoute, 0, len(routes))
+	for _, route := range routes {
+		path := strings.TrimSpace(route.Path)
+		if path == "" {
+			continue
+		}
+		out = append(out, HTTPRoute{
+			Path:    path,
+			Handler: strings.TrimSpace(route.Handler),
+		})
+	}
+	return out
 }
 
 func normalizeList(values []string) []string {

--- a/internal/plugin/manifest_test.go
+++ b/internal/plugin/manifest_test.go
@@ -137,3 +137,119 @@ func TestParseManifest_RequiresID(t *testing.T) {
 		t.Fatal("expected parse error for missing id")
 	}
 }
+
+func TestParseManifest_V3WithToolsProvider(t *testing.T) {
+	root := t.TempDir()
+	manifestPath := filepath.Join(root, "browser", "tars.plugin.json")
+	if err := os.MkdirAll(filepath.Dir(manifestPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	content := `{
+  "schema_version": 3,
+  "id": "browser-automation",
+  "name": "Browser Automation",
+  "version": "1.0.0",
+  "tools_provider": {
+    "type": "script",
+    "entry": "bin/browser-tools"
+  },
+  "lifecycle": {
+    "on_start": "echo starting",
+    "on_stop": "echo stopping"
+  },
+  "http_routes": [
+    {"path": "/v1/browser/*", "handler": "browser_handler"}
+  ]
+}`
+	if err := os.WriteFile(manifestPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	manifest, err := parseManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("parse v3 manifest: %v", err)
+	}
+	if manifest.SchemaVersion != 3 {
+		t.Fatalf("expected schema version 3, got %d", manifest.SchemaVersion)
+	}
+	if manifest.ToolsProvider == nil {
+		t.Fatal("expected tools_provider to be set")
+	}
+	if manifest.ToolsProvider.Type != "script" {
+		t.Fatalf("expected tools_provider type script, got %q", manifest.ToolsProvider.Type)
+	}
+	if manifest.ToolsProvider.Entry != "bin/browser-tools" {
+		t.Fatalf("expected entry bin/browser-tools, got %q", manifest.ToolsProvider.Entry)
+	}
+	if manifest.Lifecycle == nil {
+		t.Fatal("expected lifecycle to be set")
+	}
+	if manifest.Lifecycle.OnStart != "echo starting" {
+		t.Fatalf("expected on_start echo starting, got %q", manifest.Lifecycle.OnStart)
+	}
+	if manifest.Lifecycle.OnStop != "echo stopping" {
+		t.Fatalf("expected on_stop echo stopping, got %q", manifest.Lifecycle.OnStop)
+	}
+	if len(manifest.HTTPRoutes) != 1 {
+		t.Fatalf("expected 1 http route, got %d", len(manifest.HTTPRoutes))
+	}
+	if manifest.HTTPRoutes[0].Path != "/v1/browser/*" {
+		t.Fatalf("expected route path /v1/browser/*, got %q", manifest.HTTPRoutes[0].Path)
+	}
+	if manifest.HTTPRoutes[0].Handler != "browser_handler" {
+		t.Fatalf("expected handler browser_handler, got %q", manifest.HTTPRoutes[0].Handler)
+	}
+}
+
+func TestParseManifest_V3FieldsOnV2Rejected(t *testing.T) {
+	root := t.TempDir()
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name:    "tools_provider on v2",
+			content: `{"schema_version":2,"id":"bad","tools_provider":{"type":"script","entry":"x"}}`,
+		},
+		{
+			name:    "lifecycle on v2",
+			content: `{"schema_version":2,"id":"bad","lifecycle":{"on_start":"echo hi"}}`,
+		},
+		{
+			name:    "http_routes on v2",
+			content: `{"schema_version":2,"id":"bad","http_routes":[{"path":"/foo"}]}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := filepath.Join(root, tt.name)
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			manifestPath := filepath.Join(dir, "tars.plugin.json")
+			if err := os.WriteFile(manifestPath, []byte(tt.content), 0o644); err != nil {
+				t.Fatalf("write manifest: %v", err)
+			}
+			_, err := parseManifestFile(manifestPath)
+			if err == nil {
+				t.Fatal("expected error for v3 field on v2 manifest")
+			}
+		})
+	}
+}
+
+func TestParseManifest_V3InvalidToolsProviderType(t *testing.T) {
+	root := t.TempDir()
+	manifestPath := filepath.Join(root, "bad", "tars.plugin.json")
+	if err := os.MkdirAll(filepath.Dir(manifestPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	content := `{"schema_version":3,"id":"bad","tools_provider":{"type":"unknown"}}`
+	if err := os.WriteFile(manifestPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	_, err := parseManifestFile(manifestPath)
+	if err == nil {
+		t.Fatal("expected error for unsupported tools_provider type")
+	}
+}

--- a/internal/plugin/registry_test.go
+++ b/internal/plugin/registry_test.go
@@ -167,6 +167,39 @@ func TestLoad_FiltersUnavailablePluginsAndSkipsTheirSkillsAndMCP(t *testing.T) {
 	}
 }
 
+func TestLoad_V3PluginFieldsCarried(t *testing.T) {
+	root := t.TempDir()
+	pluginsDir := filepath.Join(root, "plugins")
+	writeManifest(t, filepath.Join(pluginsDir, "browser", "tars.plugin.json"), `{
+  "schema_version": 3,
+  "id": "browser",
+  "name": "Browser",
+  "tools_provider": {"type": "script", "entry": "bin/tools"},
+  "lifecycle": {"on_start": "echo start", "on_stop": "echo stop"},
+  "http_routes": [{"path": "/v1/browser/*", "handler": "bh"}]
+}`)
+
+	snapshot, err := Load(LoadOptions{
+		Sources: []SourceDir{{Source: SourceWorkspace, Dir: pluginsDir}},
+	})
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(snapshot.Plugins) != 1 {
+		t.Fatalf("expected 1 plugin, got %d", len(snapshot.Plugins))
+	}
+	p := snapshot.Plugins[0]
+	if p.ToolsProvider == nil || p.ToolsProvider.Type != "script" || p.ToolsProvider.Entry != "bin/tools" {
+		t.Fatalf("tools_provider not carried: %+v", p.ToolsProvider)
+	}
+	if p.Lifecycle == nil || p.Lifecycle.OnStart != "echo start" || p.Lifecycle.OnStop != "echo stop" {
+		t.Fatalf("lifecycle not carried: %+v", p.Lifecycle)
+	}
+	if len(p.HTTPRoutes) != 1 || p.HTTPRoutes[0].Path != "/v1/browser/*" {
+		t.Fatalf("http_routes not carried: %+v", p.HTTPRoutes)
+	}
+}
+
 func writeManifest(t *testing.T, path string, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -14,6 +14,24 @@ type Policies struct {
 	ToolsDeny  []string `json:"tools_deny,omitempty"`
 }
 
+// ToolsProvider declares how a plugin provides tools (v3+).
+type ToolsProvider struct {
+	Type  string `json:"type"`            // "mcp_server", "go_plugin", or "script"
+	Entry string `json:"entry,omitempty"` // entrypoint path or command
+}
+
+// Lifecycle declares shell commands to run at server start/stop (v3+).
+type Lifecycle struct {
+	OnStart string `json:"on_start,omitempty"`
+	OnStop  string `json:"on_stop,omitempty"`
+}
+
+// HTTPRoute declares an HTTP endpoint a plugin handles (v3+).
+type HTTPRoute struct {
+	Path    string `json:"path"`
+	Handler string `json:"handler,omitempty"`
+}
+
 type Source string
 
 const (
@@ -35,6 +53,9 @@ type Manifest struct {
 	SupportedArch         []string           `json:"supported_arch,omitempty"`
 	DefaultProjectProfile string             `json:"default_project_profile,omitempty"`
 	Policies              Policies           `json:"policies,omitempty"`
+	ToolsProvider         *ToolsProvider     `json:"tools_provider,omitempty"`
+	Lifecycle             *Lifecycle         `json:"lifecycle,omitempty"`
+	HTTPRoutes            []HTTPRoute        `json:"http_routes,omitempty"`
 }
 
 type Definition struct {
@@ -53,6 +74,9 @@ type Definition struct {
 	SupportedArch         []string           `json:"supported_arch,omitempty"`
 	DefaultProjectProfile string             `json:"default_project_profile,omitempty"`
 	Policies              Policies           `json:"policies,omitempty"`
+	ToolsProvider         *ToolsProvider     `json:"tools_provider,omitempty"`
+	Lifecycle             *Lifecycle         `json:"lifecycle,omitempty"`
+	HTTPRoutes            []HTTPRoute        `json:"http_routes,omitempty"`
 }
 
 type Diagnostic struct {


### PR DESCRIPTION
## Summary

- Plugin manifest **schema v3** 추가: `ToolsProvider`, `Lifecycle`, `HTTPRoute` 인터페이스
- Extensions Manager에 **lifecycle hooks** 실행 (`on_start`/`on_stop` shell commands)
- **Tool provider** collection stub (Phase 2에서 실제 구현)
- v1/v2 매니페스트 하위 호환성 유지, v3 전용 필드 격리 검증

Closes #188 (Phase 1)

## Changes

| File | Change |
|------|--------|
| `internal/plugin/types.go` | `ToolsProvider`, `Lifecycle`, `HTTPRoute` 타입 + Manifest/Definition 필드 |
| `internal/plugin/manifest.go` | v3 파싱, 필드 검증, `normalizeHTTPRoutes()` |
| `internal/plugin/loader.go` | Definition 매핑에 v3 필드 복사 |
| `internal/extensions/lifecycle.go` | 새 파일 — 훅 실행 로직 (30s timeout, non-fatal) |
| `internal/extensions/manager.go` | Start/Close에 훅 호출, Reload에 tool provider stub |

## Test plan

- [x] `TestParseManifest_V3WithToolsProvider` — v3 전체 필드 파싱
- [x] `TestParseManifest_V3FieldsOnV2Rejected` — v2에서 v3 필드 사용 시 에러
- [x] `TestParseManifest_V3InvalidToolsProviderType` — 잘못된 type 에러
- [x] `TestLoad_V3PluginFieldsCarried` — v3 필드가 Snapshot까지 전달
- [x] `TestRunLifecycleHooks_OnStart` — on_start 명령 실행
- [x] `TestRunLifecycleHooks_Timeout` — 타임아웃 처리
- [x] `TestRunLifecycleHooks_NoHook` — 훅 없는 플러그인 건너뜀
- [x] 기존 v1/v2 테스트 전체 통과
- [x] `make build` 성공