### PR TITLE
fix: reduce notification noise + legacy project session compat

### DIFF
--- a/frontend/console/src/components/Heartbeat.svelte
+++ b/frontend/console/src/components/Heartbeat.svelte
@@ -255,7 +255,7 @@
         <button class="btn btn-ghost btn-sm" onclick={loadLog}>Refresh</button>
       </div>
       {#if dailyLog}
-        <div class="hb-log hb-md">{@html renderMarkdown(dailyLog)}</div>
+        <pre class="hb-log-pre">{dailyLog}</pre>
       {:else}
         <div class="hb-empty">No heartbeat entries for today.</div>
       {/if}
@@ -439,12 +439,18 @@
   }
   .hb-md :global(strong) { font-weight: 600; color: var(--text-primary); }
 
-  .hb-log {
+  .hb-log-pre {
     padding: var(--space-3);
-    font-size: var(--text-sm);
-    line-height: 1.6;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    line-height: 1.7;
     color: var(--text-secondary);
+    background: var(--bg-base);
+    border-radius: var(--radius-md);
     max-height: 400px;
     overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+    margin: 0;
   }
 </style>

--- a/internal/tarsserver/handler_project.go
+++ b/internal/tarsserver/handler_project.go
@@ -550,7 +550,7 @@ func newProjectAPIHandler(
 				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "get project failed"})
 				return
 			}
-			sessionID := strings.TrimSpace(item.SessionID)
+			sessionID := resolveProjectSessionID(item, sessionStore)
 			if sessionID == "" {
 				writeJSON(w, http.StatusOK, map[string]any{
 					"project_id": projectID,
@@ -591,7 +591,7 @@ func newProjectAPIHandler(
 				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "get project failed"})
 				return
 			}
-			sessionID := strings.TrimSpace(item.SessionID)
+			sessionID := resolveProjectSessionID(item, sessionStore)
 			if sessionID == "" {
 				writeJSON(w, http.StatusOK, map[string]any{"cleared": false, "reason": "no session"})
 				return
@@ -623,7 +623,7 @@ func newProjectAPIHandler(
 				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "get project failed"})
 				return
 			}
-			sessionID := strings.TrimSpace(item.SessionID)
+			sessionID := resolveProjectSessionID(item, sessionStore)
 			if sessionID == "" {
 				writeJSON(w, http.StatusOK, map[string]any{"compacted": false, "reason": "no session"})
 				return
@@ -671,7 +671,7 @@ func newProjectAPIHandler(
 				}
 				systemFiles := map[string]bool{
 					"PROJECT.md": true, "STATE.md": true, "KANBAN.md": true,
-					"ACTIVITY.jsonl": true,
+					"ACTIVITY.jsonl": true, "AUTOPILOT.json": true,
 				}
 				type fileEntry struct {
 					Name   string `json:"name"`
@@ -725,4 +725,23 @@ func newProjectAPIHandler(
 	})
 
 	return mux
+}
+
+func resolveProjectSessionID(item project.Project, sessionStore *session.Store) string {
+	if id := strings.TrimSpace(item.SessionID); id != "" {
+		return id
+	}
+	if sessionStore == nil {
+		return ""
+	}
+	allSessions, err := sessionStore.List()
+	if err != nil {
+		return ""
+	}
+	for _, s := range allSessions {
+		if strings.TrimSpace(s.ProjectID) == strings.TrimSpace(item.ID) {
+			return s.ID
+		}
+	}
+	return ""
 }

--- a/internal/tarsserver/helpers_runtime.go
+++ b/internal/tarsserver/helpers_runtime.go
@@ -250,17 +250,13 @@ func newWorkspaceHeartbeatRunnerWithNotify(
 			}
 			switch {
 			case runErr != nil:
-				evt := newNotificationEvent("heartbeat", "error", "Heartbeat failed", trimForMemory(runErr.Error(), 240))
-				emit(ctx, evt)
+				emit(ctx, newNotificationEvent("heartbeat", "error", "Heartbeat failed", trimForMemory(runErr.Error(), 240)))
 			case result.Skipped:
-				evt := newNotificationEvent("heartbeat", "info", "Heartbeat skipped", trimForMemory(result.SkipReason, 240))
-				emit(ctx, evt)
+				// skip — don't emit notification for routine skips
 			case result.Acknowledged:
-				evt := newNotificationEvent("heartbeat", "info", "Heartbeat acknowledged", "no follow-up action")
-				emit(ctx, evt)
+				// skip — don't emit notification for acknowledged heartbeats
 			default:
-				evt := newNotificationEvent("heartbeat", "info", "Heartbeat action", trimForMemory(result.Response, 280))
-				emit(ctx, evt)
+				emit(ctx, newNotificationEvent("heartbeat", "info", "Heartbeat action", trimForMemory(result.Response, 280)))
 			}
 			if after != nil {
 				_ = after(ctx)


### PR DESCRIPTION
## Summary
- 하트비트 skipped/acknowledged 알림 비발행 → 노이즈 제거
- session_id 없는 구 프로젝트에서 project_id로 기존 세션 자동 매핑
- Daily Log를 pre 포맷으로 변경 (마크다운 → raw text)
- AUTOPILOT.json을 시스템 파일로 재등록 (사용자 아티팩트에서 숨김)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/tarsserver/...` passes  
- [x] `npm run check` — 0 errors