### PR TITLE
fix: auto-refresh project page after chat + filter heartbeat messages

### DIFF
--- a/frontend/console/src/components/ChatPanel.svelte
+++ b/frontend/console/src/components/ChatPanel.svelte
@@ -43,6 +43,9 @@
         chatMessages = [{ id: 'system-init', role: 'system', text: `Session: ${projectSession.id.slice(0, 8)}...` }]
         const history = await getSessionHistory(projectSession.id)
         for (const msg of history) {
+          if (msg.role === 'system' && (msg.content.startsWith('[HEARTBEAT]') || msg.content.startsWith('[COMPACTION SUMMARY]') || msg.content.startsWith('[CRON]'))) {
+            continue
+          }
           if (msg.role === 'tool') {
             chatMessages.push({
               id: `tool-${msg.tool_call_id || Date.now()}`,
@@ -275,6 +278,9 @@
       try {
         const history = await getSessionHistory(sessionId)
         for (const msg of history) {
+          if (msg.role === 'system' && (msg.content.startsWith('[HEARTBEAT]') || msg.content.startsWith('[COMPACTION SUMMARY]') || msg.content.startsWith('[CRON]'))) {
+            continue
+          }
           if (msg.role === 'tool') {
             chatMessages.push({
               id: `tool-${msg.tool_call_id || Date.now()}`,

--- a/frontend/console/src/components/ProjectView.svelte
+++ b/frontend/console/src/components/ProjectView.svelte
@@ -199,14 +199,16 @@
     }
   }
 
-  onMount(() => {
+  function refreshAll() {
     void loadDetail()
     void loadBoard()
     void loadState()
     void loadActivity()
     void loadFiles()
     void loadSessionInfo()
-  })
+  }
+
+  onMount(refreshAll)
 </script>
 
 <div class="pv">
@@ -365,7 +367,7 @@
       <!-- Chat -->
       <section class="card pv-wide">
         <span class="card-title">Chat</span>
-        <ChatPanel {projectId} />
+        <ChatPanel {projectId} onSessionChange={refreshAll} />
       </section>
 
       <!-- Activity -->


### PR DESCRIPTION
## Summary
- 채팅 완료 시 프로젝트 페이지 전체 자동 새로고침 (상태/보드/Activity/파일/세션)
- 채팅 히스토리에서 [HEARTBEAT], [COMPACTION SUMMARY], [CRON] 시스템 메시지 필터링

## Test plan
- [x] `go build` / `npm run check` passes
- [ ] Manual: 채팅에서 프로젝트 비활성화 → 헤더 뱃지 즉시 갱신 확인
- [ ] Manual: 하트비트 턴이 채팅에 안 보이는지 확인