### PR TITLE
fix: accept comma-separated MCP command allowlist in config UI

### DIFF
--- a/internal/config/parse_helpers.go
+++ b/internal/config/parse_helpers.go
@@ -72,17 +72,23 @@ func parseCSVList(raw string) []string {
 }
 
 func parseJSONStringList(raw string, fallback []string) []string {
-	var parsed []string
-	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &parsed); err != nil {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
 		return fallback
+	}
+	// Try JSON array first
+	var parsed []string
+	if err := json.Unmarshal([]byte(trimmed), &parsed); err != nil {
+		// Fall back to comma-separated
+		parsed = strings.Split(trimmed, ",")
 	}
 	out := make([]string, 0, len(parsed))
 	for _, item := range parsed {
-		trimmed := strings.TrimSpace(item)
-		if trimmed == "" {
+		v := strings.TrimSpace(item)
+		if v == "" {
 			continue
 		}
-		out = append(out, trimmed)
+		out = append(out, v)
 	}
 	if len(out) == 0 {
 		return fallback

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1,5 +1,7 @@
 package config
 
+import "strings"
+
 // FieldMeta describes a single configuration field for UI rendering.
 type FieldMeta struct {
 	Key         string   `json:"key"`
@@ -106,7 +108,7 @@ func Schema() []FieldMeta {
 		f("tools_gateway_enabled", "Tools", "bool", "Gateway Tool", "Enable gateway dispatch tool"),
 
 		// ── MCP ──────────────────────────────────
-		f("mcp_command_allowlist_json", "MCP", "json", "Command Allowlist", "JSON array of allowed commands for MCP servers (e.g. [\"npx\",\"node\",\"uvx\",\"python3\"])"),
+		f("mcp_command_allowlist_json", "MCP", "string", "Command Allowlist", "Comma-separated list of allowed commands for MCP servers (e.g. npx,node,uvx,python3)"),
 
 		// ── Vault ────────────────────────────────
 		f("vault_enabled", "Vault", "bool", "Enabled", "Enable HashiCorp Vault integration"),
@@ -313,7 +315,7 @@ func extractValue(yamlKey string, cfg Config) any {
 		return cfg.ToolsGatewayEnabled
 	// MCP
 	case "mcp_command_allowlist_json":
-		return cfg.MCPCommandAllowlist
+		return strings.Join(cfg.MCPCommandAllowlist, ",")
 	// Vault
 	case "vault_enabled":
 		return cfg.VaultEnabled


### PR DESCRIPTION
## Summary

MCP Command Allowlist 입력을 JSON 배열에서 **콤마 구분 문자열**로 변경.

Before: `["npx","node","uvx"]`
After: `npx,node,uvx`

파서는 하위 호환성을 위해 JSON 배열도 계속 지원합니다.

## Test plan

- [x] `make build` + `go test` 통과
- [ ] 콘솔 Config > MCP > Command Allowlist에 `npx,node` 입력 후 저장/재시작