### PR TITLE
feat: autonomous project execution via heartbeat

### DIFF
--- a/frontend/console/src/components/ProjectView.svelte
+++ b/frontend/console/src/components/ProjectView.svelte
@@ -343,7 +343,12 @@
           <div class="card pv-state-card">
             <span class="card-title">State</span>
             <dl class="pv-facts">
-              <div><dt>Phase</dt><dd><span class="badge {statusBadgeClass(projectState.phase || '')}">{projectState.phase || '\u2014'}</span></dd></div>
+              <div><dt>Phase</dt><dd>
+                <span class="badge {statusBadgeClass(projectState.phase || '')}">{projectState.phase || '\u2014'}</span>
+                {#if projectState.phase_number}
+                  <span style="margin-left:var(--space-1);font-size:var(--text-xs);color:var(--text-ghost)">#{projectState.phase_number}{#if project?.max_phases}/{project.max_phases}{/if}</span>
+                {/if}
+              </dd></div>
               <div><dt>Status</dt><dd><span class="badge {statusBadgeClass(projectState.status || '')}">{projectState.status || '\u2014'}</span></dd></div>
               {#if projectState.next_action}
                 <div><dt>Next</dt><dd>{projectState.next_action}</dd></div>

--- a/frontend/console/src/lib/types.ts
+++ b/frontend/console/src/lib/types.ts
@@ -222,6 +222,7 @@ export type ProjectState = {
   project_id: string
   phase?: string
   status?: string
+  phase_number?: number
   next_action?: string
   goal?: string
   last_run_summary?: string

--- a/internal/project/brief_state.go
+++ b/internal/project/brief_state.go
@@ -67,6 +67,7 @@ type ProjectState struct {
 	Goal              string   `json:"goal,omitempty"`
 	Phase             string   `json:"phase,omitempty"`
 	Status            string   `json:"status,omitempty"`
+	PhaseNumber       int      `json:"phase_number,omitempty"`
 	NextAction        string   `json:"next_action,omitempty"`
 	RemainingTasks    []string `json:"remaining_tasks,omitempty"`
 	CompletionSummary string   `json:"completion_summary,omitempty"`
@@ -81,6 +82,7 @@ type ProjectStateUpdateInput struct {
 	Goal              *string
 	Phase             *string
 	Status            *string
+	PhaseNumber       *int
 	NextAction        *string
 	RemainingTasks    []string
 	CompletionSummary *string
@@ -515,6 +517,9 @@ func applyProjectStateUpdateInput(item *ProjectState, input ProjectStateUpdateIn
 	}
 	if input.Status != nil {
 		item.Status = normalizeProjectStateStatus(*input.Status)
+	}
+	if input.PhaseNumber != nil {
+		item.PhaseNumber = *input.PhaseNumber
 	}
 	assignStringPtr(&item.NextAction, input.NextAction)
 	if len(input.RemainingTasks) > 0 {

--- a/internal/tarsserver/helpers_project_progress.go
+++ b/internal/tarsserver/helpers_project_progress.go
@@ -2,17 +2,22 @@ package tarsserver
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"strings"
 
+	"github.com/devlikebear/tars/internal/heartbeat"
 	"github.com/devlikebear/tars/internal/project"
 	"github.com/rs/zerolog"
 )
 
 // newProjectProgressAfterHeartbeat returns a callback that advances active
-// projects by one dispatch iteration after each heartbeat tick.
+// projects after each heartbeat tick. Autonomous projects get full
+// plan→execute→review cycle; manual projects only dispatch existing todos.
 func newProjectProgressAfterHeartbeat(
 	store *project.Store,
 	runner project.TaskRunner,
+	ask heartbeat.AskFunc,
 	logger zerolog.Logger,
 ) func(ctx context.Context) error {
 	if store == nil || runner == nil {
@@ -27,46 +32,222 @@ func newProjectProgressAfterHeartbeat(
 			if strings.TrimSpace(p.Status) == "archived" {
 				continue
 			}
-			board, err := store.GetBoard(p.ID)
-			if err != nil {
-				logger.Debug().Err(err).Str("project_id", p.ID).Msg("skip project progress: board read failed")
-				continue
-			}
-			if len(board.Tasks) == 0 {
-				continue
-			}
-			// Dispatch todo tasks if any
-			hasTodo := false
-			hasReview := false
-			for _, task := range board.Tasks {
-				switch strings.TrimSpace(task.Status) {
-				case "todo":
-					hasTodo = true
-				case "review":
-					hasReview = true
-				}
-			}
-			if !hasTodo && !hasReview {
-				continue
-			}
-			orch := project.NewOrchestrator(store, runner)
-			if hasTodo {
-				report, err := orch.DispatchTodo(ctx, p.ID)
-				if err != nil {
-					logger.Debug().Err(err).Str("project_id", p.ID).Msg("project progress: dispatch todo failed")
-				} else if len(report.Runs) > 0 {
-					logger.Info().Str("project_id", p.ID).Int("dispatched", len(report.Runs)).Msg("project progress: dispatched todo tasks")
-				}
-			}
-			if hasReview {
-				report, err := orch.DispatchReview(ctx, p.ID)
-				if err != nil {
-					logger.Debug().Err(err).Str("project_id", p.ID).Msg("project progress: dispatch review failed")
-				} else if len(report.Runs) > 0 {
-					logger.Info().Str("project_id", p.ID).Int("dispatched", len(report.Runs)).Msg("project progress: dispatched review tasks")
-				}
+			if strings.TrimSpace(p.ExecutionMode) == "autonomous" {
+				advanceAutonomousProject(ctx, store, runner, ask, p, logger)
+			} else {
+				advanceManualProject(ctx, store, runner, p, logger)
 			}
 		}
 		return nil
 	}
 }
+
+// advanceManualProject dispatches existing todo/review tasks only.
+func advanceManualProject(ctx context.Context, store *project.Store, runner project.TaskRunner, p project.Project, logger zerolog.Logger) {
+	board, err := store.GetBoard(p.ID)
+	if err != nil {
+		return
+	}
+	dispatchBoardTasks(ctx, store, runner, p.ID, board, logger)
+}
+
+// advanceAutonomousProject runs the full autonomous cycle:
+// 1. Check phase limit
+// 2. If board empty → LLM generates tasks (planning)
+// 3. If has todo/review → dispatch
+// 4. If all done → advance phase or complete project
+func advanceAutonomousProject(ctx context.Context, store *project.Store, runner project.TaskRunner, ask heartbeat.AskFunc, p project.Project, logger zerolog.Logger) {
+	state, err := store.GetState(p.ID)
+	if err != nil {
+		state = project.ProjectState{ProjectID: p.ID}
+	}
+
+	// Check phase limit
+	maxPhases := p.MaxPhases
+	if maxPhases <= 0 {
+		maxPhases = 3
+	}
+	if state.PhaseNumber >= maxPhases {
+		if state.Status != "done" {
+			completeProject(store, p.ID, "Maximum phases reached", logger)
+		}
+		return
+	}
+
+	board, err := store.GetBoard(p.ID)
+	if err != nil {
+		return
+	}
+
+	// Count task statuses
+	counts := countTaskStatuses(board)
+
+	// Case 1: Board empty or all done → plan next phase
+	if len(board.Tasks) == 0 || (counts["done"] == len(board.Tasks) && len(board.Tasks) > 0) {
+		if ask == nil {
+			logger.Debug().Str("project_id", p.ID).Msg("autonomous: skip planning (no LLM)")
+			return
+		}
+		nextPhase := state.PhaseNumber + 1
+		planAutonomousTasks(ctx, store, ask, p, nextPhase, logger)
+		return
+	}
+
+	// Case 2: Has in_progress tasks → skip (running)
+	if counts["in_progress"] > 0 {
+		return
+	}
+
+	// Case 3: Has todo/review → dispatch
+	if counts["todo"] > 0 || counts["review"] > 0 {
+		dispatchBoardTasks(ctx, store, runner, p.ID, board, logger)
+		return
+	}
+}
+
+// planAutonomousTasks uses LLM to generate tasks for the next phase.
+func planAutonomousTasks(ctx context.Context, store *project.Store, ask heartbeat.AskFunc, p project.Project, phaseNumber int, logger zerolog.Logger) {
+	prompt := fmt.Sprintf(
+		`You are a project planner. Generate a concise task list for phase %d of this project.
+
+Project: %s
+Objective: %s
+Instructions: %s
+
+Return a JSON array of task objects. Each task has "id" (string), "title" (string).
+Generate 1-5 concrete, actionable tasks. Only return the JSON array, nothing else.
+Example: [{"id":"task-1","title":"Write introduction section"}]`,
+		phaseNumber,
+		strings.TrimSpace(p.Name),
+		strings.TrimSpace(p.Objective),
+		strings.TrimSpace(p.Body),
+	)
+
+	response, err := ask(ctx, prompt)
+	if err != nil {
+		logger.Debug().Err(err).Str("project_id", p.ID).Msg("autonomous: planning LLM call failed")
+		return
+	}
+
+	// Parse tasks from LLM response
+	tasks := parseTasksFromLLM(response)
+	if len(tasks) == 0 {
+		logger.Debug().Str("project_id", p.ID).Str("response", response).Msg("autonomous: no tasks parsed from LLM")
+		return
+	}
+
+	// Update board with new tasks
+	boardTasks := make([]project.BoardTask, len(tasks))
+	for i, t := range tasks {
+		boardTasks[i] = project.BoardTask{
+			ID:     fmt.Sprintf("phase%d-task-%d", phaseNumber, i+1),
+			Title:  t.Title,
+			Status: "todo",
+		}
+	}
+	if _, err := store.UpdateBoard(p.ID, project.BoardUpdateInput{Tasks: boardTasks}); err != nil {
+		logger.Debug().Err(err).Str("project_id", p.ID).Msg("autonomous: update board failed")
+		return
+	}
+
+	// Update state
+	phaseName := "executing"
+	statusName := "active"
+	nextAction := fmt.Sprintf("Phase %d: execute %d tasks", phaseNumber, len(tasks))
+	_, _ = store.UpdateState(p.ID, project.ProjectStateUpdateInput{
+		Phase:       &phaseName,
+		Status:      &statusName,
+		PhaseNumber: &phaseNumber,
+		NextAction:  &nextAction,
+	})
+
+	logger.Info().
+		Str("project_id", p.ID).
+		Int("phase", phaseNumber).
+		Int("tasks", len(tasks)).
+		Msg("autonomous: planned new phase")
+}
+
+// completeProject marks a project as done.
+func completeProject(store *project.Store, projectID string, reason string, logger zerolog.Logger) {
+	donePhase := "done"
+	doneStatus := "done"
+	_, _ = store.UpdateState(projectID, project.ProjectStateUpdateInput{
+		Phase:             &donePhase,
+		Status:            &doneStatus,
+		CompletionSummary: &reason,
+	})
+	archivedStatus := "archived"
+	_, _ = store.Update(projectID, project.UpdateInput{Status: &archivedStatus})
+	logger.Info().Str("project_id", projectID).Str("reason", reason).Msg("autonomous: project completed")
+}
+
+// dispatchBoardTasks dispatches todo and review tasks via orchestrator.
+func dispatchBoardTasks(ctx context.Context, store *project.Store, runner project.TaskRunner, projectID string, board project.Board, logger zerolog.Logger) {
+	hasTodo := false
+	hasReview := false
+	for _, task := range board.Tasks {
+		switch strings.TrimSpace(task.Status) {
+		case "todo":
+			hasTodo = true
+		case "review":
+			hasReview = true
+		}
+	}
+	if !hasTodo && !hasReview {
+		return
+	}
+	orch := project.NewOrchestrator(store, runner)
+	if hasTodo {
+		report, err := orch.DispatchTodo(ctx, projectID)
+		if err != nil {
+			logger.Debug().Err(err).Str("project_id", projectID).Msg("project progress: dispatch todo failed")
+		} else if len(report.Runs) > 0 {
+			logger.Info().Str("project_id", projectID).Int("dispatched", len(report.Runs)).Msg("project progress: dispatched todo tasks")
+		}
+	}
+	if hasReview {
+		report, err := orch.DispatchReview(ctx, projectID)
+		if err != nil {
+			logger.Debug().Err(err).Str("project_id", projectID).Msg("project progress: dispatch review failed")
+		} else if len(report.Runs) > 0 {
+			logger.Info().Str("project_id", projectID).Int("dispatched", len(report.Runs)).Msg("project progress: dispatched review tasks")
+		}
+	}
+}
+
+func countTaskStatuses(board project.Board) map[string]int {
+	counts := map[string]int{}
+	for _, t := range board.Tasks {
+		counts[strings.TrimSpace(t.Status)]++
+	}
+	return counts
+}
+
+type llmTask struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+}
+
+func parseTasksFromLLM(response string) []llmTask {
+	response = strings.TrimSpace(response)
+	// Try to extract JSON array from response
+	start := strings.Index(response, "[")
+	end := strings.LastIndex(response, "]")
+	if start >= 0 && end > start {
+		response = response[start : end+1]
+	}
+	var tasks []llmTask
+	if err := json.Unmarshal([]byte(response), &tasks); err != nil {
+		return nil
+	}
+	// Filter out empty titles
+	var result []llmTask
+	for _, t := range tasks {
+		if strings.TrimSpace(t.Title) != "" {
+			result = append(result, t)
+		}
+	}
+	return result
+}
+

--- a/internal/tarsserver/main_serve_api.go
+++ b/internal/tarsserver/main_serve_api.go
@@ -406,7 +406,7 @@ func buildAPIMux(
 	}
 	projectStore := project.NewStore(cfg.WorkspaceDir, nil)
 	projectTaskRunner := gateway.NewProjectTaskRunner(gatewayRuntime, "")
-	projectProgressAfterHeartbeat = newProjectProgressAfterHeartbeat(projectStore, projectTaskRunner, logger)
+	projectProgressAfterHeartbeat = newProjectProgressAfterHeartbeat(projectStore, projectTaskRunner, deps.ask, logger)
 	chatHandler := newChatAPIHandlerWithRuntimeConfig(
 		cfg.WorkspaceDir,
 		sessionStore,


### PR DESCRIPTION
## Summary
Phase 2 — 자율실행 하트비트 로직 구현

## Autonomous mode cycle
```
하트비트 tick → 활성 프로젝트 확인
  → 보드 비어있으면 → LLM으로 태스크 자동 생성 (phase N)
  → todo/review 있으면 → worker에 디스패치
  → 전부 done → 다음 phase로 진행 or max_phases 도달 시 완료
```

## Changes
- `helpers_project_progress.go`: 모드별 분기 (autonomous / manual)
- `ProjectState.PhaseNumber`: 페이즈 카운터 추가
- LLM ask 함수를 progress 콜백에 전달
- 프론트엔드: State 카드에 phase #N/max 표시

## Test plan
- [x] `go build` / `go test` passes
- [x] `npm run check` — 0 errors