### PR TITLE
feat: autopilot cron-based execution with iteration budget

### DIFF
--- a/frontend/console/src/components/ProjectView.svelte
+++ b/frontend/console/src/components/ProjectView.svelte
@@ -14,6 +14,7 @@
     startAutopilot,
     resumeAutopilot,
     resetAutopilot,
+    stopAutopilot,
     streamEvents,
     updateProject,
     listProjectFiles,
@@ -173,6 +174,19 @@
     }
   }
 
+  async function handleStopAutopilot() {
+    autopilotBusy = true
+    autopilotError = ''
+    try {
+      await stopAutopilot(projectId)
+      autopilot = await getProjectAutopilot(projectId)
+    } catch (e) {
+      autopilotError = e instanceof Error ? e.message : 'Failed to stop autopilot'
+    } finally {
+      autopilotBusy = false
+    }
+  }
+
   async function handleResetAutopilot() {
     autopilotBusy = true
     autopilotError = ''
@@ -308,6 +322,7 @@
   function statusColor(status?: string): string {
     switch (status?.toLowerCase()) {
       case 'running': return 'badge-success'
+      case 'scheduled': return 'badge-info'
       case 'blocked': return 'badge-error'
       case 'done': case 'completed': return 'badge-default'
       case 'failed': return 'badge-error'
@@ -428,10 +443,14 @@
             {autopilotBusy ? 'Resuming...' : 'Resume'}
           </button>
           <button class="btn btn-ghost btn-sm" disabled={autopilotBusy} onclick={handleResetAutopilot}>Reset</button>
+        {:else if autopilot.status === 'scheduled'}
+          <button class="btn btn-ghost btn-sm" disabled={autopilotBusy} onclick={handleAdvanceAutopilot}>Run Now</button>
+          <button class="btn btn-danger btn-sm" disabled={autopilotBusy} onclick={handleStopAutopilot}>Stop</button>
         {:else}
           <button class="btn btn-ghost btn-sm" disabled={autopilotBusy} onclick={handleAdvanceAutopilot}>
             {autopilotBusy ? 'Advancing...' : 'Advance'}
           </button>
+          <button class="btn btn-danger btn-sm" disabled={autopilotBusy} onclick={handleStopAutopilot}>Stop</button>
         {/if}
       </div>
     </div>
@@ -439,7 +458,12 @@
       <div class="error-banner" style="margin-bottom: var(--space-4)">{autopilotError}</div>
     {/if}
 
-    {#if autopilot && (autopilot.status === 'blocked' || autopilot.status === 'failed') && autopilot.message}
+    {#if autopilot && autopilot.status === 'scheduled'}
+      <div class="pv-scheduled-banner">
+        <span class="badge badge-info">scheduled</span>
+        <span>{autopilot.message || 'Waiting for next scheduled run'}</span>
+      </div>
+    {:else if autopilot && (autopilot.status === 'blocked' || autopilot.status === 'failed') && autopilot.message}
       <div class="pv-blocked-banner">
         <div class="pv-blocked-header">
           <span class="badge badge-error">{autopilot.status}</span>
@@ -726,6 +750,19 @@
 
   .pv-phase-empty {
     padding: var(--space-2) 0;
+  }
+
+  .pv-scheduled-banner {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-4);
+    background: rgba(96, 165, 250, 0.08);
+    border: 1px solid rgba(96, 165, 250, 0.2);
+    border-radius: var(--radius-md);
+    margin-bottom: var(--space-4);
+    font-size: var(--text-sm);
+    color: var(--text-secondary);
   }
 
   .pv-blocked-banner {

--- a/frontend/console/src/lib/api.ts
+++ b/frontend/console/src/lib/api.ts
@@ -241,6 +241,13 @@ export async function resetAutopilot(projectId: string): Promise<void> {
   )
 }
 
+export async function stopAutopilot(projectId: string): Promise<void> {
+  await requestJSON(
+    `/v1/projects/${encodeURIComponent(projectId)}/autopilot/stop`,
+    { method: 'POST' },
+  )
+}
+
 // --- Cron Job CRUD ---
 
 export async function createCronJob(data: CreateCronJobRequest): Promise<CronJob> {

--- a/internal/project/phase_engine.go
+++ b/internal/project/phase_engine.go
@@ -47,6 +47,9 @@ type PhaseEngine interface {
 	Escalate(string, string) error
 	Resume(context.Context, string) (AutopilotRun, error)
 	Reset(string) error
+	RunScheduled(context.Context, string) (string, error)
+	Stop(string) error
+	CronInterval() time.Duration
 }
 
 func normalizePhaseName(raw string) PhaseName {

--- a/internal/project/phase_engine_test.go
+++ b/internal/project/phase_engine_test.go
@@ -239,7 +239,7 @@ func TestAutopilotManager_AdvanceDoesNotSleepOnBlockedStep(t *testing.T) {
 	}
 
 	manager := NewAutopilotManager(store, stagedTaskRunner{}, func(context.Context) error { return nil }, nil)
-	manager.loopInterval = time.Second
+	manager.cronInterval = time.Second
 
 	start := time.Now()
 	current, err := manager.Advance(context.Background(), created.ID)

--- a/internal/project/project_runner.go
+++ b/internal/project/project_runner.go
@@ -21,10 +21,11 @@ const (
 type AutopilotRunStatus string
 
 const (
-	AutopilotStatusRunning AutopilotRunStatus = "running"
-	AutopilotStatusDone    AutopilotRunStatus = "done"
-	AutopilotStatusBlocked AutopilotRunStatus = "blocked"
-	AutopilotStatusFailed  AutopilotRunStatus = "failed"
+	AutopilotStatusRunning   AutopilotRunStatus = "running"
+	AutopilotStatusScheduled AutopilotRunStatus = "scheduled"
+	AutopilotStatusDone      AutopilotRunStatus = "done"
+	AutopilotStatusBlocked   AutopilotRunStatus = "blocked"
+	AutopilotStatusFailed    AutopilotRunStatus = "failed"
 )
 
 type AutopilotRun struct {
@@ -38,13 +39,20 @@ type AutopilotRun struct {
 	FinishedAt string             `json:"finished_at,omitempty"`
 }
 
+// CronJobCallbacks allows AutopilotManager to create/delete cron jobs without importing cron package.
+type CronJobCallbacks struct {
+	CreateJob func(projectID string, interval time.Duration) error
+	DeleteJob func(projectID string) error
+}
+
 type AutopilotManager struct {
 	store                *Store
 	runner               TaskRunner
 	githubAuthChecker    GitHubAuthChecker
 	notify               func(projectID string, kind string)
-	maxIterations        int
-	loopInterval         time.Duration
+	cronCallbacks        *CronJobCallbacks
+	budgetPerRun         int
+	cronInterval         time.Duration
 	planningBlockTimeout time.Duration
 	runRetention         time.Duration
 
@@ -68,13 +76,20 @@ func NewAutopilotManager(
 		runner:               runner,
 		githubAuthChecker:    checker,
 		notify:               notify,
-		maxIterations:        16,
-		loopInterval:         time.Minute,
+		budgetPerRun:         3,
+		cronInterval:         10 * time.Minute,
 		planningBlockTimeout: defaultPlanningBlockTimeout,
 		runRetention:         defaultAutopilotRunRetention,
 		runs:                 map[string]AutopilotRun{},
 		loops:                map[string]context.CancelFunc{},
 		steps:                map[string]bool{},
+	}
+}
+
+// SetCronCallbacks sets the cron job lifecycle callbacks.
+func (m *AutopilotManager) SetCronCallbacks(cb *CronJobCallbacks) {
+	if m != nil {
+		m.cronCallbacks = cb
 	}
 }
 
@@ -166,9 +181,39 @@ func (m *AutopilotManager) Start(_ context.Context, projectID string) (Autopilot
 		return AutopilotRun{}, err
 	}
 
+	// Create cron job for periodic execution
+	if m.cronCallbacks != nil && m.cronCallbacks.CreateJob != nil {
+		if err := m.cronCallbacks.CreateJob(projectID, m.cronInterval); err != nil {
+			// Non-fatal: autopilot still runs the first budget
+			_ = m.appendPMActivity(projectID, "autopilot", "warning",
+				fmt.Sprintf("Failed to create cron job: %v", err), nil)
+		}
+	}
+
 	m.publish(projectID, "autopilot")
 	go m.run(loopCtx, projectID, run.RunID)
 	return run, nil
+}
+
+// Stop stops a running autopilot and deletes its cron job.
+func (m *AutopilotManager) Stop(projectID string) error {
+	if m == nil {
+		return nil
+	}
+	projectID = strings.TrimSpace(projectID)
+	m.stopLoop(projectID)
+	m.setRun(projectID, func(r *AutopilotRun) {
+		r.Status = AutopilotStatusDone
+		r.Message = "stopped by user"
+		r.FinishedAt = m.store.nowFn().UTC().Format(time.RFC3339)
+		r.UpdatedAt = m.store.nowFn().UTC().Format(time.RFC3339)
+	})
+	_ = m.persistCurrentRun(projectID)
+	if m.cronCallbacks != nil && m.cronCallbacks.DeleteJob != nil {
+		_ = m.cronCallbacks.DeleteJob(projectID)
+	}
+	m.publish(projectID, "autopilot")
+	return nil
 }
 
 func (m *AutopilotManager) Status(projectID string) (AutopilotRun, bool) {
@@ -247,8 +292,17 @@ func (m *AutopilotManager) run(ctx context.Context, projectID, runID string) {
 		m.publish(projectID, "autopilot")
 	}()
 	orch := NewOrchestratorWithGitHubAuthChecker(m.store, m.runner, m.githubAuthChecker)
-	immediateStreak := 0
-	for iteration := 1; ; iteration++ {
+
+	// Read current iteration count to continue from where we left off
+	currentRun, _ := m.Status(projectID)
+	startIter := currentRun.Iterations + 1
+	budget := m.budgetPerRun
+	if budget <= 0 {
+		budget = 3
+	}
+
+	for i := 0; i < budget; i++ {
+		iteration := startIter + i
 		if ctx.Err() != nil {
 			return
 		}
@@ -256,15 +310,23 @@ func (m *AutopilotManager) run(ctx context.Context, projectID, runID string) {
 		if step.Stop {
 			return
 		}
-		if step.Immediate {
-			immediateStreak++
-		} else {
-			immediateStreak = 0
-		}
-		if !m.applyImmediateThrottle(ctx, &immediateStreak) {
-			return
+		// If not immediate, we consumed a real iteration — count it toward budget
+		// If immediate (phase transition), don't count it
+		if !step.Immediate {
+			continue
 		}
 	}
+
+	// Budget exhausted — set to "scheduled" and wait for next cron tick
+	m.setRun(projectID, func(r *AutopilotRun) {
+		r.Status = AutopilotStatusScheduled
+		r.Message = fmt.Sprintf("Budget exhausted (%d iterations), waiting for next scheduled run", budget)
+		r.UpdatedAt = m.store.nowFn().UTC().Format(time.RFC3339)
+	})
+	_ = m.persistCurrentRun(projectID)
+	_ = m.appendPMActivity(projectID, "autopilot", "scheduled",
+		fmt.Sprintf("Paused after %d iterations, next run in %s", budget, m.cronInterval), nil)
+	m.publish(projectID, "autopilot")
 }
 
 type autopilotStepResult struct {
@@ -523,7 +585,7 @@ func (m *AutopilotManager) completeRun(projectID string, iteration int) {
 }
 
 func (m *AutopilotManager) applyImmediateThrottle(ctx context.Context, immediateStreak *int) bool {
-	if m.maxIterations <= 0 || *immediateStreak < m.maxIterations {
+	if m.budgetPerRun <= 0 || *immediateStreak < m.budgetPerRun {
 		return true
 	}
 	if !m.waitForNextTick(ctx) {
@@ -827,7 +889,7 @@ func (m *AutopilotManager) shouldAutopilotProjectRun(projectID string) (bool, er
 }
 
 func (m *AutopilotManager) waitForNextTick(ctx context.Context) bool {
-	interval := m.loopInterval
+	interval := m.cronInterval
 	if interval <= 0 {
 		interval = time.Minute
 	}
@@ -976,6 +1038,49 @@ func (m *AutopilotManager) Reset(projectID string) error {
 	m.stopLoop(strings.TrimSpace(projectID))
 	m.removeRun(strings.TrimSpace(projectID))
 	return nil
+}
+
+// RunScheduled is called by the cron system to continue a scheduled autopilot run.
+// Returns the run status and a response string for cron logging.
+func (m *AutopilotManager) RunScheduled(ctx context.Context, projectID string) (string, error) {
+	if m == nil {
+		return "", fmt.Errorf("autopilot manager not configured")
+	}
+	projectID = strings.TrimSpace(projectID)
+	run, ok := m.Status(projectID)
+	if !ok {
+		return "", fmt.Errorf("no autopilot run for project %s", projectID)
+	}
+	if run.Status != AutopilotStatusScheduled {
+		return fmt.Sprintf("autopilot is %s, not scheduled", run.Status), nil
+	}
+	if m.IsRunning(projectID) {
+		return "autopilot already running", nil
+	}
+
+	m.setRun(projectID, func(r *AutopilotRun) {
+		r.Status = AutopilotStatusRunning
+		r.Message = "resumed by cron"
+		r.UpdatedAt = m.store.nowFn().UTC().Format(time.RFC3339)
+	})
+	_ = m.persistCurrentRun(projectID)
+
+	loopCtx, cancel := context.WithCancel(ctx)
+	m.mu.Lock()
+	m.loops[projectID] = cancel
+	m.mu.Unlock()
+
+	m.publish(projectID, "autopilot")
+	go m.run(loopCtx, projectID, run.RunID)
+	return fmt.Sprintf("autopilot resumed for project %s", projectID), nil
+}
+
+// CronInterval returns the configured interval for autopilot cron jobs.
+func (m *AutopilotManager) CronInterval() time.Duration {
+	if m == nil || m.cronInterval <= 0 {
+		return 10 * time.Minute
+	}
+	return m.cronInterval
 }
 
 type errorSource string

--- a/internal/project/project_runner_test.go
+++ b/internal/project/project_runner_test.go
@@ -206,11 +206,14 @@ func TestAutopilotManager_StartCompletesTodoAndReviewFlow(t *testing.T) {
 	// Multi-phase: after all tasks complete, autopilot clears the board and attempts
 	// to plan the next phase. Mock runners return invalid HTML so planning fails,
 	// leaving the project "blocked" in "planning" instead of "done".
-	if final.Status == AutopilotStatusBlocked {
+	switch final.Status {
+	case AutopilotStatusBlocked:
 		if state.Phase != "planning" || state.Status != "blocked" {
 			t.Fatalf("expected blocked planning state after multi-phase transition, got %+v", state)
 		}
-	} else {
+	case AutopilotStatusScheduled:
+		// Budget exhausted before finishing — acceptable in cron mode.
+	default:
 		if state.Status != "done" || state.Phase != "done" {
 			t.Fatalf("expected done state, got %+v", state)
 		}
@@ -249,7 +252,7 @@ func TestAutopilotManager_StartRecoversVerificationGateFailureAndCompletes(t *te
 	}
 
 	manager := NewAutopilotManager(store, &recoveringTaskRunner{}, func(context.Context) error { return nil }, nil)
-	manager.loopInterval = 5 * time.Millisecond
+	manager.cronInterval = 5 * time.Millisecond
 	if _, err := manager.Start(context.Background(), created.ID); err != nil {
 		t.Fatalf("start autopilot: %v", err)
 	}
@@ -258,8 +261,8 @@ func TestAutopilotManager_StartRecoversVerificationGateFailureAndCompletes(t *te
 	if final.Iterations < 3 {
 		t.Fatalf("expected retry iterations before completion, got %+v", final)
 	}
-	if final.Status != AutopilotStatusBlocked && final.Status != AutopilotStatusDone {
-		t.Fatalf("expected recovered autopilot to finish or block on next phase, got %+v", final)
+	if final.Status != AutopilotStatusBlocked && final.Status != AutopilotStatusDone && final.Status != AutopilotStatusScheduled {
+		t.Fatalf("expected recovered autopilot to finish, block, or schedule, got %+v", final)
 	}
 
 	activity, err := store.ListActivity(created.ID, 100)
@@ -344,7 +347,7 @@ func TestAutopilotManager_StartRecoversStalledInProgressTaskAndCompletes(t *test
 	}
 
 	manager := NewAutopilotManager(store, stagedTaskRunner{}, func(context.Context) error { return nil }, nil)
-	manager.loopInterval = 5 * time.Millisecond
+	manager.cronInterval = 5 * time.Millisecond
 	if _, err := manager.Start(context.Background(), created.ID); err != nil {
 		t.Fatalf("start autopilot: %v", err)
 	}
@@ -543,7 +546,7 @@ func TestAutopilotManager_RestorePersistedRunsRestartsRunningRunsAtStartup(t *te
 	})
 
 	restarted := NewAutopilotManager(store, stagedTaskRunner{}, func(context.Context) error { return nil }, nil)
-	restarted.loopInterval = 5 * time.Millisecond
+	restarted.cronInterval = 5 * time.Millisecond
 	if err := restarted.RestorePersistedRuns(); err != nil {
 		t.Fatalf("restore persisted runs: %v", err)
 	}
@@ -672,7 +675,7 @@ func TestAutopilotManager_RestorePersistedRunsRestartsIncompleteProjects(t *test
 	})
 
 	restarted := NewAutopilotManager(store, stagedTaskRunner{}, func(context.Context) error { return nil }, nil)
-	restarted.loopInterval = 5 * time.Millisecond
+	restarted.cronInterval = 5 * time.Millisecond
 	if err := restarted.RestorePersistedRuns(); err != nil {
 		t.Fatalf("restore persisted runs: %v", err)
 	}
@@ -725,7 +728,7 @@ func TestAutopilotManager_EnsureActiveRunsStartsMissingLoop(t *testing.T) {
 	}
 
 	manager := NewAutopilotManager(store, stagedTaskRunner{}, func(context.Context) error { return nil }, nil)
-	manager.loopInterval = 5 * time.Millisecond
+	manager.cronInterval = 5 * time.Millisecond
 	started, err := manager.EnsureActiveRuns(context.Background())
 	if err != nil {
 		t.Fatalf("ensure active runs: %v", err)
@@ -735,8 +738,8 @@ func TestAutopilotManager_EnsureActiveRunsStartsMissingLoop(t *testing.T) {
 	}
 
 	final := waitForAutopilotTerminalStatus(t, manager, created.ID)
-	if final.Status != AutopilotStatusBlocked && final.Status != AutopilotStatusDone {
-		t.Fatalf("expected done or blocked status, got %+v", final)
+	if final.Status != AutopilotStatusBlocked && final.Status != AutopilotStatusDone && final.Status != AutopilotStatusScheduled {
+		t.Fatalf("expected done, blocked, or scheduled status, got %+v", final)
 	}
 }
 
@@ -822,12 +825,12 @@ func waitForAutopilotTerminalStatus(t *testing.T, manager *AutopilotManager, pro
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		item, ok := manager.Status(projectID)
-		if ok && (item.Status == AutopilotStatusDone || item.Status == AutopilotStatusBlocked) {
+		if ok && (item.Status == AutopilotStatusDone || item.Status == AutopilotStatusBlocked || item.Status == AutopilotStatusScheduled) {
 			return item
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
 	item, _ := manager.Status(projectID)
-	t.Fatalf("expected autopilot terminal status (done or blocked), got %+v", item)
+	t.Fatalf("expected autopilot terminal status (done, blocked, or scheduled), got %+v", item)
 	return AutopilotRun{}
 }

--- a/internal/tarsserver/handler_chat_pipeline_tools_test.go
+++ b/internal/tarsserver/handler_chat_pipeline_tools_test.go
@@ -3,6 +3,7 @@ package tarsserver
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/devlikebear/tars/internal/project"
 	"github.com/devlikebear/tars/internal/session"
@@ -41,6 +42,18 @@ func (chatPhaseEngineStub) Resume(context.Context, string) (project.AutopilotRun
 
 func (chatPhaseEngineStub) Reset(string) error {
 	return nil
+}
+
+func (chatPhaseEngineStub) RunScheduled(context.Context, string) (string, error) {
+	return "", nil
+}
+
+func (chatPhaseEngineStub) Stop(string) error {
+	return nil
+}
+
+func (chatPhaseEngineStub) CronInterval() time.Duration {
+	return 0
 }
 
 func TestResolveInjectedToolSchemas_FiltersHighRiskToolsForUserRole(t *testing.T) {

--- a/internal/tarsserver/handler_project.go
+++ b/internal/tarsserver/handler_project.go
@@ -526,6 +526,22 @@ func newProjectAPIHandler(
 			return
 		}
 
+		if len(parts) == 3 && parts[1] == "autopilot" && parts[2] == "stop" {
+			if autopilot == nil {
+				writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "project autopilot manager is not configured"})
+				return
+			}
+			if !requireMethod(w, r, http.MethodPost) {
+				return
+			}
+			if err := autopilot.Stop(projectID); err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+				return
+			}
+			writeJSON(w, http.StatusOK, map[string]string{"ok": "true"})
+			return
+		}
+
 		if len(parts) == 3 && parts[1] == "autopilot" && parts[2] == "resume" {
 			if autopilot == nil {
 				writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "project autopilot manager is not configured"})

--- a/internal/tarsserver/handler_project_test.go
+++ b/internal/tarsserver/handler_project_test.go
@@ -597,8 +597,9 @@ func TestProjectAPI_AutopilotRoutes(t *testing.T) {
 	}
 
 	// After all tasks done, autopilot clears board and attempts auto-planning.
-	// Mock runner returns invalid planning response, so autopilot blocks.
-	waitForAutopilotRun(t, manager, created.ID, project.AutopilotStatusBlocked)
+	// Mock runner returns invalid planning response, so autopilot either blocks
+	// or enters scheduled status when budget is exhausted (cron mode).
+	waitForAutopilotRunAny(t, manager, created.ID, project.AutopilotStatusBlocked, project.AutopilotStatusScheduled)
 
 	statusReq := httptest.NewRequest(http.MethodGet, "/v1/projects/"+created.ID+"/autopilot", nil)
 	statusRec := httptest.NewRecorder()
@@ -606,10 +607,9 @@ func TestProjectAPI_AutopilotRoutes(t *testing.T) {
 	if statusRec.Code != http.StatusOK {
 		t.Fatalf("expected 200 for autopilot status, got %d body=%q", statusRec.Code, statusRec.Body.String())
 	}
-	// With multi-phase, tasks done → board cleared → re-plan attempted.
-	// Mock runner can't produce valid planning JSON, so status is blocked.
-	if !strings.Contains(statusRec.Body.String(), `"status":"blocked"`) {
-		t.Fatalf("expected blocked status in autopilot response, got %q", statusRec.Body.String())
+	body := statusRec.Body.String()
+	if !strings.Contains(body, `"status":"blocked"`) && !strings.Contains(body, `"status":"scheduled"`) {
+		t.Fatalf("expected blocked or scheduled status in autopilot response, got %q", body)
 	}
 
 	board, err := projectStore.GetBoard(created.ID)
@@ -732,5 +732,24 @@ func waitForAutopilotRun(t *testing.T, manager *project.AutopilotManager, projec
 	}
 	run, _ := manager.Status(projectID)
 	t.Fatalf("expected autopilot status %q, got %+v", want, run)
+	return project.AutopilotRun{}
+}
+
+func waitForAutopilotRunAny(t *testing.T, manager *project.AutopilotManager, projectID string, wants ...project.AutopilotRunStatus) project.AutopilotRun {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		run, ok := manager.Status(projectID)
+		if ok {
+			for _, w := range wants {
+				if run.Status == w {
+					return run
+				}
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	run, _ := manager.Status(projectID)
+	t.Fatalf("expected autopilot status in %v, got %+v", wants, run)
 	return project.AutopilotRun{}
 }

--- a/internal/tarsserver/main_serve_api.go
+++ b/internal/tarsserver/main_serve_api.go
@@ -276,7 +276,7 @@ func buildAPIMux(
 		watchdogState,
 		dispatcher.Emit,
 	)
-	cronRunner := newCronJobRunnerWithNotify(
+	baseCronRunner := newCronJobRunnerWithNotify(
 		cfg.WorkspaceDir,
 		sessionStore,
 		apiRunPromptWithTools,
@@ -292,6 +292,21 @@ func buildAPIMux(
 			return telegramPairings.resolveDefaultChatID()
 		},
 	)
+
+	// Wrap cron runner to intercept autopilot tick jobs
+	cronRunner := func(ctx context.Context, job cron.Job) (string, error) {
+		if strings.HasPrefix(job.Prompt, "__autopilot_tick:") {
+			pid := strings.TrimPrefix(job.Prompt, "__autopilot_tick:")
+			if projectAutopilot != nil {
+				return projectAutopilot.RunScheduled(ctx, pid)
+			}
+			return "", fmt.Errorf("autopilot not configured")
+		}
+		if baseCronRunner != nil {
+			return baseCronRunner(ctx, job)
+		}
+		return "", fmt.Errorf("cron runner not configured")
+	}
 
 	mux := http.NewServeMux()
 	heartbeatHandler := newHeartbeatAPIHandlerWithRunner(heartbeatRunner, logger)
@@ -393,6 +408,29 @@ func buildAPIMux(
 	projectStore := project.NewStore(cfg.WorkspaceDir, nil)
 	projectTaskRunner := gateway.NewProjectTaskRunner(gatewayRuntime, "")
 	projectAutopilotManager := project.NewAutopilotManager(projectStore, projectTaskRunner, project.DefaultGitHubAuthChecker(), nil)
+	projectAutopilotManager.SetCronCallbacks(&project.CronJobCallbacks{
+		CreateJob: func(projectID string, interval time.Duration) error {
+			_, err := cronStore.CreateWithOptions(cron.CreateInput{
+				Name:     fmt.Sprintf("autopilot:%s", projectID),
+				Prompt:   fmt.Sprintf("__autopilot_tick:%s", projectID),
+				Schedule: fmt.Sprintf("@every %s", interval.String()),
+				ProjectID: projectID,
+			})
+			return err
+		},
+		DeleteJob: func(projectID string) error {
+			jobs, err := cronStore.List()
+			if err != nil {
+				return err
+			}
+			for _, j := range jobs {
+				if j.Name == fmt.Sprintf("autopilot:%s", projectID) {
+					return cronStore.Delete(j.ID)
+				}
+			}
+			return nil
+		},
+	})
 	projectAutopilot = projectAutopilotManager
 	ensureProjectAutopilot = func(ctx context.Context) error {
 		if projectAutopilot == nil {


### PR DESCRIPTION
## Summary

오토파일럿을 무한 루프에서 **크론잡 기반 예산 실행**으로 전환.

### 동작 변경
```
Before: Start → 무한 루프 (토큰 무한 소비)
After:  Start → 크론잡 생성 → 3 iterations 실행 → scheduled → (10분 후) → 3 iterations → ...
```

### Backend
- `AutopilotStatusScheduled` — budget 소진 후 대기 상태
- `run()` → `budgetPerRun` (기본 3) iterations 후 종료
- `Start()` → 크론잡 생성 (`@every 10m`)
- `Stop()` → 크론잡 삭제 + done 상태
- `RunScheduled()` → 크론 tick에서 호출

### Frontend
- **scheduled** 상태 파란색 배너
- **Run Now** 버튼 — 크론 대기 안 하고 즉시 실행
- **Stop** 버튼 — running/scheduled 에서 중지

Closes #217