### PR TITLE
chore: change worktree path to .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ node_modules/
 
 # for development, ignore the following files
 .claude/*.local.json
+.claude/worktrees/
 .docs/
 .analysis/sessions/
 .analysis/RESUME.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,12 +79,12 @@ cd frontend/console && npm run check   # svelte-check + tsc
 ```bash
 # Create worktree
 git fetch origin && git switch main && git pull --rebase
-git worktree add ../tars-worktrees/<branch-name> -b <branch-name> main
+git worktree add .claude/worktrees/<branch-name> -b <branch-name> main
 
 # Branch naming: feat/<name>, fix/<name>, chore/<name> (lowercase kebab-case)
 
 # After PR merge, cleanup
-git worktree remove ../tars-worktrees/<branch-name>
+git worktree remove .claude/worktrees/<branch-name>
 git worktree prune
 git fetch origin && git switch main && git pull --rebase
 ```


### PR DESCRIPTION
## Summary
- worktree 경로를 `../tars-worktrees/` → `.claude/worktrees/`로 변경
- `.gitignore`에 `.claude/worktrees/` 추가

## Changes
- `CLAUDE.md` — worktree 경로 업데이트
- `.gitignore` — `.claude/worktrees/` 추가