### PR TITLE
fix: prevent config field double-commit on Enter then blur

### DIFF
--- a/frontend/console/src/components/Config.svelte
+++ b/frontend/console/src/components/Config.svelte
@@ -138,6 +138,7 @@
   }
 
   function commitEdit(field: ConfigFieldMeta) {
+    if (editingKey === null) return // already committed (e.g. Enter then blur)
     let parsed: unknown
     if (field.type === 'bool') {
       parsed = editBool


### PR DESCRIPTION
## Summary

Config 폼에서 값 입력 후 Enter 치면 값이 사라지는 버그 수정.

**원인**: Enter → `commitEdit()` → `editValue=''` → blur → `commitEdit()` 재호출 → 빈 값으로 dirty 리셋
**수정**: `editingKey === null` guard로 이미 커밋된 상태에서 재호출 방지

## Test plan

- [x] `make console-build` + `make build` 성공
- [ ] Config 폼에서 값 입력 후 Enter → 값이 유지되고 dirty 뱃지 표시