### PR TITLE
feat: autopilot auto-plans backlog via LLM when board is empty

### DIFF
--- a/internal/project/orchestrator_plan.go
+++ b/internal/project/orchestrator_plan.go
@@ -1,0 +1,157 @@
+package project
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// PlanTasks calls the LLM to generate board tasks from the project brief and state.
+// Returns a list of tasks with status="todo" ready for dispatch.
+func (o *Orchestrator) PlanTasks(ctx context.Context, projectID string) ([]BoardTask, error) {
+	if o == nil || o.store == nil || o.runner == nil {
+		return nil, fmt.Errorf("orchestrator not configured")
+	}
+
+	prompt, err := o.buildPlanningPrompt(projectID)
+	if err != nil {
+		return nil, fmt.Errorf("build planning prompt: %w", err)
+	}
+
+	run, err := o.runner.Start(ctx, TaskRunRequest{
+		ProjectID:  projectID,
+		TaskID:     "planning",
+		Title:      "Generate project backlog",
+		Prompt:     prompt,
+		Agent:      "",
+		Role:       "planner",
+		WorkerKind: "main",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("start planning run: %w", err)
+	}
+
+	result, err := o.runner.Wait(ctx, run.ID)
+	if err != nil {
+		return nil, fmt.Errorf("wait planning run: %w", err)
+	}
+	if result.Status == TaskRunStatusFailed {
+		return nil, fmt.Errorf("planning run failed: %s", result.Error)
+	}
+
+	tasks, err := parsePlanningResponse(result.Response)
+	if err != nil {
+		return nil, fmt.Errorf("parse planning response: %w", err)
+	}
+	if len(tasks) == 0 {
+		return nil, fmt.Errorf("planning produced no tasks")
+	}
+	return tasks, nil
+}
+
+func (o *Orchestrator) buildPlanningPrompt(projectID string) (string, error) {
+	var parts []string
+
+	parts = append(parts, "You are a project planner. Based on the project information below, generate a list of concrete tasks for the next phase.")
+	parts = append(parts, "")
+
+	// Project brief
+	brief, err := o.store.GetBrief(projectID)
+	if err == nil {
+		parts = append(parts, "## Project Brief")
+		if brief.Title != "" {
+			parts = append(parts, fmt.Sprintf("Title: %s", brief.Title))
+		}
+		if brief.Goal != "" {
+			parts = append(parts, fmt.Sprintf("Goal: %s", brief.Goal))
+		}
+		if brief.Premise != "" {
+			parts = append(parts, fmt.Sprintf("Premise: %s", brief.Premise))
+		}
+		if brief.Kind != "" {
+			parts = append(parts, fmt.Sprintf("Kind: %s", brief.Kind))
+		}
+		parts = append(parts, "")
+	}
+
+	// Project state
+	state, err := o.store.GetState(projectID)
+	if err == nil {
+		parts = append(parts, "## Current State")
+		if state.Phase != "" {
+			parts = append(parts, fmt.Sprintf("Phase: %s", state.Phase))
+		}
+		if state.NextAction != "" {
+			parts = append(parts, fmt.Sprintf("Next action: %s", state.NextAction))
+		}
+		if state.LastRunSummary != "" {
+			parts = append(parts, fmt.Sprintf("Last run: %s", state.LastRunSummary))
+		}
+		if len(state.RemainingTasks) > 0 {
+			parts = append(parts, fmt.Sprintf("Remaining tasks: %s", strings.Join(state.RemainingTasks, ", ")))
+		}
+		parts = append(parts, "")
+	}
+
+	parts = append(parts, "## Instructions")
+	parts = append(parts, "Generate 1-5 concrete tasks for the next phase. Each task should be a small, actionable unit of work.")
+	parts = append(parts, "")
+	parts = append(parts, "Respond with a JSON array of task objects. Each task must have:")
+	parts = append(parts, `- "id": unique short identifier (e.g., "task-1")`)
+	parts = append(parts, `- "title": clear description of what to do`)
+	parts = append(parts, `- "status": always "todo"`)
+	parts = append(parts, "")
+	parts = append(parts, "Example response:")
+	parts = append(parts, "```json")
+	parts = append(parts, `[{"id":"task-1","title":"Write chapter outline","status":"todo"},{"id":"task-2","title":"Draft opening scene","status":"todo"}]`)
+	parts = append(parts, "```")
+	parts = append(parts, "")
+	parts = append(parts, "Respond with ONLY the JSON array, no other text.")
+
+	return strings.Join(parts, "\n"), nil
+}
+
+func parsePlanningResponse(response string) ([]BoardTask, error) {
+	response = strings.TrimSpace(response)
+
+	// Extract JSON from markdown code block if present
+	if idx := strings.Index(response, "```json"); idx >= 0 {
+		start := idx + len("```json")
+		end := strings.Index(response[start:], "```")
+		if end >= 0 {
+			response = strings.TrimSpace(response[start : start+end])
+		}
+	} else if idx := strings.Index(response, "```"); idx >= 0 {
+		start := idx + len("```")
+		end := strings.Index(response[start:], "```")
+		if end >= 0 {
+			response = strings.TrimSpace(response[start : start+end])
+		}
+	}
+
+	// Find JSON array bounds
+	arrStart := strings.Index(response, "[")
+	arrEnd := strings.LastIndex(response, "]")
+	if arrStart >= 0 && arrEnd > arrStart {
+		response = response[arrStart : arrEnd+1]
+	}
+
+	var tasks []BoardTask
+	if err := json.Unmarshal([]byte(response), &tasks); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+
+	// Validate and normalize
+	valid := make([]BoardTask, 0, len(tasks))
+	for _, t := range tasks {
+		t.ID = strings.TrimSpace(t.ID)
+		t.Title = strings.TrimSpace(t.Title)
+		if t.ID == "" || t.Title == "" {
+			continue
+		}
+		t.Status = "todo"
+		valid = append(valid, t)
+	}
+	return valid, nil
+}

--- a/internal/project/project_runner.go
+++ b/internal/project/project_runner.go
@@ -287,7 +287,7 @@ func (m *AutopilotManager) runIteration(
 	}
 	switch {
 	case len(board.Tasks) == 0:
-		return m.handleEmptyBoard(ctx, projectID, runID, iteration, isBackgroundRun)
+		return m.handleEmptyBoard(ctx, orch, projectID, runID, iteration, isBackgroundRun)
 	case boardHasStatus(board, "todo"):
 		return m.handleDispatchStage(ctx, orch, projectID, runID, iteration, "todo", isBackgroundRun)
 	case boardHasStatus(board, "review"):
@@ -304,23 +304,53 @@ func (m *AutopilotManager) runIteration(
 
 func (m *AutopilotManager) handleEmptyBoard(
 	ctx context.Context,
+	orch *Orchestrator,
 	projectID string,
 	runID string,
 	iteration int,
 	isBackgroundRun bool,
 ) autopilotStepResult {
-	if isBackgroundRun && m.planningBlockExpired(projectID) {
-		message := "Planning approval timed out: backlog is still empty"
-		nextAction := "Update or approve the backlog, then run /project autopilot advance to continue"
-		m.planningTimedOut(projectID, runID, iteration, message, nextAction)
+	// Try auto-planning via LLM before blocking
+	m.setRunningRun(projectID, "Planning next phase via LLM", iteration)
+	m.publish(projectID, "autopilot")
+	_ = m.appendPMActivity(projectID, "autopilot", "planning", "Auto-planning: generating backlog from project brief", nil)
+
+	tasks, err := orch.PlanTasks(ctx, projectID)
+	if err != nil {
+		// Planning failed — fall back to manual block
+		_ = m.appendPMActivity(projectID, "autopilot", "blocked", fmt.Sprintf("Auto-planning failed: %v", err), nil)
+		if isBackgroundRun && m.planningBlockExpired(projectID) {
+			message := "Planning approval timed out: backlog is still empty"
+			nextAction := "Update or approve the backlog, then run /project autopilot advance to continue"
+			m.planningTimedOut(projectID, runID, iteration, message, nextAction)
+			return autopilotStepResult{Stop: true}
+		}
+		message := fmt.Sprintf("Auto-planning failed: %v", err)
+		nextAction := "Create or approve the next phase backlog manually"
+		m.planningRequired(projectID, runID, iteration, message, nextAction)
 		return autopilotStepResult{Stop: true}
 	}
-	_ = ctx
-	_ = isBackgroundRun
-	message := "Autopilot paused: backlog is empty"
-	nextAction := "Create or approve the next phase backlog"
-	m.planningRequired(projectID, runID, iteration, message, nextAction)
-	return autopilotStepResult{Stop: true}
+
+	// Update board with planned tasks
+	board, _ := m.store.GetBoard(projectID)
+	board.Tasks = tasks
+	if _, updateErr := m.store.UpdateBoard(projectID, BoardUpdateInput{
+		Columns: board.Columns,
+		Tasks:   tasks,
+	}); updateErr != nil {
+		message := fmt.Sprintf("Failed to update board with planned tasks: %v", updateErr)
+		m.planningRequired(projectID, runID, iteration, message, "Retry or manually update the board")
+		return autopilotStepResult{Stop: true}
+	}
+
+	taskTitles := make([]string, 0, len(tasks))
+	for _, t := range tasks {
+		taskTitles = append(taskTitles, t.Title)
+	}
+	_ = m.appendPMActivity(projectID, "autopilot", "planned",
+		fmt.Sprintf("Auto-planned %d tasks: %s", len(tasks), strings.Join(taskTitles, "; ")), nil)
+	m.publish(projectID, "autopilot", "board")
+	return autopilotStepResult{Immediate: true} // continue to dispatch
 }
 
 func (m *AutopilotManager) handleDispatchStage(


### PR DESCRIPTION
## Summary

오토파일럿이 빈 보드를 만나면 즉시 block하지 않고 **LLM을 호출하여 자동으로 backlog를 생성**합니다.

### 동작 흐름
```
Empty board → LLM planning prompt (brief + state) → parse tasks → update board → dispatch
```

### Planning prompt 구성
- 프로젝트 Brief (title, goal, premise, kind)
- 프로젝트 State (phase, next_action, remaining_tasks, last_run_summary)
- 1-5개 concrete tasks 생성 지시
- JSON 배열로 응답 요청

### Fallback
LLM 실패, 빈 응답, 파싱 에러 → 기존 blocking 동작 (사유 메시지와 함께)

Closes #209

## Test plan

- [x] `make build` + `go test ./internal/project/` 통과
- [ ] 빈 보드 프로젝트에서 Start Autopilot → LLM이 tasks 생성 → 자동 dispatch 확인
- [ ] LLM 응답 파싱 실패 시 blocked 상태 + 에러 메시지 표시 확인