### PR TITLE
fix: project chats create own sessions instead of using main

### DIFF
--- a/frontend/console/src/components/ChatPanel.svelte
+++ b/frontend/console/src/components/ChatPanel.svelte
@@ -312,7 +312,7 @@
     } else if (projectId) {
       // Find the latest session for this project
       await loadSessions()
-      const projectSession = sessions.find((s) => s.project_id === projectId && s.kind === 'main')
+      const projectSession = sessions.find((s) => s.project_id === projectId)
       if (projectSession) {
         void switchSession(projectSession.id)
       } else {

--- a/internal/tarsserver/handler_chat.go
+++ b/internal/tarsserver/handler_chat.go
@@ -25,7 +25,7 @@ import (
 	"github.com/rs/zerolog"
 )
 
-func resolveChatSession(store *session.Store, sessionID string, mainSessionID string, userMessage string) (string, error) {
+func resolveChatSession(store *session.Store, sessionID string, mainSessionID string, userMessage string, projectID string) (string, error) {
 	// The public session API exposes the main session as id="main";
 	// translate it back to the real internal ID so store.Get succeeds.
 	trimmedID := strings.TrimSpace(sessionID)
@@ -35,6 +35,10 @@ func resolveChatSession(store *session.Store, sessionID string, mainSessionID st
 		return createFallbackChatSession(store)
 	}
 	if strings.TrimSpace(sessionID) == "" {
+		// Project chats always get their own session — never fall back to main
+		if strings.TrimSpace(projectID) != "" {
+			return createFallbackChatSession(store)
+		}
 		if project.DefaultWorkflowPolicy.IsKickoffMessage(userMessage) {
 			return createFallbackChatSession(store)
 		}

--- a/internal/tarsserver/handler_chat_context.go
+++ b/internal/tarsserver/handler_chat_context.go
@@ -50,7 +50,7 @@ func prepareChatRunState(r *http.Request, req chatRequestPayload, deps chatHandl
 		return chatRunState{}, http.StatusInternalServerError, "resolve workspace failed", err
 	}
 
-	sessionID, err := resolveChatSession(reqStore, req.SessionID, deps.mainSessionID, req.Message)
+	sessionID, err := resolveChatSession(reqStore, req.SessionID, deps.mainSessionID, req.Message, req.ProjectID)
 	if err != nil {
 		if strings.TrimSpace(req.SessionID) == "" {
 			deps.logger.Error().Err(err).Msg("create session failed")

--- a/internal/tarsserver/main_session_test.go
+++ b/internal/tarsserver/main_session_test.go
@@ -19,7 +19,7 @@ func TestResolveSession_MainSession_UsesMainWhenEmpty(t *testing.T) {
 	}
 	_ = otherSession
 
-	resolved, err := resolveChatSession(store, "", mainSession.ID, "hello")
+	resolved, err := resolveChatSession(store, "", mainSession.ID, "hello", "")
 	if err != nil {
 		t.Fatalf("resolveChatSession: %v", err)
 	}
@@ -39,7 +39,7 @@ func TestResolveSession_MainSession_ExplicitSessionWins(t *testing.T) {
 		t.Fatalf("create custom session: %v", err)
 	}
 
-	resolved, err := resolveChatSession(store, customSession.ID, mainSession.ID, "hello")
+	resolved, err := resolveChatSession(store, customSession.ID, mainSession.ID, "hello", "")
 	if err != nil {
 		t.Fatalf("resolveChatSession: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestResolveSession_MainSession_CreatesWhenNoSessions(t *testing.T) {
 func TestResolveSession_StaleMainSession_CreatesNewSession(t *testing.T) {
 	store := session.NewStore(t.TempDir())
 	// Simulate a stale mainSessionID that no longer exists in the store.
-	resolved, err := resolveChatSession(store, "", "deleted-stale-id", "hello")
+	resolved, err := resolveChatSession(store, "", "deleted-stale-id", "hello", "")
 	if err != nil {
 		t.Fatalf("expected fallback to new session, got error: %v", err)
 	}
@@ -96,7 +96,7 @@ func TestResolveSession_StaleExplicitSession_CreatesNewSession(t *testing.T) {
 	}
 	// Explicit session ID is stale, should create a fresh session instead of
 	// silently attaching to the main session.
-	resolved, err := resolveChatSession(store, "stale-explicit-id", mainSession.ID, "hello")
+	resolved, err := resolveChatSession(store, "stale-explicit-id", mainSession.ID, "hello", "")
 	if err != nil {
 		t.Fatalf("expected fallback to new session, got error: %v", err)
 	}
@@ -114,7 +114,7 @@ func TestResolveSession_StaleExplicitSession_CreatesNewSession(t *testing.T) {
 func TestResolveSession_StaleExplicitAndMainSession_CreatesNew(t *testing.T) {
 	store := session.NewStore(t.TempDir())
 	// Both explicit and main session IDs are stale.
-	resolved, err := resolveChatSession(store, "stale-explicit", "stale-main", "hello")
+	resolved, err := resolveChatSession(store, "stale-explicit", "stale-main", "hello", "")
 	if err != nil {
 		t.Fatalf("expected fallback to new session, got error: %v", err)
 	}
@@ -136,7 +136,7 @@ func TestResolveSession_EmptyKickoffMessage_CreatesNewSession(t *testing.T) {
 		t.Fatalf("create main session: %v", err)
 	}
 
-	resolved, err := resolveChatSession(store, "", mainSession.ID, "todo 앱 만드는 프로젝트 시작해줘")
+	resolved, err := resolveChatSession(store, "", mainSession.ID, "todo 앱 만드는 프로젝트 시작해줘", "")
 	if err != nil {
 		t.Fatalf("resolveChatSession: %v", err)
 	}


### PR DESCRIPTION
## Summary

- **Backend**: `resolveChatSession()`에서 `project_id`가 있고 `session_id`가 비어있으면 main fallback 대신 새 세션 생성
- **Frontend**: 프로젝트 세션 찾을 때 `kind === 'main'` 필터 제거

프로젝트 채팅이 글로벌 main 세션에 합류하지 않고 독립 세션을 사용합니다.

## Test plan

- [x] `make build` + `go test` 통과
- [ ] 프로젝트 채팅 → main 세션이 아닌 새 프로젝트 세션 생성 확인
- [ ] Home 채팅 → 기존처럼 main 세션 사용 확인