### PR TITLE
feat: autopilot blocked state UI with resume/reset controls

### DIFF
--- a/frontend/console/src/components/ProjectView.svelte
+++ b/frontend/console/src/components/ProjectView.svelte
@@ -12,6 +12,8 @@
     listProjectActivity,
     reviewApproval,
     startAutopilot,
+    resumeAutopilot,
+    resetAutopilot,
     streamEvents,
     updateProject,
   } from '../lib/api'
@@ -129,6 +131,31 @@
       autopilot = await advanceAutopilot(projectId)
     } catch (e) {
       autopilotError = e instanceof Error ? e.message : 'Failed to advance autopilot'
+    } finally {
+      autopilotBusy = false
+    }
+  }
+
+  async function handleResumeAutopilot() {
+    autopilotBusy = true
+    autopilotError = ''
+    try {
+      autopilot = await resumeAutopilot(projectId)
+    } catch (e) {
+      autopilotError = e instanceof Error ? e.message : 'Failed to resume autopilot'
+    } finally {
+      autopilotBusy = false
+    }
+  }
+
+  async function handleResetAutopilot() {
+    autopilotBusy = true
+    autopilotError = ''
+    try {
+      await resetAutopilot(projectId)
+      autopilot = null
+    } catch (e) {
+      autopilotError = e instanceof Error ? e.message : 'Failed to reset autopilot'
     } finally {
       autopilotBusy = false
     }
@@ -335,10 +362,15 @@
         </div>
       {/if}
       <div class="pv-phase-actions">
-        {#if !autopilot || autopilot.status === 'done' || autopilot.status === 'failed'}
+        {#if !autopilot || autopilot.status === 'done'}
           <button class="btn btn-primary btn-sm" disabled={autopilotBusy} onclick={handleStartAutopilot}>
             {autopilotBusy ? 'Starting...' : 'Start Autopilot'}
           </button>
+        {:else if autopilot.status === 'blocked' || autopilot.status === 'failed'}
+          <button class="btn btn-primary btn-sm" disabled={autopilotBusy} onclick={handleResumeAutopilot}>
+            {autopilotBusy ? 'Resuming...' : 'Resume'}
+          </button>
+          <button class="btn btn-ghost btn-sm" disabled={autopilotBusy} onclick={handleResetAutopilot}>Reset</button>
         {:else}
           <button class="btn btn-ghost btn-sm" disabled={autopilotBusy} onclick={handleAdvanceAutopilot}>
             {autopilotBusy ? 'Advancing...' : 'Advance'}
@@ -350,7 +382,20 @@
       <div class="error-banner" style="margin-bottom: var(--space-4)">{autopilotError}</div>
     {/if}
 
-    {#if autopilot?.next_action}
+    {#if autopilot && (autopilot.status === 'blocked' || autopilot.status === 'failed') && autopilot.message}
+      <div class="pv-blocked-banner">
+        <div class="pv-blocked-header">
+          <span class="badge badge-error">{autopilot.status}</span>
+          <strong>{autopilot.message}</strong>
+        </div>
+        {#if autopilot.next_action}
+          <p class="pv-blocked-action">{autopilot.next_action}</p>
+        {/if}
+        {#if autopilot.summary && autopilot.summary !== autopilot.message}
+          <p class="pv-blocked-summary">{autopilot.summary}</p>
+        {/if}
+      </div>
+    {:else if autopilot?.next_action}
       <div class="pv-next-action">
         <span class="label">Next action</span>
         <p>{autopilot.next_action}</p>
@@ -584,6 +629,34 @@
 
   .pv-phase-empty {
     padding: var(--space-2) 0;
+  }
+
+  .pv-blocked-banner {
+    padding: var(--space-3) var(--space-4);
+    background: rgba(248, 113, 113, 0.08);
+    border: 1px solid rgba(248, 113, 113, 0.2);
+    border-radius: var(--radius-md);
+    margin-bottom: var(--space-4);
+  }
+  .pv-blocked-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+  .pv-blocked-header strong {
+    color: var(--text-primary);
+    font-size: var(--text-sm);
+  }
+  .pv-blocked-action {
+    margin-top: var(--space-2);
+    color: var(--text-secondary);
+    font-size: var(--text-sm);
+    font-style: italic;
+  }
+  .pv-blocked-summary {
+    margin-top: var(--space-1);
+    color: var(--text-tertiary);
+    font-size: var(--text-xs);
   }
 
   .pv-next-action {

--- a/frontend/console/src/lib/api.ts
+++ b/frontend/console/src/lib/api.ts
@@ -207,6 +207,20 @@ export async function advanceAutopilot(projectId: string): Promise<ProjectAutopi
   )
 }
 
+export async function resumeAutopilot(projectId: string): Promise<ProjectAutopilotRun> {
+  return requestJSON<ProjectAutopilotRun>(
+    `/v1/projects/${encodeURIComponent(projectId)}/autopilot/resume`,
+    { method: 'POST' },
+  )
+}
+
+export async function resetAutopilot(projectId: string): Promise<void> {
+  await requestJSON(
+    `/v1/projects/${encodeURIComponent(projectId)}/autopilot/reset`,
+    { method: 'POST' },
+  )
+}
+
 // --- Cron Job CRUD ---
 
 export async function createCronJob(data: CreateCronJobRequest): Promise<CronJob> {

--- a/internal/project/phase_engine.go
+++ b/internal/project/phase_engine.go
@@ -45,6 +45,8 @@ type PhaseEngine interface {
 	Advance(context.Context, string) (PhaseSnapshot, error)
 	EnsureActiveRuns(context.Context) (int, error)
 	Escalate(string, string) error
+	Resume(context.Context, string) (AutopilotRun, error)
+	Reset(string) error
 }
 
 func normalizePhaseName(raw string) PhaseName {

--- a/internal/project/project_runner.go
+++ b/internal/project/project_runner.go
@@ -868,6 +868,44 @@ func (m *AutopilotManager) removeRun(projectID string) {
 	_ = os.Remove(path)
 }
 
+// Resume re-starts a blocked or failed autopilot run.
+func (m *AutopilotManager) Resume(ctx context.Context, projectID string) (AutopilotRun, error) {
+	if m == nil {
+		return AutopilotRun{}, fmt.Errorf("autopilot manager not configured")
+	}
+	projectID = strings.TrimSpace(projectID)
+	run, ok := m.Status(projectID)
+	if !ok {
+		return AutopilotRun{}, fmt.Errorf("no autopilot run for project %s", projectID)
+	}
+	if run.Status != AutopilotStatusBlocked && run.Status != AutopilotStatusFailed {
+		return run, nil // already running or done
+	}
+	// Reset status and restart the loop
+	m.stopLoop(projectID)
+	m.setRun(projectID, func(r *AutopilotRun) {
+		r.Status = AutopilotStatusRunning
+		r.Message = "resumed by user"
+		r.FinishedAt = ""
+		r.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	})
+	_ = m.persistCurrentRun(projectID)
+	runID := run.RunID
+	go m.run(ctx, projectID, runID)
+	updated, _ := m.Status(projectID)
+	return updated, nil
+}
+
+// Reset removes the current autopilot run, allowing a fresh start.
+func (m *AutopilotManager) Reset(projectID string) error {
+	if m == nil {
+		return fmt.Errorf("autopilot manager not configured")
+	}
+	m.stopLoop(strings.TrimSpace(projectID))
+	m.removeRun(strings.TrimSpace(projectID))
+	return nil
+}
+
 type errorSource string
 
 func writeJSONAtomicWithTrailingNewline(path string, payload any) error {

--- a/internal/tarsserver/handler_chat_pipeline_tools_test.go
+++ b/internal/tarsserver/handler_chat_pipeline_tools_test.go
@@ -35,6 +35,14 @@ func (chatPhaseEngineStub) Escalate(string, string) error {
 	return nil
 }
 
+func (chatPhaseEngineStub) Resume(context.Context, string) (project.AutopilotRun, error) {
+	return project.AutopilotRun{}, nil
+}
+
+func (chatPhaseEngineStub) Reset(string) error {
+	return nil
+}
+
 func TestResolveInjectedToolSchemas_FiltersHighRiskToolsForUserRole(t *testing.T) {
 	registry := newBaseToolRegistryWithProcess(t.TempDir(), tool.NewProcessManager())
 	registry.Register(tool.NewApplyPatchTool(t.TempDir(), true))

--- a/internal/tarsserver/handler_project.go
+++ b/internal/tarsserver/handler_project.go
@@ -524,6 +524,39 @@ func newProjectAPIHandler(
 			return
 		}
 
+		if len(parts) == 3 && parts[1] == "autopilot" && parts[2] == "resume" {
+			if autopilot == nil {
+				writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "project autopilot manager is not configured"})
+				return
+			}
+			if !requireMethod(w, r, http.MethodPost) {
+				return
+			}
+			run, err := autopilot.Resume(r.Context(), projectID)
+			if err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+				return
+			}
+			writeJSON(w, http.StatusOK, run)
+			return
+		}
+
+		if len(parts) == 3 && parts[1] == "autopilot" && parts[2] == "reset" {
+			if autopilot == nil {
+				writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "project autopilot manager is not configured"})
+				return
+			}
+			if !requireMethod(w, r, http.MethodPost) {
+				return
+			}
+			if err := autopilot.Reset(projectID); err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+				return
+			}
+			writeJSON(w, http.StatusOK, map[string]string{"ok": "true"})
+			return
+		}
+
 		if len(parts) == 2 && parts[1] == "autopilot" {
 			if autopilot == nil {
 				writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "project autopilot manager is not configured"})


### PR DESCRIPTION
## Summary

오토파일럿 blocked/failed 상태에서 사용자가 사유를 확인하고 재개/리셋할 수 있는 UI.

### Backend
- `Resume()` — blocked/failed → running 전환 후 루프 재시작
- `Reset()` — 오토파일럿 상태 완전 제거
- `POST /v1/projects/{id}/autopilot/resume` + `/reset` 엔드포인트

### Frontend
- **빨간색 blocked 배너** — 사유(`message`), 다음 액션(`next_action`), 요약(`summary`) 표시
- **Resume 버튼** — blocked/failed 상태에서 재개
- **Reset 버튼** — 상태 초기화 후 다시 시작 가능

Closes #207

## Test plan

- [x] `make build` + `go test` 통과
- [ ] blocked 프로젝트에서 사유 배너 표시 확인
- [ ] Resume 클릭 → running 전환 확인
- [ ] Reset 클릭 → 상태 초기화 + Start Autopilot 버튼 표시