### PR TITLE
fix: session UX — remove duplicate transcript, fix scroll and list refresh

### DIFF
--- a/frontend/console/src/components/ChatPanel.svelte
+++ b/frontend/console/src/components/ChatPanel.svelte
@@ -19,9 +19,10 @@
     projectId?: string
     sessionId?: string
     initialPrompt?: string
+    onSessionChange?: () => void
   }
 
-  let { projectId, sessionId, initialPrompt }: Props = $props()
+  let { projectId, sessionId, initialPrompt, onSessionChange }: Props = $props()
 
   let chatInput = $state('')
   let chatBusy = $state(false)
@@ -49,6 +50,7 @@
     chatStatusLine = ''
     chatError = ''
     showSessions = false
+    autoScroll = true
     try {
       const history = await getSessionHistory(sid)
       for (const msg of history) {
@@ -72,6 +74,7 @@
         }
       }
       chatMessages = [...chatMessages]
+      void scrollToBottom()
     } catch { /* ignore */ }
   }
 
@@ -155,6 +158,7 @@
         chatSessionId = event.session_id?.trim() || chatSessionId
         chatStatusLine = 'done'
         void loadSessions()
+        onSessionChange?.()
         break
       case 'error':
         chatError = event.error?.trim() || 'Stream failed'

--- a/frontend/console/src/components/Sessions.svelte
+++ b/frontend/console/src/components/Sessions.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { listSessions, getSessionHistory } from '../lib/api'
-  import { renderMarkdown } from '../lib/markdown'
-  import type { Session, SessionMessage } from '../lib/types'
+  import { listSessions } from '../lib/api'
+  import type { Session } from '../lib/types'
   import ChatPanel from './ChatPanel.svelte'
 
   let sessions: Session[] = $state([])
@@ -11,9 +10,6 @@
   let showHidden = $state(false)
 
   let selectedSession: Session | null = $state(null)
-  let history: SessionMessage[] = $state([])
-  let historyLoading = $state(false)
-  let historyError = $state('')
 
   function fmt(value?: string): string {
     const text = value?.trim()
@@ -47,29 +43,17 @@
     }
   }
 
-  async function selectSession(session: Session) {
+  function selectSession(session: Session) {
     if (selectedSession?.id === session.id) {
       selectedSession = null
-      history = []
       return
     }
     selectedSession = session
-    historyLoading = true
-    historyError = ''
-    history = []
-    try {
-      history = await getSessionHistory(session.id)
-    } catch (err) {
-      historyError = err instanceof Error ? err.message : 'Failed to load history'
-    } finally {
-      historyLoading = false
-    }
   }
 
   function toggleHidden() {
     showHidden = !showHidden
     selectedSession = null
-    history = []
     void load()
   }
 
@@ -137,61 +121,11 @@
             <div><dt>Updated</dt><dd>{fmt(selectedSession.updated_at)}</dd></div>
           </dl>
 
-          <!-- Chat -->
+          <!-- Chat (includes history + tool cards) -->
           <div class="session-chat">
-            <span class="card-title">Chat</span>
             {#key selectedSession.id}
-              <ChatPanel sessionId={selectedSession.id} projectId={selectedSession.project_id || undefined} />
+              <ChatPanel sessionId={selectedSession.id} projectId={selectedSession.project_id || undefined} onSessionChange={load} />
             {/key}
-          </div>
-
-          <div class="session-transcript">
-            <span class="card-title">Transcript</span>
-            {#if historyLoading}
-              <div class="sessions-loading">Loading transcript...</div>
-            {:else if historyError}
-              <div class="error-banner">{historyError}</div>
-            {:else if history.length === 0}
-              <div class="empty-state"><p>No messages in this session.</p></div>
-            {:else}
-              <div class="transcript-messages">
-                {#each history as msg}
-                  {#if msg.role === 'tool'}
-                    <div class="transcript-msg transcript-tool">
-                      <div class="transcript-msg-top">
-                        <span class="transcript-tool-icon">{'\u2713'}</span>
-                        <span class="transcript-tool-name">{msg.tool_name || 'tool'}</span>
-                        <span class="transcript-time">{fmt(msg.timestamp)}</span>
-                      </div>
-                      {#if msg.tool_args}
-                        <div class="transcript-tool-detail">
-                          <span class="transcript-tool-label">args</span>
-                          <code class="transcript-tool-value">{msg.tool_args}</code>
-                        </div>
-                      {/if}
-                      {#if msg.content}
-                        <div class="transcript-tool-detail">
-                          <span class="transcript-tool-label">result</span>
-                          <code class="transcript-tool-value">{msg.content}</code>
-                        </div>
-                      {/if}
-                    </div>
-                  {:else}
-                    <div class="transcript-msg transcript-{msg.role}">
-                      <div class="transcript-msg-top">
-                        <span class="transcript-role">{msg.role}</span>
-                        <span class="transcript-time">{fmt(msg.timestamp)}</span>
-                      </div>
-                      {#if msg.role === 'assistant'}
-                        <div class="transcript-content transcript-md">{@html renderMarkdown(msg.content || '')}</div>
-                      {:else}
-                        <div class="transcript-content">{msg.content || ''}</div>
-                      {/if}
-                    </div>
-                  {/if}
-                {/each}
-              </div>
-            {/if}
           </div>
         </div>
       {/if}


### PR DESCRIPTION
## Summary

1. **트랜스크립트 중복 제거** — Sessions 페이지의 별도 transcript 섹션 제거. ChatPanel이 히스토리 + tool 카드를 이미 표시
2. **자동 스크롤** — 세션 전환 시 히스토리 로드 후 맨 아래로 스크롤
3. **목록 갱신** — ChatPanel에서 채팅 완료 시 Sessions 페이지 목록 자동 갱신 (`onSessionChange` callback)

## Test plan

- [x] `make console-build` + `make build` 성공
- [ ] Sessions 페이지에서 세션 선택 → ChatPanel만 표시 (트랜스크립트 중복 없음)
- [ ] 세션 전환 시 스크롤이 맨 아래
- [ ] 채팅 완료 후 세션 목록에 새 세션 표시