### PR TITLE
fix: sync STATE.md when project is activated/deactivated

### DIFF
--- a/internal/tarsserver/handler_project.go
+++ b/internal/tarsserver/handler_project.go
@@ -514,6 +514,13 @@ func newProjectAPIHandler(
 				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "activate project failed"})
 				return
 			}
+			// Sync STATE.md back to active
+			planningPhase := "planning"
+			activeState := "active"
+			_, _ = store.UpdateState(projectID, project.ProjectStateUpdateInput{
+				Phase:  &planningPhase,
+				Status: &activeState,
+			})
 			writeJSON(w, http.StatusOK, map[string]any{
 				"activated":  true,
 				"project_id": projectID,
@@ -537,6 +544,15 @@ func newProjectAPIHandler(
 				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "deactivate project failed"})
 				return
 			}
+			// Sync STATE.md to done/archived
+			donePhase := "done"
+			doneStatus := "done"
+			stopReason := "Project archived"
+			_, _ = store.UpdateState(projectID, project.ProjectStateUpdateInput{
+				Phase:      &donePhase,
+				Status:     &doneStatus,
+				StopReason: &stopReason,
+			})
 			writeJSON(w, http.StatusOK, map[string]any{
 				"deactivated": true,
 				"project_id":  updated.ID,


### PR DESCRIPTION
## Summary
- 프로젝트 비활성화(archive) 시 STATE.md를 phase=done, status=done으로 동기화
- 프로젝트 활성화(activate) 시 STATE.md를 phase=planning, status=active로 복원

## Test plan
- [x] `go build` / `go test` passes