### PR TITLE
fix: sync STATE.md on any project status change

### DIFF
--- a/internal/tarsserver/handler_project.go
+++ b/internal/tarsserver/handler_project.go
@@ -264,6 +264,8 @@ func newProjectAPIHandler(
 					return
 				}
 
+				// Sync STATE.md when project status changes
+				syncProjectStateOnStatusChange(store, projectID, updated.Status)
 				writeJSON(w, http.StatusOK, updated)
 			case http.MethodDelete:
 				if err := store.Delete(projectID); err != nil {
@@ -514,13 +516,7 @@ func newProjectAPIHandler(
 				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "activate project failed"})
 				return
 			}
-			// Sync STATE.md back to active
-			planningPhase := "planning"
-			activeState := "active"
-			_, _ = store.UpdateState(projectID, project.ProjectStateUpdateInput{
-				Phase:  &planningPhase,
-				Status: &activeState,
-			})
+			syncProjectStateOnStatusChange(store, projectID, "active")
 			writeJSON(w, http.StatusOK, map[string]any{
 				"activated":  true,
 				"project_id": projectID,
@@ -544,15 +540,7 @@ func newProjectAPIHandler(
 				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "deactivate project failed"})
 				return
 			}
-			// Sync STATE.md to done/archived
-			donePhase := "done"
-			doneStatus := "done"
-			stopReason := "Project archived"
-			_, _ = store.UpdateState(projectID, project.ProjectStateUpdateInput{
-				Phase:      &donePhase,
-				Status:     &doneStatus,
-				StopReason: &stopReason,
-			})
+			syncProjectStateOnStatusChange(store, projectID, "archived")
 			writeJSON(w, http.StatusOK, map[string]any{
 				"deactivated": true,
 				"project_id":  updated.ID,
@@ -749,6 +737,27 @@ func newProjectAPIHandler(
 	})
 
 	return mux
+}
+
+func syncProjectStateOnStatusChange(store *project.Store, projectID, status string) {
+	if store == nil {
+		return
+	}
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "archived":
+		donePhase := "done"
+		doneStatus := "done"
+		stopReason := "Project archived"
+		_, _ = store.UpdateState(projectID, project.ProjectStateUpdateInput{
+			Phase: &donePhase, Status: &doneStatus, StopReason: &stopReason,
+		})
+	case "active":
+		planningPhase := "planning"
+		activeStatus := "active"
+		_, _ = store.UpdateState(projectID, project.ProjectStateUpdateInput{
+			Phase: &planningPhase, Status: &activeStatus,
+		})
+	}
 }
 
 func resolveProjectSessionID(item project.Project, sessionStore *session.Store) string {


### PR DESCRIPTION
## Summary
- `PATCH /v1/projects/{id}`로 status 변경 시에도 STATE.md 동기화
- 채팅에서 `project_update`로 archived 설정해도 State가 done으로 반영됨
- activate/deactivate 핸들러의 중복 코드를 `syncProjectStateOnStatusChange()`로 통합

## Test plan
- [x] `go build` / `go test` passes