### PR TITLE
fix: auto-correct invalid active_hours clock values

### DIFF
--- a/internal/heartbeat/heartbeat.go
+++ b/internal/heartbeat/heartbeat.go
@@ -317,8 +317,31 @@ func parseActiveHourRange(raw string) (int, int, error) {
 
 func parseClockMinutes(raw string) (int, error) {
 	value := strings.TrimSpace(raw)
+	// Auto-correct common invalid values
+	switch value {
+	case "24:00":
+		return 23*60 + 59, nil
+	case "0:00":
+		return 0, nil
+	}
 	t, err := time.Parse("15:04", value)
 	if err != nil {
+		// Try to salvage: parse as H:MM or HH:M
+		parts := strings.SplitN(value, ":", 2)
+		if len(parts) == 2 {
+			h, m := 0, 0
+			if _, e := fmt.Sscanf(parts[0], "%d", &h); e == nil {
+				if _, e := fmt.Sscanf(parts[1], "%d", &m); e == nil {
+					if h > 23 {
+						h = 23
+					}
+					if m > 59 {
+						m = 59
+					}
+					return h*60 + m, nil
+				}
+			}
+		}
 		return 0, fmt.Errorf("invalid active_hours clock %q (expected HH:MM)", value)
 	}
 	return t.Hour()*60 + t.Minute(), nil

--- a/internal/heartbeat/heartbeat_test.go
+++ b/internal/heartbeat/heartbeat_test.go
@@ -267,3 +267,36 @@ func TestRunOnceWithLLMResultWithPolicy_IncludesSessionContextAndAppendsTurn(t *
 		t.Fatalf("expected session turn append with response, got %+v", appended)
 	}
 }
+
+func TestParseClockMinutes_AutoCorrects(t *testing.T) {
+	cases := []struct {
+		input   string
+		want    int
+		wantErr bool
+	}{
+		{"09:00", 9 * 60, false},
+		{"23:59", 23*60 + 59, false},
+		{"00:00", 0, false},
+		{"24:00", 23*60 + 59, false},  // auto-correct
+		{"0:00", 0, false},            // auto-correct
+		{"25:30", 23*60 + 30, false},  // clamp hour
+		{"12:99", 12*60 + 59, false},  // clamp minute
+		{"abc", 0, true},
+	}
+	for _, tc := range cases {
+		got, err := parseClockMinutes(tc.input)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("parseClockMinutes(%q) expected error", tc.input)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseClockMinutes(%q) unexpected error: %v", tc.input, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("parseClockMinutes(%q) = %d, want %d", tc.input, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `24:00` → `23:59` 자동 보정
- 시간 > 23 → 23으로 클램프, 분 > 59 → 59로 클램프
- `0:00` 같은 느슨한 포맷 지원
- 테스트 추가

## Test plan
- [x] `go test ./internal/heartbeat/...` — TestParseClockMinutes_AutoCorrects passes