### PR TITLE
fix: expose MCP allowlist in config UI, improve tool loading diagnostics

### DIFF
--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -94,7 +94,6 @@ func Schema() []FieldMeta {
 		// ── Tools ────────────────────────────────
 		f("tools_web_search_enabled", "Tools", "bool", "Web Search", "Enable web search tool"),
 		f("tools_web_fetch_enabled", "Tools", "bool", "Web Fetch", "Enable web fetch tool"),
-		fsel("tools_default_set", "Tools", "Default Tool Set", "Tool set preset", []string{"minimal", "standard", "full"}),
 		f("tools_allow_high_risk_user", "Tools", "bool", "Allow High-Risk Tools", "Allow user-level access to high-risk tools"),
 		fs("tools_web_search_api_key", "Tools", "Search API Key", "API key for web search provider", true),
 		fsel("tools_web_search_provider", "Tools", "Search Provider", "Web search backend", []string{"brave", "perplexity"}),
@@ -105,6 +104,9 @@ func Schema() []FieldMeta {
 		f("tools_browser_enabled", "Tools", "bool", "Browser Tool", "Enable browser automation tool"),
 		f("tools_nodes_enabled", "Tools", "bool", "Nodes Tool", "Enable sub-agent nodes tool"),
 		f("tools_gateway_enabled", "Tools", "bool", "Gateway Tool", "Enable gateway dispatch tool"),
+
+		// ── MCP ──────────────────────────────────
+		f("mcp_command_allowlist_json", "MCP", "json", "Command Allowlist", "JSON array of allowed commands for MCP servers (e.g. [\"npx\",\"node\",\"uvx\",\"python3\"])"),
 
 		// ── Vault ────────────────────────────────
 		f("vault_enabled", "Vault", "bool", "Enabled", "Enable HashiCorp Vault integration"),
@@ -289,8 +291,6 @@ func extractValue(yamlKey string, cfg Config) any {
 		return cfg.ToolsWebSearchEnabled
 	case "tools_web_fetch_enabled":
 		return cfg.ToolsWebFetchEnabled
-	case "tools_default_set":
-		return cfg.ToolsDefaultSet
 	case "tools_allow_high_risk_user":
 		return cfg.ToolsAllowHighRiskUser
 	case "tools_web_search_api_key":
@@ -311,6 +311,9 @@ func extractValue(yamlKey string, cfg Config) any {
 		return cfg.ToolsNodesEnabled
 	case "tools_gateway_enabled":
 		return cfg.ToolsGatewayEnabled
+	// MCP
+	case "mcp_command_allowlist_json":
+		return cfg.MCPCommandAllowlist
 	// Vault
 	case "vault_enabled":
 		return cfg.VaultEnabled

--- a/internal/extensions/manager.go
+++ b/internal/extensions/manager.go
@@ -233,7 +233,8 @@ func (m *Manager) Reload(ctx context.Context) error {
 		m.opts.MCPRuntime.SetServers(mcpServers)
 		mcpTools, err = m.opts.MCPRuntime.BuildTools(ctx)
 		if err != nil {
-			// MCP server failures should not block startup; continue without mcp tools.
+			// MCP server failures should not block startup; record diagnostic and continue.
+			mcpDiagnostics = append(mcpDiagnostics, fmt.Sprintf("mcp tools build failed: %v", err))
 			mcpTools = nil
 		}
 	}

--- a/internal/mcp/client_api.go
+++ b/internal/mcp/client_api.go
@@ -73,16 +73,16 @@ func (c *Client) ListTools(ctx context.Context) ([]ToolInfo, error) {
 	wg.Wait()
 
 	out := make([]ToolInfo, 0)
-	failed := 0
-	for _, result := range results {
+	var errs []string
+	for i, result := range results {
 		if result.err != nil {
-			failed++
+			errs = append(errs, fmt.Sprintf("mcp server %q: %v", servers[i].Name, result.err))
 			continue
 		}
 		out = append(out, result.tools...)
 	}
-	if len(out) == 0 && failed > 0 {
-		return nil, fmt.Errorf("all configured mcp servers failed")
+	if len(out) == 0 && len(errs) > 0 {
+		return nil, fmt.Errorf("all configured mcp servers failed: %s", strings.Join(errs, "; "))
 	}
 	return out, nil
 }

--- a/internal/tarsserver/handler_chat_policy.go
+++ b/internal/tarsserver/handler_chat_policy.go
@@ -83,7 +83,7 @@ func buildChatToolRegistry(
 
 func resolveInjectedToolSchemas(
 	registry *tool.Registry,
-	toolsDefaultSet string,
+	_ string, // toolsDefaultSet — deprecated, individual tool toggles + high-risk filter used instead
 	activeProject *project.Project,
 	authRole string,
 	allowHighRiskUser bool,
@@ -91,12 +91,9 @@ func resolveInjectedToolSchemas(
 	if registry == nil {
 		return nil
 	}
-	mode := strings.TrimSpace(strings.ToLower(toolsDefaultSet))
+
 	if activeProject == nil {
-		if mode == "minimal" {
-			names := filterHighRiskToolNamesForRole(defaultMinimalToolNames(), authRole, allowHighRiskUser)
-			return registry.SchemasForNames(names)
-		}
+		// No project context: use all registered tools, filtered by high-risk policy
 		if shouldFilterHighRiskTools(authRole, allowHighRiskUser) {
 			names := filterHighRiskToolNamesForRole(toolNamesFromSchemas(registry.Schemas()), authRole, allowHighRiskUser)
 			return registry.SchemasForNames(names)
@@ -104,7 +101,8 @@ func resolveInjectedToolSchemas(
 		return registry.Schemas()
 	}
 
-	names := defaultMinimalToolNames()
+	// Project context: start with all registered tools, apply project policy
+	names := toolNamesFromSchemas(registry.Schemas())
 	policy := project.NormalizeToolPolicy(project.ToolPolicySpec{
 		ToolsAllow:               activeProject.ToolsAllow,
 		ToolsAllowExists:         len(activeProject.ToolsAllow) > 0,
@@ -117,10 +115,6 @@ func resolveInjectedToolSchemas(
 		ToolsRiskMax:             activeProject.ToolsRiskMax,
 		ToolsRiskMaxExists:       strings.TrimSpace(activeProject.ToolsRiskMax) != "",
 	}, knownToolsFromRegistry(registry), project.ToolPolicyOptions{})
-	if len(policy.AllowedTools) > 0 {
-		names = append(names, policy.AllowedTools...)
-	}
-	names = normalizeToolNames(names)
 	names = project.ApplyToolConstraints(names, policy)
 	names = filterHighRiskToolNamesForRole(names, authRole, allowHighRiskUser)
 	if len(names) == 0 {


### PR DESCRIPTION
## Summary

- **MCP Command Allowlist** 콘솔 UI Config에 노출 (MCP 섹션 추가)
- **MCP 도구 로드 실패** 시 에러를 diagnostics에 기록 (기존: 무시)
- **tools_default_set 필터링 제거** — 개별 토글 + high-risk 필터로 충분

## Test plan

- [x] `make build` + `go test` 통과
- [ ] 콘솔에서 MCP > Command Allowlist 설정 가능 확인