### PR TITLE
fix: telegram polling backoff up to 60s with log suppression

### DIFF
--- a/internal/tarsserver/telegram_poller.go
+++ b/internal/tarsserver/telegram_poller.go
@@ -136,6 +136,8 @@ func (p *telegramUpdatePoller) Run(ctx context.Context) {
 		}
 	}
 	backoff := 500 * time.Millisecond
+	consecutiveErrors := 0
+	const maxBackoff = 60 * time.Second
 	for {
 		if ctx.Err() != nil {
 			return
@@ -145,21 +147,31 @@ func (p *telegramUpdatePoller) Run(ctx context.Context) {
 			if ctx.Err() != nil {
 				return
 			}
-			p.logger.Debug().Err(err).Msg("telegram polling failed")
+			consecutiveErrors++
+			// Log first few errors at debug, then warn once, then suppress
+			if consecutiveErrors <= 3 {
+				p.logger.Debug().Err(err).Int("consecutive_errors", consecutiveErrors).Msg("telegram polling failed")
+			} else if consecutiveErrors == 4 {
+				p.logger.Warn().Err(err).Int("consecutive_errors", consecutiveErrors).Msg("telegram polling repeatedly failing, suppressing further logs until recovery")
+			}
 			select {
 			case <-ctx.Done():
 				return
 			case <-time.After(backoff):
 			}
-			if backoff < 5*time.Second {
+			if backoff < maxBackoff {
 				backoff *= 2
-				if backoff > 5*time.Second {
-					backoff = 5 * time.Second
+				if backoff > maxBackoff {
+					backoff = maxBackoff
 				}
 			}
 			continue
 		}
+		if consecutiveErrors > 3 {
+			p.logger.Info().Int("recovered_after", consecutiveErrors).Msg("telegram polling recovered")
+		}
 		backoff = 500 * time.Millisecond
+		consecutiveErrors = 0
 		for _, update := range updates {
 			if update.UpdateID >= offset {
 				offset = update.UpdateID + 1


### PR DESCRIPTION
네트워크 장애 시 Telegram polling 로그 폭주 수정.

- 최대 백오프 5초 → **60초**
- 처음 3회 에러: debug 로그
- 4회차: warn + "suppressing further logs"
- 복구 시: info 로그