### PR TITLE
fix: autopilot cleanup cron on complete + reset stale state

### DIFF
--- a/internal/project/project_runner.go
+++ b/internal/project/project_runner.go
@@ -159,6 +159,13 @@ func (m *AutopilotManager) Start(_ context.Context, projectID string, opts ...St
 	if current, ok := m.Status(projectID); ok && m.IsRunning(projectID) {
 		return current, nil
 	}
+	// Reset project state to active when starting fresh
+	if state, err := m.store.GetState(projectID); err == nil && (state.Phase == "done" || state.Status == "done") {
+		m.updateState(projectID, workflowStateUpdate{
+			Phase:  "planning",
+			Status: "active",
+		})
+	}
 
 	now := m.store.nowFn().UTC()
 	message := "Autopilot started"
@@ -595,6 +602,10 @@ func (m *AutopilotManager) completeRun(projectID string, iteration int) {
 		terminal:   true,
 		stateUpdate: DefaultWorkflowPolicy.AutopilotCompletedState(message),
 	})
+	// Clean up the cron job
+	if m.cronCallbacks != nil && m.cronCallbacks.DeleteJob != nil {
+		_ = m.cronCallbacks.DeleteJob(projectID)
+	}
 }
 
 func (m *AutopilotManager) applyImmediateThrottle(ctx context.Context, immediateStreak *int) bool {


### PR DESCRIPTION
1. completeRun()에서 크론잡 삭제 (고아 크론 방지)
2. Start()에서 done 상태를 planning/active로 리셋 (LLM이 stale 'done' 보고 즉시 완료하는 문제)