### PR TITLE
fix: new session creation falls back to main session

### DIFF
--- a/frontend/console/src/components/ChatPanel.svelte
+++ b/frontend/console/src/components/ChatPanel.svelte
@@ -76,7 +76,7 @@
   }
 
   function startNewSession() {
-    chatSessionId = ''
+    chatSessionId = 'new'
     chatMessages = [{ id: 'system-init', role: 'system', text: 'New session' }]
     chatStatusLine = ''
     chatError = ''

--- a/internal/tarsserver/handler_chat.go
+++ b/internal/tarsserver/handler_chat.go
@@ -28,8 +28,11 @@ import (
 func resolveChatSession(store *session.Store, sessionID string, mainSessionID string, userMessage string) (string, error) {
 	// The public session API exposes the main session as id="main";
 	// translate it back to the real internal ID so store.Get succeeds.
-	if strings.EqualFold(strings.TrimSpace(sessionID), "main") {
+	trimmedID := strings.TrimSpace(sessionID)
+	if strings.EqualFold(trimmedID, "main") {
 		sessionID = strings.TrimSpace(mainSessionID)
+	} else if strings.EqualFold(trimmedID, "new") {
+		return createFallbackChatSession(store)
 	}
 	if strings.TrimSpace(sessionID) == "" {
 		if project.DefaultWorkflowPolicy.IsKickoffMessage(userMessage) {


### PR DESCRIPTION
## Summary

New 버튼으로 세션 생성 시 main 세션으로 라우팅되는 버그 수정.

**원인**: 빈 session_id → `resolveChatSession()`이 mainSessionID로 fallback
**수정**: `"new"` 특수 session_id를 인식하여 `createFallbackChatSession()` 호출

## Test plan

- [x] `make build` + `go test` 통과
- [ ] New 버튼 → 채팅 → 새 세션 생성 확인 (main과 분리)