### PR TITLE
feat: rename chat sessions

### DIFF
--- a/frontend/console/src/components/ChatPanel.svelte
+++ b/frontend/console/src/components/ChatPanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy, tick } from 'svelte'
-  import { streamChat, listSessions, getSessionHistory } from '../lib/api'
+  import { streamChat, listSessions, getSessionHistory, renameSession } from '../lib/api'
   import { renderMarkdown } from '../lib/markdown'
   import type { ChatAttachment, ChatEvent, Session, SessionMessage } from '../lib/types'
 
@@ -37,6 +37,22 @@
   // Multi-session
   let sessions: Session[] = $state([])
   let showSessions = $state(false)
+  let renamingId: string | null = $state(null)
+  let renameValue = $state('')
+
+  function startRename(s: Session) {
+    renamingId = s.id
+    renameValue = s.title || s.id.slice(0, 12)
+  }
+
+  async function commitRename() {
+    if (!renamingId || !renameValue.trim()) { renamingId = null; return }
+    try {
+      await renameSession(renamingId, renameValue.trim())
+      await loadSessions()
+    } catch { /* ignore */ }
+    renamingId = null
+  }
 
   async function loadSessions() {
     try {
@@ -319,10 +335,22 @@
   {#if showSessions && sessions.length > 0}
     <div class="session-list">
       {#each sessions.slice(0, 20) as s}
-        <button class="session-item" class:active={chatSessionId === s.id} onclick={() => switchSession(s.id)}>
-          <span class="session-item-title">{s.title || s.id.slice(0, 12)}</span>
+        <div class="session-item" class:active={chatSessionId === s.id}>
+          {#if renamingId === s.id}
+            <input
+              class="session-rename-input"
+              bind:value={renameValue}
+              onkeydown={(e) => { if (e.key === 'Enter') commitRename(); if (e.key === 'Escape') renamingId = null }}
+              onblur={() => commitRename()}
+            />
+          {:else}
+            <button class="session-item-btn" onclick={() => switchSession(s.id)}>
+              <span class="session-item-title">{s.title || s.id.slice(0, 12)}</span>
+            </button>
+            <button class="session-rename-btn" onclick={() => startRename(s)} title="Rename">&#9998;</button>
+          {/if}
           <span class="session-item-meta">{s.kind || 'main'}</span>
-        </button>
+        </div>
       {/each}
     </div>
   {/if}
@@ -461,16 +489,23 @@
   .session-item {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    padding: var(--space-2) var(--space-3);
+    gap: var(--space-1);
+    padding: var(--space-1) var(--space-3);
     background: transparent;
-    border: none;
-    cursor: pointer;
-    text-align: left;
     transition: background var(--duration-fast) var(--ease-out);
   }
   .session-item:hover { background: rgba(255, 255, 255, 0.03); }
   .session-item.active { background: rgba(224, 145, 69, 0.1); border-left: 2px solid var(--accent); }
+
+  .session-item-btn {
+    flex: 1;
+    background: none;
+    border: none;
+    cursor: pointer;
+    text-align: left;
+    padding: var(--space-1) 0;
+    min-width: 0;
+  }
 
   .session-item-title {
     font-size: var(--text-xs);
@@ -478,13 +513,39 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 200px;
+    display: block;
+  }
+  .session-item-btn:hover .session-item-title { color: var(--accent); }
+
+  .session-rename-btn {
+    background: none;
+    border: none;
+    color: var(--text-ghost);
+    cursor: pointer;
+    font-size: 11px;
+    padding: 2px;
+    opacity: 0;
+    transition: opacity var(--duration-fast);
+  }
+  .session-item:hover .session-rename-btn { opacity: 1; }
+  .session-rename-btn:hover { color: var(--accent); }
+
+  .session-rename-input {
+    flex: 1;
+    padding: 2px var(--space-1);
+    font-size: var(--text-xs);
+    background: var(--bg-base);
+    border: 1px solid var(--accent);
+    border-radius: var(--radius-sm);
+    color: var(--text-primary);
+    outline: none;
   }
 
   .session-item-meta {
     font-size: 10px;
     color: var(--text-ghost);
     font-family: var(--font-mono);
+    flex-shrink: 0;
   }
 
   .chat-log {

--- a/frontend/console/src/lib/api.ts
+++ b/frontend/console/src/lib/api.ts
@@ -146,6 +146,13 @@ export async function getSessionHistory(sessionId: string): Promise<SessionMessa
   return requestJSON<SessionMessage[]>(`/v1/admin/sessions/${encodeURIComponent(sessionId)}/history`)
 }
 
+export async function renameSession(sessionId: string, title: string): Promise<void> {
+  await requestJSON(`/v1/sessions/${encodeURIComponent(sessionId)}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ title }),
+  })
+}
+
 export async function getEventsHistory(limit = 30): Promise<EventsHistoryInfo> {
   return requestJSON<EventsHistoryInfo>(`/v1/events/history?limit=${limit}`)
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -202,6 +202,24 @@ func (s *Store) Touch(id string, updatedAt time.Time) error {
 	return s.saveIndex(index)
 }
 
+// SetTitle renames a session.
+func (s *Store) SetTitle(id string, title string) error {
+	unlock := lockPath(s.indexPath())
+	defer unlock()
+	index, err := s.loadIndex()
+	if err != nil {
+		return err
+	}
+	sess, ok := index[id]
+	if !ok {
+		return fmt.Errorf("session not found")
+	}
+	sess.Title = strings.TrimSpace(title)
+	sess.UpdatedAt = time.Now().UTC()
+	index[id] = sess
+	return s.saveIndex(index)
+}
+
 func (s *Store) SetProjectID(id string, projectID string) error {
 	unlock := lockPath(s.indexPath())
 	defer unlock()

--- a/internal/tarsserver/handler_session.go
+++ b/internal/tarsserver/handler_session.go
@@ -130,6 +130,22 @@ func newSessionAPIHandler(store *session.Store, logger zerolog.Logger) http.Hand
 					return
 				}
 				writeJSON(w, http.StatusOK, mainSession)
+			case http.MethodPatch:
+				actualID := sessionID
+				if isPublicMain {
+					actualID = internalMainID
+				}
+				var req struct {
+					Title string `json:"title"`
+				}
+				if !decodeJSONBody(w, r, &req) {
+					return
+				}
+				if err := reqStore.SetTitle(actualID, req.Title); err != nil {
+					writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+					return
+				}
+				writeJSON(w, http.StatusOK, map[string]string{"ok": "true"})
 			case http.MethodDelete:
 				publicUnsupported(w)
 			default:


### PR DESCRIPTION
## Summary

- **Backend**: `Store.SetTitle()` + `PATCH /v1/sessions/{id}` 엔드포인트
- **Frontend**: 세션 목록에서 연필 아이콘 클릭 → 인라인 이름 편집 (Enter/Escape/blur)

## Test plan

- [x] `make build` + `go test` 통과
- [ ] Sessions 버튼 → 세션 hover → 연필 아이콘 → 이름 입력 → Enter → 이름 변경 확인