### PR TITLE
feat: add heartbeat_interval config with auto-ticker

### DIFF
--- a/frontend/console/src/components/Heartbeat.svelte
+++ b/frontend/console/src/components/Heartbeat.svelte
@@ -152,6 +152,7 @@
         {/if}
       </div>
       <dl class="hb-facts">
+        <div><dt>Interval</dt><dd>{status?.interval || 'disabled'}</dd></div>
         <div><dt>Active Hours</dt><dd>{status?.active_hours || 'always'}</dd></div>
         <div><dt>Timezone</dt><dd>{status?.timezone || 'system'}</dd></div>
         <div><dt>Last Run</dt><dd>{relativeTime(status?.last_run_at)}</dd></div>

--- a/frontend/console/src/lib/types.ts
+++ b/frontend/console/src/lib/types.ts
@@ -1,5 +1,6 @@
 export type HeartbeatStatus = {
   configured: boolean
+  interval?: string
   active_hours?: string
   timezone?: string
   chat_busy?: boolean

--- a/internal/config/config_input_fields.go
+++ b/internal/config/config_input_fields.go
@@ -54,6 +54,7 @@ var configInputFields = []configInputField{
 	stringField("usage_limit_mode", []string{"USAGE_LIMIT_MODE", "TARS_USAGE_LIMIT_MODE"}, func(cfg *Config) *string { return &cfg.UsageLimitMode }, lowerTrimmedString),
 	usagePriceOverridesField("usage_price_overrides_json", []string{"USAGE_PRICE_OVERRIDES_JSON", "TARS_USAGE_PRICE_OVERRIDES_JSON"}),
 	intField("agent_max_iterations", []string{"AGENT_MAX_ITERATIONS", "TARS_AGENT_MAX_ITERATIONS"}, func(cfg *Config) *int { return &cfg.AgentMaxIterations }, parsePositiveInt),
+	stringField("heartbeat_interval", []string{"HEARTBEAT_INTERVAL", "TARS_HEARTBEAT_INTERVAL"}, func(cfg *Config) *string { return &cfg.HeartbeatInterval }, strings.TrimSpace),
 	stringField("heartbeat_active_hours", []string{"HEARTBEAT_ACTIVE_HOURS", "TARS_HEARTBEAT_ACTIVE_HOURS"}, func(cfg *Config) *string { return &cfg.HeartbeatActiveHours }, strings.TrimSpace),
 	stringField("heartbeat_timezone", []string{"HEARTBEAT_TIMEZONE", "TARS_HEARTBEAT_TIMEZONE"}, func(cfg *Config) *string { return &cfg.HeartbeatTimezone }, strings.TrimSpace),
 	intField("cron_run_history_limit", []string{"CRON_RUN_HISTORY_LIMIT", "TARS_CRON_RUN_HISTORY_LIMIT"}, func(cfg *Config) *int { return &cfg.CronRunHistoryLimit }, parsePositiveInt),

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -79,6 +79,7 @@ func Schema() []FieldMeta {
 
 		// ── Automation ───────────────────────────
 		f("agent_max_iterations", "Automation", "int", "Max Iterations", "Maximum agent loop iterations per request"),
+		f("heartbeat_interval", "Automation", "string", "Heartbeat Interval", "Heartbeat tick interval (e.g. 5m, 30m). Empty = disabled."),
 		f("heartbeat_active_hours", "Automation", "string", "Active Hours", "Heartbeat active hours range (e.g. 09:00-18:00)"),
 		f("heartbeat_timezone", "Automation", "string", "Timezone", "Timezone for active hours evaluation"),
 		f("cron_run_history_limit", "Automation", "int", "Cron History Limit", "Maximum run records kept per cron job"),
@@ -265,6 +266,8 @@ func extractValue(yamlKey string, cfg Config) any {
 	// Automation
 	case "agent_max_iterations":
 		return cfg.AgentMaxIterations
+	case "heartbeat_interval":
+		return cfg.HeartbeatInterval
 	case "heartbeat_active_hours":
 		return cfg.HeartbeatActiveHours
 	case "heartbeat_timezone":

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -89,6 +89,7 @@ type UsageConfig struct {
 
 type AutomationConfig struct {
 	AgentMaxIterations   int
+	HeartbeatInterval    string
 	HeartbeatActiveHours string
 	HeartbeatTimezone    string
 	CronRunHistoryLimit  int

--- a/internal/tarsserver/helpers_heartbeat_ticker.go
+++ b/internal/tarsserver/helpers_heartbeat_ticker.go
@@ -1,0 +1,49 @@
+package tarsserver
+
+import (
+	"context"
+	"time"
+
+	"github.com/devlikebear/tars/internal/heartbeat"
+	"github.com/rs/zerolog"
+)
+
+type heartbeatTickerManager struct {
+	run      func(ctx context.Context) (heartbeat.RunResult, error)
+	interval time.Duration
+	logger   zerolog.Logger
+}
+
+func newHeartbeatTickerManager(
+	run func(ctx context.Context) (heartbeat.RunResult, error),
+	interval time.Duration,
+	logger zerolog.Logger,
+) *heartbeatTickerManager {
+	if run == nil || interval <= 0 {
+		return nil
+	}
+	return &heartbeatTickerManager{
+		run:      run,
+		interval: interval,
+		logger:   logger,
+	}
+}
+
+func (m *heartbeatTickerManager) Start(ctx context.Context) error {
+	if m == nil || m.run == nil {
+		return nil
+	}
+	ticker := time.NewTicker(m.interval)
+	defer ticker.Stop()
+	m.logger.Info().Dur("interval", m.interval).Msg("heartbeat ticker started")
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if _, err := m.run(ctx); err != nil {
+				m.logger.Debug().Err(err).Msg("heartbeat tick failed")
+			}
+		}
+	}
+}

--- a/internal/tarsserver/helpers_runtime.go
+++ b/internal/tarsserver/helpers_runtime.go
@@ -96,19 +96,20 @@ func (s *heartbeatWorkspaceState) record(workspaceID string, ranAt time.Time, re
 func (s *heartbeatWorkspaceState) snapshot(
 	workspaceID string,
 	configured bool,
-	activeHours, timezone string,
+	interval, activeHours, timezone string,
 	chatBusy bool,
 ) tool.HeartbeatStatus {
 	state := s.get(workspaceID)
 	if state == nil {
 		return tool.HeartbeatStatus{
 			Configured:  configured,
+			Interval:    strings.TrimSpace(interval),
 			ActiveHours: strings.TrimSpace(activeHours),
 			Timezone:    strings.TrimSpace(timezone),
 			ChatBusy:    chatBusy,
 		}
 	}
-	return state.snapshot(configured, activeHours, timezone, chatBusy)
+	return state.snapshot(configured, interval, activeHours, timezone, chatBusy)
 }
 
 func (s *heartbeatRuntimeState) record(ranAt time.Time, result heartbeat.RunResult, runErr error) {
@@ -127,9 +128,10 @@ func (s *heartbeatRuntimeState) record(ranAt time.Time, result heartbeat.RunResu
 	}
 }
 
-func (s *heartbeatRuntimeState) snapshot(configured bool, activeHours, timezone string, chatBusy bool) tool.HeartbeatStatus {
+func (s *heartbeatRuntimeState) snapshot(configured bool, interval, activeHours, timezone string, chatBusy bool) tool.HeartbeatStatus {
 	status := tool.HeartbeatStatus{
 		Configured:  configured,
+		Interval:    strings.TrimSpace(interval),
 		ActiveHours: strings.TrimSpace(activeHours),
 		Timezone:    strings.TrimSpace(timezone),
 		ChatBusy:    chatBusy,

--- a/internal/tarsserver/main_serve_api.go
+++ b/internal/tarsserver/main_serve_api.go
@@ -41,6 +41,7 @@ type serveAPIRuntime struct {
 	gatewayAgentsWatch      *gatewayAgentsWatcher
 	cronManager             *workspaceCronManager
 	watchdogManager         *workspaceWatchdogManager
+	heartbeatTicker         *heartbeatTickerManager
 	telegramPoller          *telegramUpdatePoller
 }
 
@@ -300,6 +301,7 @@ func buildAPIMux(
 			return heartbeatState.snapshot(
 				defaultWorkspaceID,
 				deps.ask != nil,
+				cfg.HeartbeatInterval,
 				cfg.HeartbeatActiveHours,
 				cfg.HeartbeatTimezone,
 				activity.isChatBusy(),
@@ -389,6 +391,7 @@ func buildAPIMux(
 				return heartbeatState.snapshot(
 					defaultWorkspaceID,
 					deps.ask != nil,
+					cfg.HeartbeatInterval,
 					cfg.HeartbeatActiveHours,
 					cfg.HeartbeatTimezone,
 					activity.isChatBusy(),
@@ -532,6 +535,16 @@ func buildAPIMux(
 	cronManager := newWorkspaceCronManager(cronStoreResolver, cronRunner, 30*time.Second, nowFn, logger)
 	watchdogManager := newWorkspaceWatchdogManager(watchdogRunner, defaultWatchdogInterval)
 
+	var heartbeatTickerInterval time.Duration
+	if raw := strings.TrimSpace(cfg.HeartbeatInterval); raw != "" {
+		if parsed, err := time.ParseDuration(raw); err == nil && parsed > 0 {
+			heartbeatTickerInterval = parsed
+		} else {
+			logger.Warn().Str("value", raw).Msg("invalid heartbeat_interval, heartbeat ticker disabled")
+		}
+	}
+	heartbeatTicker := newHeartbeatTickerManager(heartbeatRunner, heartbeatTickerInterval, logger)
+
 	return &serveAPIRuntime{
 		cfg:                     cfg,
 		configPath:              resolvedConfigPath,
@@ -542,6 +555,7 @@ func buildAPIMux(
 		gatewayAgentsWatch:      gatewayAgentsWatch,
 		cronManager:             cronManager,
 		watchdogManager:         watchdogManager,
+		heartbeatTicker:         heartbeatTicker,
 		telegramPoller:          telegramPoller,
 	}, nil
 }
@@ -656,6 +670,13 @@ func startBackgrounds(ctx context.Context, runtime *serveAPIRuntime, logger zero
 		go func() {
 			if err := runtime.cronManager.Start(ctx); err != nil {
 				logger.Error().Err(err).Msg("cron manager stopped with error")
+			}
+		}()
+	}
+	if runtime.heartbeatTicker != nil {
+		go func() {
+			if err := runtime.heartbeatTicker.Start(ctx); err != nil {
+				logger.Error().Err(err).Msg("heartbeat ticker stopped with error")
 			}
 		}()
 	}

--- a/internal/tarsserver/workspace_runtime_test.go
+++ b/internal/tarsserver/workspace_runtime_test.go
@@ -111,11 +111,11 @@ func TestWorkspaceHeartbeatRunner_AlwaysWritesDefaultWorkspace(t *testing.T) {
 		t.Fatalf("expected default heartbeat tick log, got %q", string(defaultLog))
 	}
 
-	defaultStatus := state.snapshot(defaultWorkspaceID, true, "", "", false)
+	defaultStatus := state.snapshot(defaultWorkspaceID, true, "", "", "", false)
 	if strings.TrimSpace(defaultStatus.LastRunAt) == "" {
 		t.Fatalf("expected default heartbeat state to record last run")
 	}
-	tenantStatus := state.snapshot("team-a", true, "", "", false)
+	tenantStatus := state.snapshot("team-a", true, "", "", "", false)
 	if strings.TrimSpace(tenantStatus.LastRunAt) != "" {
 		t.Fatalf("did not expect team-a heartbeat state, got %+v", tenantStatus)
 	}

--- a/internal/tool/automation_heartbeat.go
+++ b/internal/tool/automation_heartbeat.go
@@ -9,6 +9,7 @@ import (
 
 type HeartbeatStatus struct {
 	Configured       bool   `json:"configured"`
+	Interval         string `json:"interval,omitempty"`
 	ActiveHours      string `json:"active_hours,omitempty"`
 	Timezone         string `json:"timezone,omitempty"`
 	ChatBusy         bool   `json:"chat_busy,omitempty"`


### PR DESCRIPTION
## Summary
- `heartbeat_interval` config 필드 추가 (예: "5m", "30m")
- 설정 시 자동으로 heartbeat ticker가 주기적 실행
- 콘솔 Heartbeat 페이지에 interval 표시

## Changes
- `config/types.go` — `HeartbeatInterval` 필드 추가
- `config/config_input_fields.go` + `schema.go` — YAML/env/schema 매핑
- `helpers_heartbeat_ticker.go` — 신규 ticker manager
- `main_serve_api.go` — ticker 생성/시작 연결
- `tool/automation_heartbeat.go` — `HeartbeatStatus.Interval` 필드
- `Heartbeat.svelte` + `types.ts` — UI에 interval 표시

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/tarsserver/... ./internal/config/... ./internal/tool/...` passes
- [x] `npm run check` — 0 errors