### PR TITLE
feat: multi-session chat + tool call transcript persistence

### DIFF
--- a/frontend/console/src/components/ChatPanel.svelte
+++ b/frontend/console/src/components/ChatPanel.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { onMount, onDestroy, tick } from 'svelte'
-  import { streamChat } from '../lib/api'
+  import { streamChat, listSessions, getSessionHistory } from '../lib/api'
   import { renderMarkdown } from '../lib/markdown'
-  import type { ChatAttachment, ChatEvent } from '../lib/types'
+  import type { ChatAttachment, ChatEvent, Session, SessionMessage } from '../lib/types'
 
   type ChatMessage = {
     id: string
@@ -32,6 +32,56 @@
 
   let chatLogEl: HTMLDivElement | undefined = $state()
   let autoScroll = $state(true)
+
+  // Multi-session
+  let sessions: Session[] = $state([])
+  let showSessions = $state(false)
+
+  async function loadSessions() {
+    try {
+      sessions = await listSessions()
+    } catch { /* ignore */ }
+  }
+
+  async function switchSession(sid: string) {
+    chatSessionId = sid
+    chatMessages = [{ id: 'system-init', role: 'system', text: `Session: ${sid.slice(0, 8)}...` }]
+    chatStatusLine = ''
+    chatError = ''
+    showSessions = false
+    try {
+      const history = await getSessionHistory(sid)
+      for (const msg of history) {
+        if (msg.role === 'tool') {
+          chatMessages.push({
+            id: `tool-${msg.tool_call_id || Date.now()}`,
+            role: 'tool',
+            text: '',
+            toolName: msg.tool_name,
+            toolCallId: msg.tool_call_id,
+            toolArgs: msg.tool_args,
+            toolResult: msg.content,
+            toolDone: true,
+          })
+        } else {
+          chatMessages.push({
+            id: `hist-${chatMessages.length}`,
+            role: msg.role as ChatMessage['role'],
+            text: msg.content,
+          })
+        }
+      }
+      chatMessages = [...chatMessages]
+    } catch { /* ignore */ }
+  }
+
+  function startNewSession() {
+    chatSessionId = ''
+    chatMessages = [{ id: 'system-init', role: 'system', text: 'New session' }]
+    chatStatusLine = ''
+    chatError = ''
+    showSessions = false
+  }
 
   function handleScroll() {
     if (!chatLogEl) return
@@ -104,6 +154,7 @@
       case 'done':
         chatSessionId = event.session_id?.trim() || chatSessionId
         chatStatusLine = 'done'
+        void loadSessions()
         break
       case 'error':
         chatError = event.error?.trim() || 'Stream failed'
@@ -233,20 +284,44 @@
   let textareaEl: HTMLTextAreaElement | undefined = $state()
 
   onMount(() => {
-    if (sessionId) chatSessionId = sessionId
-    const scope = sessionId ? `session ${sessionId}` : projectId ? `project ${projectId}` : 'TARS'
-    chatMessages = [{ id: 'system-init', role: 'system', text: `Chat scoped to ${scope}` }]
+    if (sessionId) {
+      chatSessionId = sessionId
+      void switchSession(sessionId)
+    } else {
+      const scope = projectId ? `project ${projectId}` : 'TARS'
+      chatMessages = [{ id: 'system-init', role: 'system', text: `Chat scoped to ${scope}` }]
+    }
     if (initialPrompt) {
       chatInput = initialPrompt
       tick().then(() => textareaEl?.focus())
     }
+    void loadSessions()
   })
 </script>
 
 <div class="chat-panel">
-  <div class="chat-status">
-    {chatBusy ? 'streaming' : chatStatusLine || 'idle'}
+  <div class="chat-toolbar-row">
+    <div class="chat-status">
+      {chatBusy ? 'streaming' : chatStatusLine || 'idle'}
+    </div>
+    <div class="session-controls">
+      {#if chatSessionId}
+        <span class="session-id" title={chatSessionId}>{chatSessionId.slice(0, 8)}</span>
+      {/if}
+      <button class="btn btn-ghost btn-sm" onclick={() => { showSessions = !showSessions; if (showSessions) void loadSessions() }}>Sessions</button>
+      <button class="btn btn-ghost btn-sm" onclick={startNewSession}>New</button>
+    </div>
   </div>
+  {#if showSessions && sessions.length > 0}
+    <div class="session-list">
+      {#each sessions.slice(0, 20) as s}
+        <button class="session-item" class:active={chatSessionId === s.id} onclick={() => switchSession(s.id)}>
+          <span class="session-item-title">{s.title || s.id.slice(0, 12)}</span>
+          <span class="session-item-meta">{s.kind || 'main'}</span>
+        </button>
+      {/each}
+    </div>
+  {/if}
   <div class="chat-log" bind:this={chatLogEl} onscroll={handleScroll}>
     {#each chatMessages as msg}
       {#if msg.role === 'tool'}
@@ -340,10 +415,72 @@
     min-height: 0;
   }
 
+  .chat-toolbar-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: var(--space-2);
+  }
+
   .chat-status {
     font-size: var(--text-xs);
     color: var(--text-tertiary);
-    margin-bottom: var(--space-3);
+  }
+
+  .session-controls {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+  }
+
+  .session-id {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-ghost);
+    background: var(--bg-elevated);
+    padding: 1px var(--space-1);
+    border-radius: var(--radius-sm);
+  }
+
+  .session-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    max-height: 200px;
+    overflow-y: auto;
+    margin-bottom: var(--space-2);
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+  }
+
+  .session-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-2) var(--space-3);
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    text-align: left;
+    transition: background var(--duration-fast) var(--ease-out);
+  }
+  .session-item:hover { background: rgba(255, 255, 255, 0.03); }
+  .session-item.active { background: rgba(224, 145, 69, 0.1); border-left: 2px solid var(--accent); }
+
+  .session-item-title {
+    font-size: var(--text-xs);
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 200px;
+  }
+
+  .session-item-meta {
+    font-size: 10px;
+    color: var(--text-ghost);
+    font-family: var(--font-mono);
   }
 
   .chat-log {

--- a/frontend/console/src/components/Sessions.svelte
+++ b/frontend/console/src/components/Sessions.svelte
@@ -156,17 +156,39 @@
             {:else}
               <div class="transcript-messages">
                 {#each history as msg}
-                  <div class="transcript-msg transcript-{msg.role}">
-                    <div class="transcript-msg-top">
-                      <span class="transcript-role">{msg.role}</span>
-                      <span class="transcript-time">{fmt(msg.timestamp)}</span>
+                  {#if msg.role === 'tool'}
+                    <div class="transcript-msg transcript-tool">
+                      <div class="transcript-msg-top">
+                        <span class="transcript-tool-icon">{'\u2713'}</span>
+                        <span class="transcript-tool-name">{msg.tool_name || 'tool'}</span>
+                        <span class="transcript-time">{fmt(msg.timestamp)}</span>
+                      </div>
+                      {#if msg.tool_args}
+                        <div class="transcript-tool-detail">
+                          <span class="transcript-tool-label">args</span>
+                          <code class="transcript-tool-value">{msg.tool_args}</code>
+                        </div>
+                      {/if}
+                      {#if msg.content}
+                        <div class="transcript-tool-detail">
+                          <span class="transcript-tool-label">result</span>
+                          <code class="transcript-tool-value">{msg.content}</code>
+                        </div>
+                      {/if}
                     </div>
-                    {#if msg.role === 'assistant'}
-                      <div class="transcript-content transcript-md">{@html renderMarkdown(msg.content || '')}</div>
-                    {:else}
-                      <div class="transcript-content">{msg.content || ''}</div>
-                    {/if}
-                  </div>
+                  {:else}
+                    <div class="transcript-msg transcript-{msg.role}">
+                      <div class="transcript-msg-top">
+                        <span class="transcript-role">{msg.role}</span>
+                        <span class="transcript-time">{fmt(msg.timestamp)}</span>
+                      </div>
+                      {#if msg.role === 'assistant'}
+                        <div class="transcript-content transcript-md">{@html renderMarkdown(msg.content || '')}</div>
+                      {:else}
+                        <div class="transcript-content">{msg.content || ''}</div>
+                      {/if}
+                    </div>
+                  {/if}
                 {/each}
               </div>
             {/if}
@@ -370,6 +392,23 @@
 
   .transcript-assistant {
     background: var(--bg-elevated);
+  }
+
+  .transcript-tool {
+    background: rgba(139, 92, 246, 0.06);
+    border: 1px solid rgba(139, 92, 246, 0.12);
+    padding: var(--space-2) var(--space-3);
+    font-size: var(--text-xs);
+  }
+  .transcript-tool-icon { font-size: var(--text-sm); }
+  .transcript-tool-name { font-family: var(--font-mono); font-weight: 600; color: var(--text-primary); }
+  .transcript-tool-detail { margin-top: var(--space-1); display: flex; gap: var(--space-2); align-items: flex-start; }
+  .transcript-tool-label { font-family: var(--font-mono); color: var(--text-ghost); flex-shrink: 0; min-width: 36px; }
+  .transcript-tool-value {
+    font-family: var(--font-mono); color: var(--text-secondary);
+    white-space: pre-wrap; word-break: break-all; font-size: var(--text-xs);
+    background: rgba(255, 255, 255, 0.04); padding: 2px 6px; border-radius: 3px;
+    max-height: 120px; overflow-y: auto;
   }
 
   .transcript-system {

--- a/frontend/console/src/lib/types.ts
+++ b/frontend/console/src/lib/types.ts
@@ -116,6 +116,9 @@ export type SessionMessage = {
   role: string
   content: string
   timestamp: string
+  tool_name?: string
+  tool_call_id?: string
+  tool_args?: string
 }
 
 export type OpsStatus = {

--- a/internal/session/message.go
+++ b/internal/session/message.go
@@ -3,8 +3,12 @@ package session
 import "time"
 
 // Message represents a single chat message in a session transcript.
+// Tool fields are optional (omitempty) for backward compatibility with existing transcripts.
 type Message struct {
-	Role      string    `json:"role"`
-	Content   string    `json:"content"`
-	Timestamp time.Time `json:"timestamp"`
+	Role       string    `json:"role"`
+	Content    string    `json:"content"`
+	Timestamp  time.Time `json:"timestamp"`
+	ToolName   string    `json:"tool_name,omitempty"`
+	ToolCallID string    `json:"tool_call_id,omitempty"`
+	ToolArgs   string    `json:"tool_args,omitempty"`
 }

--- a/internal/tarsserver/handler_chat.go
+++ b/internal/tarsserver/handler_chat.go
@@ -355,6 +355,14 @@ func hasActiveProjectBrief(workspaceDir, sessionID string) bool {
 	return project.DefaultWorkflowPolicy.HasActiveBriefStatus(item.Status)
 }
 
+// ToolCallRecord holds a tool invocation for transcript persistence.
+type ToolCallRecord struct {
+	ToolName   string
+	ToolCallID string
+	ToolArgs   string
+	ToolResult string
+}
+
 func setupAgentLoop(
 	client llm.Client,
 	registry *tool.Registry,
@@ -362,7 +370,8 @@ func setupAgentLoop(
 	historyLen int,
 	logger zerolog.Logger,
 	sendStatus func(string, string, string, string, string, string),
-) *agent.Loop {
+) (*agent.Loop, *[]ToolCallRecord) {
+	toolCalls := &[]ToolCallRecord{}
 	if _, ok := registry.Get("session_status"); !ok {
 		registry.Register(tool.NewSessionStatusTool(func(_ context.Context) (tool.SessionStatus, error) {
 			return tool.SessionStatus{
@@ -407,6 +416,12 @@ func setupAgentLoop(
 				"",
 				statusPreview(evt.ToolResult, 180),
 			)
+			*toolCalls = append(*toolCalls, ToolCallRecord{
+				ToolName:   evt.ToolName,
+				ToolCallID: evt.ToolCallID,
+				ToolArgs:   statusPreview(evt.ToolArgs, 500),
+				ToolResult: statusPreview(evt.ToolResult, 500),
+			})
 		case agent.EventLoopEnd:
 			sendStatus("loop_end", "agent loop completed", "", "", "", "")
 			logger.Debug().
@@ -422,7 +437,7 @@ func setupAgentLoop(
 			sendStatus("error", msg, evt.ToolName, evt.ToolCallID, "", "")
 		}
 	})
-	return agent.NewLoop(client, registry, counterHook, auditHook, logHook)
+	return agent.NewLoop(client, registry, counterHook, auditHook, logHook), toolCalls
 }
 
 func resolveAgentMaxIterations(value int) int {

--- a/internal/tarsserver/handler_chat_execution.go
+++ b/internal/tarsserver/handler_chat_execution.go
@@ -15,10 +15,10 @@ func executeChatLoop(
 	deps chatHandlerDeps,
 	state chatRunState,
 	stream *chatStreamWriter,
-) (llm.ChatResponse, bool, error) {
+) (llm.ChatResponse, bool, []ToolCallRecord, error) {
 	streamingAnnounced := false
 	deltaSent := false
-	loop := setupAgentLoop(deps.client, state.registry, state.sessionID, len(state.history), deps.logger, stream.status)
+	loop, toolCallRecords := setupAgentLoop(deps.client, state.registry, state.sessionID, len(state.history), deps.logger, stream.status)
 
 	deps.logger.Debug().Str("session_id", state.sessionID).Int("messages", len(state.llmMessages)).Msg("llm chat call start")
 	chatResp, err := loop.Run(ctx, state.llmMessages, agent.RunOptions{
@@ -40,7 +40,7 @@ func executeChatLoop(
 	})
 	if err != nil {
 		deps.logger.Debug().Str("session_id", state.sessionID).Err(err).Msg("llm chat call failed")
-		return llm.ChatResponse{}, false, err
+		return llm.ChatResponse{}, false, nil, err
 	}
 	deps.logger.Debug().
 		Str("session_id", state.sessionID).
@@ -50,11 +50,26 @@ func executeChatLoop(
 		Str("stop_reason", chatResp.StopReason).
 		Msg("llm chat call complete")
 
-	return chatResp, deltaSent, nil
+	return chatResp, deltaSent, *toolCallRecords, nil
 }
 
-func persistChatResult(state chatRunState, userMessage string, chatResp llm.ChatResponse, logger zerolog.Logger) {
-	assistantMsg := session.Message{Role: "assistant", Content: chatResp.Message.Content, Timestamp: time.Now().UTC()}
+func persistChatResult(state chatRunState, userMessage string, chatResp llm.ChatResponse, toolCalls []ToolCallRecord, logger zerolog.Logger) {
+	now := time.Now().UTC()
+	// Persist tool call messages before the assistant response
+	for _, tc := range toolCalls {
+		toolMsg := session.Message{
+			Role:       "tool",
+			Content:    tc.ToolResult,
+			Timestamp:  now,
+			ToolName:   tc.ToolName,
+			ToolCallID: tc.ToolCallID,
+			ToolArgs:   tc.ToolArgs,
+		}
+		if err := session.AppendMessage(state.transcriptPath, toolMsg); err != nil {
+			logger.Error().Err(err).Str("tool", tc.ToolName).Msg("append tool message failed")
+		}
+	}
+	assistantMsg := session.Message{Role: "assistant", Content: chatResp.Message.Content, Timestamp: now}
 	if err := session.AppendMessage(state.transcriptPath, assistantMsg); err != nil {
 		logger.Error().Err(err).Msg("append assistant message failed")
 	} else if err := state.store.Touch(state.sessionID, assistantMsg.Timestamp); err != nil {

--- a/internal/tarsserver/handler_chat_pipeline.go
+++ b/internal/tarsserver/handler_chat_pipeline.go
@@ -81,7 +81,7 @@ func handleChatRequest(w http.ResponseWriter, r *http.Request, deps chatHandlerD
 		SessionID: state.sessionID,
 		ProjectID: state.projectID,
 	})
-	chatResp, deltaSent, err := executeChatLoop(chatCtx, deps, state, stream)
+	chatResp, deltaSent, toolCalls, err := executeChatLoop(chatCtx, deps, state, stream)
 	if err != nil {
 		stream.error(err)
 		return
@@ -94,7 +94,7 @@ func handleChatRequest(w http.ResponseWriter, r *http.Request, deps chatHandlerD
 		stream.delta(chatResp.Message.Content)
 	}
 
-	persistChatResult(state, req.Message, chatResp, deps.logger)
+	persistChatResult(state, req.Message, chatResp, toolCalls, deps.logger)
 	stream.done(chatResp.Usage)
 	deps.logger.Debug().Str("session_id", state.sessionID).Msg("chat request complete")
 }

--- a/internal/tarsserver/handler_chat_pipeline_state_test.go
+++ b/internal/tarsserver/handler_chat_pipeline_state_test.go
@@ -86,7 +86,7 @@ func TestPersistChatResult_AppendsAssistantMessageAndTouchesSession(t *testing.T
 			Role:    "assistant",
 			Content: "reply",
 		},
-	}, logger)
+	}, nil, logger)
 
 	msgs, err := session.ReadMessages(store.TranscriptPath(sess.ID))
 	if err != nil {
@@ -149,8 +149,8 @@ func TestPersistChatResult_PromotesMemoryAndDedupesExperience(t *testing.T) {
 	}
 	userMessage := "remember I prefer black coffee"
 
-	persistChatResult(state, userMessage, response, logger)
-	persistChatResult(state, userMessage, response, logger)
+	persistChatResult(state, userMessage, response, nil, logger)
+	persistChatResult(state, userMessage, response, nil, logger)
 
 	memoryFile, err := os.ReadFile(filepath.Join(root, "MEMORY.md"))
 	if err != nil {

--- a/internal/tarsserver/helpers_agent.go
+++ b/internal/tarsserver/helpers_agent.go
@@ -208,7 +208,7 @@ func newAgentPromptRunnerWithToolsAndMemory(
 			meta.RunID = strings.TrimSpace(label[idx+1:])
 		}
 		ctx = usage.WithCallMeta(ctx, meta)
-		loop := setupAgentLoop(client, registry, label, 0, logger, func(string, string, string, string, string, string) {})
+		loop, _ := setupAgentLoop(client, registry, label, 0, logger, func(string, string, string, string, string, string) {})
 		resp, err := loop.Run(ctx, []llm.ChatMessage{
 			{Role: "system", Content: systemPrompt},
 			{Role: "user", Content: promptText},


### PR DESCRIPTION
## Summary

### 백엔드
- `session.Message`에 `ToolName`, `ToolCallID`, `ToolArgs` 필드 추가 (하위 호환)
- 채팅 실행 시 tool 호출 기록을 트랜스크립트에 저장 (assistant 응답 전)
- agent event hook에서 tool call 수집

### 프론트엔드 ChatPanel
- **Sessions** 버튼 — 세션 목록 표시/전환
- **New** 버튼 — 새 세션 시작
- 세션 전환 시 히스토리 로드 (tool 카드 포함)
- 세션 ID 표시

### 프론트엔드 Sessions
- 트랜스크립트에서 tool 메시지를 보라색 카드로 렌더링 (실시간 채팅과 동일 스타일)

Closes #199

## Test plan

- [x] `make build` + `go test` 통과
- [x] `make console-build` 성공
- [ ] 채팅에서 tool 사용 → Sessions 페이지에서 tool 카드 표시 확인
- [ ] Sessions 버튼 → 세션 목록 → 클릭하여 세션 전환 + 히스토리 로드