### PR TITLE
feat: add heartbeat management page to console

### DIFF
--- a/frontend/console/src/App.svelte
+++ b/frontend/console/src/App.svelte
@@ -8,6 +8,7 @@
   import Ops from './components/Ops.svelte'
   import Config from './components/Config.svelte'
   import Extensions from './components/Extensions.svelte'
+  import Heartbeat from './components/Heartbeat.svelte'
   import { resolveRoute, type Route } from './lib/router'
   import { getEventsHistory, streamEvents } from './lib/api'
 
@@ -93,6 +94,8 @@
     <Ops onAskAI={navigateWithPrompt} />
   {:else if route.view === 'config'}
     <Config />
+  {:else if route.view === 'heartbeat'}
+    <Heartbeat />
   {:else if route.view === 'extensions'}
     <Extensions />
   {/if}

--- a/frontend/console/src/components/Heartbeat.svelte
+++ b/frontend/console/src/components/Heartbeat.svelte
@@ -1,0 +1,449 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte'
+  import {
+    getHeartbeatStatus,
+    runHeartbeatOnce,
+    getHeartbeatConfig,
+    saveHeartbeatConfig,
+    getHeartbeatLog,
+  } from '../lib/api'
+  import { renderMarkdown } from '../lib/markdown'
+  import type { HeartbeatStatus, HeartbeatRunResult } from '../lib/types'
+
+  let status: HeartbeatStatus | null = $state(null)
+  let heartbeatMd = $state('')
+  let dailyLog = $state('')
+  let dailyLogDate = $state('')
+
+  let loading = $state(true)
+  let error = $state('')
+
+  let running = $state(false)
+  let runResult: HeartbeatRunResult | null = $state(null)
+
+  let editing = $state(false)
+  let editContent = $state('')
+  let saving = $state(false)
+  let saveMsg = $state('')
+
+  let refreshInterval: ReturnType<typeof setInterval> | null = null
+
+  async function loadStatus() {
+    try {
+      status = await getHeartbeatStatus()
+    } catch { /* ignore */ }
+  }
+
+  async function loadConfig() {
+    try {
+      const result = await getHeartbeatConfig()
+      heartbeatMd = result.content
+    } catch { heartbeatMd = '' }
+  }
+
+  async function loadLog() {
+    try {
+      const result = await getHeartbeatLog()
+      dailyLog = result.content
+      dailyLogDate = result.date
+    } catch { dailyLog = '' }
+  }
+
+  async function loadAll() {
+    loading = true
+    error = ''
+    try {
+      await Promise.all([loadStatus(), loadConfig(), loadLog()])
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'Failed to load'
+    } finally {
+      loading = false
+    }
+  }
+
+  async function handleRun() {
+    running = true
+    runResult = null
+    try {
+      runResult = await runHeartbeatOnce()
+      await loadStatus()
+      await loadLog()
+    } catch (e) {
+      runResult = { response: e instanceof Error ? e.message : 'Run failed' }
+    } finally {
+      running = false
+    }
+  }
+
+  function startEdit() {
+    editContent = heartbeatMd
+    saveMsg = ''
+    editing = true
+  }
+
+  function cancelEdit() {
+    editing = false
+    saveMsg = ''
+  }
+
+  async function handleSave() {
+    saving = true
+    saveMsg = ''
+    try {
+      await saveHeartbeatConfig(editContent)
+      heartbeatMd = editContent
+      editing = false
+      saveMsg = 'Saved'
+      setTimeout(() => { saveMsg = '' }, 2000)
+    } catch (e) {
+      saveMsg = e instanceof Error ? e.message : 'Save failed'
+    } finally {
+      saving = false
+    }
+  }
+
+  function fmtTime(value?: string): string {
+    if (!value?.trim()) return '\u2014'
+    const date = new Date(value)
+    if (Number.isNaN(date.getTime())) return value
+    return new Intl.DateTimeFormat('en', { dateStyle: 'medium', timeStyle: 'short' }).format(date)
+  }
+
+  function relativeTime(value?: string): string {
+    if (!value?.trim()) return 'never'
+    const date = new Date(value)
+    if (Number.isNaN(date.getTime())) return value
+    const seconds = Math.floor((Date.now() - date.getTime()) / 1000)
+    if (seconds < 60) return `${seconds}s ago`
+    if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`
+    if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`
+    return `${Math.floor(seconds / 86400)}d ago`
+  }
+
+  onMount(() => {
+    void loadAll()
+    refreshInterval = setInterval(loadStatus, 30000)
+  })
+
+  onDestroy(() => {
+    if (refreshInterval) clearInterval(refreshInterval)
+  })
+</script>
+
+<div class="hb">
+  {#if loading}
+    <div class="hb-loading">Loading heartbeat...</div>
+  {:else}
+    {#if error}
+      <div class="error-banner" style="margin-bottom:var(--space-4)">{error}</div>
+    {/if}
+
+    <!-- Status -->
+    <section class="card">
+      <div class="card-header">
+        <span class="card-title">Status</span>
+        {#if status?.configured}
+          <span class="badge badge-success">configured</span>
+        {:else}
+          <span class="badge badge-default">not configured</span>
+        {/if}
+        {#if status?.chat_busy}
+          <span class="badge badge-warning">chat busy</span>
+        {/if}
+      </div>
+      <dl class="hb-facts">
+        <div><dt>Active Hours</dt><dd>{status?.active_hours || 'always'}</dd></div>
+        <div><dt>Timezone</dt><dd>{status?.timezone || 'system'}</dd></div>
+        <div><dt>Last Run</dt><dd>{relativeTime(status?.last_run_at)}</dd></div>
+      </dl>
+    </section>
+
+    <!-- Last Result + Run Action -->
+    <section class="card">
+      <div class="card-header">
+        <span class="card-title">Last Result</span>
+        <div class="hb-badges">
+          {#if status?.last_skipped}
+            <span class="badge badge-warning">skipped</span>
+          {/if}
+          {#if status?.last_acknowledged}
+            <span class="badge badge-success">acknowledged</span>
+          {/if}
+          {#if status?.last_logged}
+            <span class="badge badge-info">logged</span>
+          {/if}
+          {#if status?.last_error}
+            <span class="badge badge-error">error</span>
+          {/if}
+        </div>
+      </div>
+      {#if status?.last_error}
+        <div class="hb-error">{status.last_error}</div>
+      {/if}
+      {#if status?.last_skip_reason}
+        <div class="hb-skip-reason">Skip reason: {status.last_skip_reason}</div>
+      {/if}
+      {#if status?.last_response}
+        <div class="hb-response">{status.last_response}</div>
+      {:else if !status?.last_error && !status?.last_skip_reason}
+        <div class="hb-empty">No heartbeat result yet.</div>
+      {/if}
+
+      <div class="hb-actions">
+        <button class="btn btn-primary btn-sm" disabled={running || status?.chat_busy} onclick={handleRun}>
+          {running ? 'Running...' : 'Run Now'}
+        </button>
+        {#if status?.chat_busy}
+          <span class="hb-hint">Paused while chat is active</span>
+        {/if}
+      </div>
+
+      {#if runResult}
+        <div class="hb-run-result">
+          <div class="hb-run-result-header">
+            <strong>Run result</strong>
+            <div class="hb-badges">
+              {#if runResult.skipped}<span class="badge badge-warning">skipped</span>{/if}
+              {#if runResult.acknowledged}<span class="badge badge-success">ack</span>{/if}
+              {#if runResult.logged}<span class="badge badge-info">logged</span>{/if}
+            </div>
+          </div>
+          {#if runResult.skip_reason}
+            <div class="hb-skip-reason">{runResult.skip_reason}</div>
+          {/if}
+          {#if runResult.response}
+            <div class="hb-response">{runResult.response}</div>
+          {/if}
+        </div>
+      {/if}
+    </section>
+
+    <!-- HEARTBEAT.md -->
+    <section class="card">
+      <div class="card-header">
+        <span class="card-title">HEARTBEAT.md</span>
+        {#if !editing}
+          <button class="btn btn-ghost btn-sm" onclick={startEdit}>Edit</button>
+        {/if}
+        {#if saveMsg}
+          <span class="hb-save-msg">{saveMsg}</span>
+        {/if}
+      </div>
+      {#if editing}
+        <textarea class="hb-editor" bind:value={editContent} rows="12"></textarea>
+        <div class="hb-editor-actions">
+          <button class="btn btn-primary btn-sm" disabled={saving} onclick={handleSave}>
+            {saving ? 'Saving...' : 'Save'}
+          </button>
+          <button class="btn btn-ghost btn-sm" onclick={cancelEdit}>Cancel</button>
+        </div>
+      {:else if heartbeatMd}
+        <div class="hb-md-preview hb-md">{@html renderMarkdown(heartbeatMd)}</div>
+      {:else}
+        <div class="hb-empty">No HEARTBEAT.md configured. Click Edit to create one.</div>
+      {/if}
+    </section>
+
+    <!-- Today's Log -->
+    <section class="card">
+      <div class="card-header">
+        <span class="card-title">Daily Log</span>
+        {#if dailyLogDate}
+          <span class="badge badge-default">{dailyLogDate}</span>
+        {/if}
+        <button class="btn btn-ghost btn-sm" onclick={loadLog}>Refresh</button>
+      </div>
+      {#if dailyLog}
+        <div class="hb-log hb-md">{@html renderMarkdown(dailyLog)}</div>
+      {:else}
+        <div class="hb-empty">No heartbeat entries for today.</div>
+      {/if}
+    </section>
+  {/if}
+</div>
+
+<style>
+  .hb {
+    display: grid;
+    gap: var(--space-4);
+    animation: fadeIn var(--duration-normal) var(--ease-out);
+  }
+
+  @keyframes fadeIn {
+    from { opacity: 0; transform: translateY(8px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  .hb-loading {
+    padding: var(--space-10);
+    text-align: center;
+    color: var(--text-tertiary);
+  }
+
+  .hb-facts {
+    display: grid;
+    gap: var(--space-2);
+    margin-top: var(--space-3);
+  }
+
+  .hb-facts div {
+    display: grid;
+    grid-template-columns: 120px minmax(0, 1fr);
+    gap: var(--space-3);
+  }
+
+  .hb-facts dt {
+    color: var(--text-tertiary);
+    font-size: var(--text-sm);
+  }
+
+  .hb-facts dd {
+    margin: 0;
+    font-size: var(--text-sm);
+  }
+
+  .hb-badges {
+    display: flex;
+    gap: var(--space-1);
+  }
+
+  .hb-response {
+    padding: var(--space-3);
+    background: var(--bg-base);
+    border-radius: var(--radius-md);
+    font-size: var(--text-sm);
+    line-height: 1.6;
+    white-space: pre-wrap;
+    color: var(--text-secondary);
+    margin-top: var(--space-2);
+  }
+
+  .hb-error {
+    padding: var(--space-2) var(--space-3);
+    background: var(--error-muted);
+    border-radius: var(--radius-md);
+    font-size: var(--text-sm);
+    color: var(--error);
+    margin-top: var(--space-2);
+  }
+
+  .hb-skip-reason {
+    font-size: var(--text-xs);
+    color: var(--text-ghost);
+    margin-top: var(--space-1);
+  }
+
+  .hb-empty {
+    padding: var(--space-3);
+    color: var(--text-ghost);
+    font-size: var(--text-sm);
+  }
+
+  .hb-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    margin-top: var(--space-3);
+  }
+
+  .hb-hint {
+    font-size: var(--text-xs);
+    color: var(--text-ghost);
+  }
+
+  .hb-run-result {
+    margin-top: var(--space-3);
+    padding: var(--space-3);
+    background: rgba(224, 145, 69, 0.06);
+    border: 1px solid rgba(224, 145, 69, 0.12);
+    border-radius: var(--radius-md);
+  }
+
+  .hb-run-result-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: var(--space-2);
+  }
+
+  .hb-run-result-header strong {
+    font-family: var(--font-display);
+    font-size: var(--text-sm);
+    font-weight: 500;
+  }
+
+  .hb-editor {
+    width: 100%;
+    min-height: 200px;
+    padding: var(--space-3);
+    background: var(--bg-base);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    line-height: 1.6;
+    resize: vertical;
+    margin-top: var(--space-2);
+  }
+
+  .hb-editor:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+
+  .hb-editor-actions {
+    display: flex;
+    gap: var(--space-2);
+    margin-top: var(--space-2);
+  }
+
+  .hb-save-msg {
+    font-size: var(--text-xs);
+    color: var(--success);
+  }
+
+  .hb-md-preview {
+    padding: var(--space-3);
+    font-size: var(--text-sm);
+    line-height: 1.6;
+    color: var(--text-secondary);
+  }
+
+  .hb-md :global(h1), .hb-md :global(h2), .hb-md :global(h3) {
+    font-family: var(--font-display);
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: var(--space-3) 0 var(--space-1);
+  }
+  .hb-md :global(p) { margin: 0 0 var(--space-2); }
+  .hb-md :global(ul), .hb-md :global(ol) { margin: var(--space-1) 0; padding-left: var(--space-5); }
+  .hb-md :global(li) { margin-bottom: var(--space-1); font-size: var(--text-sm); }
+  .hb-md :global(code) {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: rgba(255,255,255,0.06);
+    padding: 1px 5px;
+    border-radius: 3px;
+  }
+  .hb-md :global(pre) {
+    background: var(--bg-base);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    padding: var(--space-2);
+    overflow-x: auto;
+    margin: var(--space-2) 0;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+  }
+  .hb-md :global(strong) { font-weight: 600; color: var(--text-primary); }
+
+  .hb-log {
+    padding: var(--space-3);
+    font-size: var(--text-sm);
+    line-height: 1.6;
+    color: var(--text-secondary);
+    max-height: 400px;
+    overflow-y: auto;
+  }
+</style>

--- a/frontend/console/src/components/Nav.svelte
+++ b/frontend/console/src/components/Nav.svelte
@@ -18,6 +18,7 @@
     { id: 'projects', label: 'Projects', path: '/console/projects', icon: '\u25eb' },
     { id: 'sessions', label: 'Sessions', path: '/console/sessions', icon: '\u25ce' },
     { id: 'ops', label: 'Operations', path: '/console/ops', icon: '\u2699' },
+    { id: 'heartbeat', label: 'Heartbeat', path: '/console/heartbeat', icon: '\u2661' },
     { id: 'extensions', label: 'Extensions', path: '/console/extensions', icon: '\u2756' },
     { id: 'config', label: 'Settings', path: '/console/config', icon: '\u2638' },
   ]

--- a/frontend/console/src/lib/api.ts
+++ b/frontend/console/src/lib/api.ts
@@ -23,6 +23,8 @@ import type {
   Project,
   ProjectActivity,
   ProjectSessionInfo,
+  HeartbeatStatus,
+  HeartbeatRunResult,
   Session,
   SessionMessage,
   UpdateCronJobRequest,
@@ -58,6 +60,34 @@ async function requestJSON<T>(input: string, init?: RequestInit): Promise<T> {
 
   return (await response.json()) as T
 }
+
+// --- Heartbeat ---
+
+export async function getHeartbeatStatus(): Promise<HeartbeatStatus> {
+  return requestJSON<HeartbeatStatus>('/v1/heartbeat/status')
+}
+
+export async function runHeartbeatOnce(): Promise<HeartbeatRunResult> {
+  return requestJSON<HeartbeatRunResult>('/v1/heartbeat/run-once', { method: 'POST' })
+}
+
+export async function getHeartbeatConfig(): Promise<{ content: string }> {
+  return requestJSON<{ content: string }>('/v1/heartbeat/config')
+}
+
+export async function saveHeartbeatConfig(content: string): Promise<void> {
+  await requestJSON<{ ok: string }>('/v1/heartbeat/config', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  })
+}
+
+export async function getHeartbeatLog(): Promise<{ date: string; content: string }> {
+  return requestJSON<{ date: string; content: string }>('/v1/heartbeat/log')
+}
+
+// --- Projects ---
 
 export async function listProjects(): Promise<Project[]> {
   return requestJSON<Project[]>('/v1/projects')

--- a/frontend/console/src/lib/router.ts
+++ b/frontend/console/src/lib/router.ts
@@ -9,6 +9,7 @@ export type Route =
   | { view: 'ops' }
   | { view: 'config' }
   | { view: 'extensions' }
+  | { view: 'heartbeat' }
 
 export function resolveRoute(pathname: string): Route {
   const path = pathname.trim()
@@ -39,6 +40,10 @@ export function resolveRoute(pathname: string): Route {
 
   if (path.startsWith(`${consoleBase}/extensions`)) {
     return { view: 'extensions' }
+  }
+
+  if (path.startsWith(`${consoleBase}/heartbeat`)) {
+    return { view: 'heartbeat' }
   }
 
   return { view: 'home' }

--- a/frontend/console/src/lib/types.ts
+++ b/frontend/console/src/lib/types.ts
@@ -1,3 +1,25 @@
+export type HeartbeatStatus = {
+  configured: boolean
+  active_hours?: string
+  timezone?: string
+  chat_busy?: boolean
+  last_run_at?: string
+  last_skipped?: boolean
+  last_skip_reason?: string
+  last_logged?: boolean
+  last_acknowledged?: boolean
+  last_response?: string
+  last_error?: string
+}
+
+export type HeartbeatRunResult = {
+  response?: string
+  skipped?: boolean
+  skip_reason?: string
+  acknowledged?: boolean
+  logged?: boolean
+}
+
 export type Project = {
   id: string
   name: string

--- a/internal/tarsserver/handlers.go
+++ b/internal/tarsserver/handlers.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/devlikebear/tars/internal/heartbeat"
 	"github.com/devlikebear/tars/internal/serverauth"
+	"github.com/devlikebear/tars/internal/tool"
 	"github.com/rs/zerolog"
 )
 
@@ -49,6 +52,96 @@ func newHeartbeatAPIHandlerWithRunner(
 			"acknowledged": result.Acknowledged,
 			"logged":       result.Logged,
 		})
+	})
+
+	return mux
+}
+
+func newHeartbeatAPIHandlerFull(
+	workspaceDir string,
+	nowFn func() time.Time,
+	runHeartbeat func(ctx context.Context) (heartbeat.RunResult, error),
+	getStatus func() tool.HeartbeatStatus,
+	logger zerolog.Logger,
+) http.Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/v1/heartbeat/run-once", func(w http.ResponseWriter, r *http.Request) {
+		if !requireMethod(w, r, http.MethodPost) {
+			return
+		}
+		result, err := runHeartbeat(r.Context())
+		if err != nil {
+			logger.Error().Err(err).Msg("heartbeat run-once api failed")
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"response":     result.Response,
+			"skipped":      result.Skipped,
+			"skip_reason":  result.SkipReason,
+			"acknowledged": result.Acknowledged,
+			"logged":       result.Logged,
+		})
+	})
+
+	mux.HandleFunc("/v1/heartbeat/status", func(w http.ResponseWriter, r *http.Request) {
+		if !requireMethod(w, r, http.MethodGet) {
+			return
+		}
+		if getStatus == nil {
+			writeJSON(w, http.StatusOK, tool.HeartbeatStatus{})
+			return
+		}
+		writeJSON(w, http.StatusOK, getStatus())
+	})
+
+	mux.HandleFunc("/v1/heartbeat/config", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			data, err := os.ReadFile(filepath.Join(workspaceDir, "HEARTBEAT.md"))
+			if err != nil {
+				if os.IsNotExist(err) {
+					writeJSON(w, http.StatusOK, map[string]string{"content": ""})
+					return
+				}
+				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "read heartbeat config failed"})
+				return
+			}
+			writeJSON(w, http.StatusOK, map[string]string{"content": string(data)})
+		case http.MethodPut:
+			var req struct {
+				Content string `json:"content"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+				return
+			}
+			if err := os.WriteFile(filepath.Join(workspaceDir, "HEARTBEAT.md"), []byte(req.Content), 0o644); err != nil {
+				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "write heartbeat config failed"})
+				return
+			}
+			writeJSON(w, http.StatusOK, map[string]string{"ok": "true"})
+		default:
+			requireMethod(w, r, http.MethodGet, http.MethodPut)
+		}
+	})
+
+	mux.HandleFunc("/v1/heartbeat/log", func(w http.ResponseWriter, r *http.Request) {
+		if !requireMethod(w, r, http.MethodGet) {
+			return
+		}
+		today := nowFn().Format("2006-01-02")
+		data, err := os.ReadFile(filepath.Join(workspaceDir, "memory", today+".md"))
+		if err != nil {
+			if os.IsNotExist(err) {
+				writeJSON(w, http.StatusOK, map[string]any{"date": today, "content": ""})
+				return
+			}
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "read daily log failed"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"date": today, "content": string(data)})
 	})
 
 	return mux

--- a/internal/tarsserver/main_serve_api.go
+++ b/internal/tarsserver/main_serve_api.go
@@ -292,7 +292,21 @@ func buildAPIMux(
 	}
 
 	mux := http.NewServeMux()
-	heartbeatHandler := newHeartbeatAPIHandlerWithRunner(heartbeatRunner, logger)
+	heartbeatHandler := newHeartbeatAPIHandlerFull(
+		resolveWorkspaceDir(cfg.WorkspaceDir, defaultWorkspaceID),
+		nowFn,
+		heartbeatRunner,
+		func() tool.HeartbeatStatus {
+			return heartbeatState.snapshot(
+				defaultWorkspaceID,
+				deps.ask != nil,
+				cfg.HeartbeatActiveHours,
+				cfg.HeartbeatTimezone,
+				activity.isChatBusy(),
+			)
+		},
+		logger,
+	)
 
 	processManager := tool.NewProcessManager()
 	mcpClient := mcp.NewClient(cfg.MCPServers)


### PR DESCRIPTION
## Summary
- 콘솔에 하트비트 전용 관리 페이지 추가
- 상태 조회, 즉시 실행, HEARTBEAT.md 편집, 일일 로그 확인

## Changes
- **Backend**: `GET /status`, `GET/PUT /config`, `GET /log` 4개 엔드포인트 추가
- **Frontend**: `Heartbeat.svelte` 신규 + router/nav/api/types 연결

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/tarsserver/...` passes
- [x] `npm run check` — 0 errors
- [ ] Manual: `/console/heartbeat` 접속 → 상태/로그/에디터 확인