### PR TITLE
feat: configurable autopilot interval and budget at start time

### DIFF
--- a/frontend/console/src/components/ProjectView.svelte
+++ b/frontend/console/src/components/ProjectView.svelte
@@ -138,11 +138,16 @@
     }
   }
 
+  let showStartForm = $state(false)
+  let startInterval = $state(10)
+  let startBudget = $state(3)
+
   async function handleStartAutopilot() {
     autopilotBusy = true
     autopilotError = ''
     try {
-      autopilot = await startAutopilot(projectId)
+      autopilot = await startAutopilot(projectId, { interval_minutes: startInterval, budget_per_run: startBudget })
+      showStartForm = false
     } catch (e) {
       autopilotError = e instanceof Error ? e.message : 'Failed to start autopilot'
     } finally {
@@ -435,9 +440,24 @@
       {/if}
       <div class="pv-phase-actions">
         {#if !autopilot || autopilot.status === 'done'}
-          <button class="btn btn-primary btn-sm" disabled={autopilotBusy} onclick={handleStartAutopilot}>
-            {autopilotBusy ? 'Starting...' : 'Start Autopilot'}
-          </button>
+          {#if showStartForm}
+            <div class="autopilot-start-form">
+              <label class="autopilot-param">
+                <span>Interval</span>
+                <input type="number" min="1" max="1440" bind:value={startInterval} class="autopilot-param-input" /> <span class="autopilot-param-unit">min</span>
+              </label>
+              <label class="autopilot-param">
+                <span>Budget</span>
+                <input type="number" min="1" max="20" bind:value={startBudget} class="autopilot-param-input" /> <span class="autopilot-param-unit">iter</span>
+              </label>
+              <button class="btn btn-primary btn-sm" disabled={autopilotBusy} onclick={handleStartAutopilot}>
+                {autopilotBusy ? 'Starting...' : 'Start'}
+              </button>
+              <button class="btn btn-ghost btn-sm" onclick={() => { showStartForm = false }}>Cancel</button>
+            </div>
+          {:else}
+            <button class="btn btn-primary btn-sm" onclick={() => { showStartForm = true }}>Start Autopilot</button>
+          {/if}
         {:else if autopilot.status === 'blocked' || autopilot.status === 'failed'}
           <button class="btn btn-primary btn-sm" disabled={autopilotBusy} onclick={handleResumeAutopilot}>
             {autopilotBusy ? 'Resuming...' : 'Resume'}
@@ -751,6 +771,34 @@
   .pv-phase-empty {
     padding: var(--space-2) 0;
   }
+
+  /* ── Autopilot start form ──────────────────── */
+  .autopilot-start-form {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+  }
+  .autopilot-param {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    font-size: var(--text-xs);
+    color: var(--text-secondary);
+  }
+  .autopilot-param-input {
+    width: 50px;
+    padding: 2px var(--space-1);
+    font-size: var(--text-xs);
+    font-family: var(--font-mono);
+    background: var(--bg-base);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    color: var(--text-primary);
+    text-align: center;
+  }
+  .autopilot-param-input:focus { outline: none; border-color: var(--accent); }
+  .autopilot-param-unit { font-size: 10px; color: var(--text-ghost); }
 
   .pv-scheduled-banner {
     display: flex;

--- a/frontend/console/src/lib/api.ts
+++ b/frontend/console/src/lib/api.ts
@@ -213,10 +213,10 @@ export async function getProjectFileContent(projectId: string, filename: string)
   return requestJSON<ProjectFileContent>(`/v1/projects/${encodeURIComponent(projectId)}/files/${encodeURIComponent(filename)}`)
 }
 
-export async function startAutopilot(projectId: string): Promise<ProjectAutopilotRun> {
+export async function startAutopilot(projectId: string, opts?: { interval_minutes?: number; budget_per_run?: number }): Promise<ProjectAutopilotRun> {
   return requestJSON<ProjectAutopilotRun>(
     `/v1/projects/${encodeURIComponent(projectId)}/autopilot`,
-    { method: 'POST' },
+    { method: 'POST', body: opts ? JSON.stringify(opts) : undefined },
   )
 }
 

--- a/internal/project/phase_engine.go
+++ b/internal/project/phase_engine.go
@@ -39,7 +39,7 @@ type PhaseSnapshot struct {
 }
 
 type PhaseEngine interface {
-	Start(context.Context, string) (AutopilotRun, error)
+	Start(context.Context, string, ...StartOptions) (AutopilotRun, error)
 	Status(string) (AutopilotRun, bool)
 	Current(string) (PhaseSnapshot, bool)
 	Advance(context.Context, string) (PhaseSnapshot, error)

--- a/internal/project/project_runner.go
+++ b/internal/project/project_runner.go
@@ -129,7 +129,20 @@ func (m *AutopilotManager) RestorePersistedRuns() error {
 	return nil
 }
 
-func (m *AutopilotManager) Start(_ context.Context, projectID string) (AutopilotRun, error) {
+// StartOptions controls autopilot execution parameters.
+type StartOptions struct {
+	IntervalMinutes int `json:"interval_minutes,omitempty"` // cron interval in minutes (default 10)
+	BudgetPerRun    int `json:"budget_per_run,omitempty"`   // max iterations per cron tick (default 3)
+}
+
+func (m *AutopilotManager) Start(_ context.Context, projectID string, opts ...StartOptions) (AutopilotRun, error) {
+	// Apply per-start options
+	if len(opts) > 0 && opts[0].IntervalMinutes > 0 {
+		m.cronInterval = time.Duration(opts[0].IntervalMinutes) * time.Minute
+	}
+	if len(opts) > 0 && opts[0].BudgetPerRun > 0 {
+		m.budgetPerRun = opts[0].BudgetPerRun
+	}
 	if m == nil || m.store == nil {
 		return AutopilotRun{}, fmt.Errorf("autopilot manager store is not configured")
 	}

--- a/internal/tarsserver/handler_chat_pipeline_tools_test.go
+++ b/internal/tarsserver/handler_chat_pipeline_tools_test.go
@@ -12,7 +12,7 @@ import (
 
 type chatPhaseEngineStub struct{}
 
-func (chatPhaseEngineStub) Start(context.Context, string) (project.AutopilotRun, error) {
+func (chatPhaseEngineStub) Start(context.Context, string, ...project.StartOptions) (project.AutopilotRun, error) {
 	return project.AutopilotRun{}, nil
 }
 

--- a/internal/tarsserver/handler_project.go
+++ b/internal/tarsserver/handler_project.go
@@ -1,6 +1,7 @@
 package tarsserver
 
 import (
+	"encoding/json"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -599,7 +600,10 @@ func newProjectAPIHandler(
 				}
 				writeJSON(w, http.StatusOK, payload)
 			case http.MethodPost:
-				item, err := autopilot.Start(r.Context(), projectID)
+				var startReq project.StartOptions
+				// Best-effort parse — empty body is fine (uses defaults)
+				_ = json.NewDecoder(r.Body).Decode(&startReq)
+				item, err := autopilot.Start(r.Context(), projectID, startReq)
 				if err != nil {
 					lower := strings.ToLower(err.Error())
 					if strings.Contains(lower, "not found") {

--- a/internal/tool/tool_project_runtime.go
+++ b/internal/tool/tool_project_runtime.go
@@ -221,7 +221,7 @@ func NewProjectDispatchTool(store *project.Store, runner project.TaskRunner, che
 }
 
 type projectAutopilotStarter interface {
-	Start(context.Context, string) (project.AutopilotRun, error)
+	Start(context.Context, string, ...project.StartOptions) (project.AutopilotRun, error)
 }
 
 func NewProjectAutopilotStartTool(manager projectAutopilotStarter) Tool {


### PR DESCRIPTION
Start Autopilot 시 **간격(분)**과 **budget(iterations)**를 설정할 수 있는 폼 추가.

- 기본값: 간격 10분, budget 3 iterations
- 사용자가 매번 조절 가능
- API: `POST /v1/projects/{id}/autopilot` body에 `{interval_minutes, budget_per_run}` 전달