### PR TITLE
fix: autopilot planning writes clean board + hardened LLM prompt

### DIFF
--- a/internal/project/orchestrator_plan.go
+++ b/internal/project/orchestrator_plan.go
@@ -97,17 +97,17 @@ func (o *Orchestrator) buildPlanningPrompt(projectID string) (string, error) {
 	parts = append(parts, "## Instructions")
 	parts = append(parts, "Generate 1-5 concrete tasks for the next phase. Each task should be a small, actionable unit of work.")
 	parts = append(parts, "")
+	parts = append(parts, "IMPORTANT: Do NOT use any tools. Do NOT modify any files. ONLY respond with the JSON array below.")
+	parts = append(parts, "")
 	parts = append(parts, "Respond with a JSON array of task objects. Each task must have:")
 	parts = append(parts, `- "id": unique short identifier (e.g., "task-1")`)
 	parts = append(parts, `- "title": clear description of what to do`)
 	parts = append(parts, `- "status": always "todo"`)
 	parts = append(parts, "")
-	parts = append(parts, "Example response:")
-	parts = append(parts, "```json")
+	parts = append(parts, "Example:")
 	parts = append(parts, `[{"id":"task-1","title":"Write chapter outline","status":"todo"},{"id":"task-2","title":"Draft opening scene","status":"todo"}]`)
-	parts = append(parts, "```")
 	parts = append(parts, "")
-	parts = append(parts, "Respond with ONLY the JSON array, no other text.")
+	parts = append(parts, "Respond with ONLY the JSON array, no other text. No markdown code blocks.")
 
 	return strings.Join(parts, "\n"), nil
 }

--- a/internal/project/project_runner.go
+++ b/internal/project/project_runner.go
@@ -331,14 +331,15 @@ func (m *AutopilotManager) handleEmptyBoard(
 		return autopilotStepResult{Stop: true}
 	}
 
-	// Update board with planned tasks
-	board, _ := m.store.GetBoard(projectID)
-	board.Tasks = tasks
-	if _, updateErr := m.store.UpdateBoard(projectID, BoardUpdateInput{
-		Columns: board.Columns,
-		Tasks:   tasks,
-	}); updateErr != nil {
-		message := fmt.Sprintf("Failed to update board with planned tasks: %v", updateErr)
+	// Write a clean board with planned tasks (overwrite any corrupted KANBAN.md)
+	cleanBoard := Board{
+		ProjectID: projectID,
+		UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+		Columns:   append([]string(nil), defaultBoardColumns...),
+		Tasks:     tasks,
+	}
+	if writeErr := m.store.writeBoard(cleanBoard); writeErr != nil {
+		message := fmt.Sprintf("Failed to write board with planned tasks: %v", writeErr)
 		m.planningRequired(projectID, runID, iteration, message, "Retry or manually update the board")
 		return autopilotStepResult{Stop: true}
 	}


### PR DESCRIPTION
## Summary

오토파일럿 auto-planning에서 보드가 깨지는 문제 수정:

1. **LLM prompt 강화** — "Do NOT use tools, do NOT modify files, ONLY return JSON"
2. **깨끗한 보드 쓰기** — writeBoard()로 새 Board 구조 직접 기록 (UpdateBoard 대신)

### 수정 전 문제
```
빈 보드 → LLM이 도구 사용하여 KANBAN.md를 마크다운으로 덮어씀 → 파싱 실패 → 여전히 빈 보드 → block
```

### 수정 후
```
빈 보드 → LLM이 JSON만 응답 → tasks 파싱 → writeBoard로 깨끗한 YAML 기록 → dispatch
```

## Test plan

- [x] `make build` + `go test` 통과
- [ ] 프로젝트 Reset → Start Autopilot → LLM이 tasks 생성 → 자동 dispatch