### PR TITLE
feat: project-scoped chat sessions

### DIFF
--- a/frontend/console/src/components/ChatPanel.svelte
+++ b/frontend/console/src/components/ChatPanel.svelte
@@ -56,7 +56,9 @@
 
   async function loadSessions() {
     try {
-      sessions = await listSessions()
+      const all = await listSessions()
+      // Filter by project if scoped
+      sessions = projectId ? all.filter((s) => s.project_id === projectId) : all
     } catch { /* ignore */ }
   }
 
@@ -303,19 +305,27 @@
 
   let textareaEl: HTMLTextAreaElement | undefined = $state()
 
-  onMount(() => {
+  onMount(async () => {
     if (sessionId) {
       chatSessionId = sessionId
       void switchSession(sessionId)
+    } else if (projectId) {
+      // Find the latest session for this project
+      await loadSessions()
+      const projectSession = sessions.find((s) => s.project_id === projectId && s.kind === 'main')
+      if (projectSession) {
+        void switchSession(projectSession.id)
+      } else {
+        chatMessages = [{ id: 'system-init', role: 'system', text: `Project: ${projectId}` }]
+      }
     } else {
-      const scope = projectId ? `project ${projectId}` : 'TARS'
-      chatMessages = [{ id: 'system-init', role: 'system', text: `Chat scoped to ${scope}` }]
+      chatMessages = [{ id: 'system-init', role: 'system', text: 'TARS' }]
     }
     if (initialPrompt) {
       chatInput = initialPrompt
       tick().then(() => textareaEl?.focus())
     }
-    void loadSessions()
+    if (!sessionId) void loadSessions()
   })
 </script>
 


### PR DESCRIPTION
## Summary

프로젝트 컨텍스트의 ChatPanel에서:
- **세션 목록을 프로젝트별 필터링** — 해당 프로젝트의 세션만 표시
- **마운트 시 최근 프로젝트 세션 자동 로드** — main 세션 우선
- 새 세션 생성 시 백엔드가 자동으로 project_id 기록 (기존 동작)

## Test plan

- [x] `make console-build` + `make build` 성공
- [ ] 프로젝트 뷰에서 채팅 → 프로젝트 전용 세션 사용 확인
- [ ] Sessions 버튼 → 프로젝트 세션만 표시
- [ ] 프로젝트 없는 Home 채팅 → 전체 세션 표시