### PR TITLE
feat: project creation UI with execution mode + critic review loop

### DIFF
--- a/frontend/console/src/components/Projects.svelte
+++ b/frontend/console/src/components/Projects.svelte
@@ -46,6 +46,9 @@
   let newProjectObjective = $state('')
   let newProjectGitRepo = $state('')
   let newProjectType = $state('')
+  let newProjectMode: 'manual' | 'autonomous' = $state('manual')
+  let newProjectMaxPhases = $state(3)
+  let newProjectSubAgents = $state('')
   let newProjectSaving = $state(false)
   let newProjectError = $state('')
 
@@ -82,11 +85,17 @@
     newProjectSaving = true
     newProjectError = ''
     try {
+      const subAgents = newProjectSubAgents.trim()
+        ? newProjectSubAgents.split(',').map((s) => s.trim()).filter(Boolean)
+        : undefined
       const p = await createProject({
         name: newProjectName.trim(),
         type: newProjectType.trim() || undefined,
         objective: newProjectObjective.trim() || undefined,
         git_repo: newProjectGitRepo.trim() || undefined,
+        execution_mode: newProjectMode,
+        max_phases: newProjectMode === 'autonomous' ? newProjectMaxPhases : undefined,
+        sub_agents: subAgents,
       })
       projects = [p, ...projects]
       showNewProject = false
@@ -94,6 +103,9 @@
       newProjectObjective = ''
       newProjectGitRepo = ''
       newProjectType = ''
+      newProjectMode = 'manual'
+      newProjectMaxPhases = 3
+      newProjectSubAgents = ''
       goToProject(p.id)
     } catch (e) {
       newProjectError = e instanceof Error ? e.message : 'Failed to create project'
@@ -169,6 +181,25 @@
         <input type="text" placeholder="Type (optional)" bind:value={newProjectType} class="form-input" />
         <input type="text" placeholder="Objective (optional)" bind:value={newProjectObjective} class="form-input form-span-2" />
         <input type="text" placeholder="Git repo URL (optional)" bind:value={newProjectGitRepo} class="form-input form-span-2" />
+        <div class="form-span-2 form-row">
+          <label class="form-label">
+            Execution mode
+            <select bind:value={newProjectMode} class="form-select">
+              <option value="manual">Manual</option>
+              <option value="autonomous">Autonomous</option>
+            </select>
+          </label>
+          {#if newProjectMode === 'autonomous'}
+            <label class="form-label">
+              Max phases
+              <input type="number" min="1" max="20" bind:value={newProjectMaxPhases} class="form-input form-input-sm" />
+            </label>
+            <label class="form-label">
+              Sub-agents
+              <input type="text" placeholder="critic, reviewer (comma-separated)" bind:value={newProjectSubAgents} class="form-input" />
+            </label>
+          {/if}
+        </div>
       </div>
       <button
         class="btn btn-primary btn-sm"
@@ -287,6 +318,28 @@
     font-size: var(--text-sm);
   }
   .form-input:focus { outline: none; border-color: var(--accent); }
+  .form-input-sm { max-width: 80px; }
+  .form-select {
+    padding: var(--space-2) var(--space-3);
+    background: var(--bg-base);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    color: var(--text-primary);
+    font-size: var(--text-sm);
+  }
+  .form-row {
+    display: flex;
+    gap: var(--space-3);
+    align-items: flex-end;
+    flex-wrap: wrap;
+  }
+  .form-label {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    font-size: var(--text-xs);
+    color: var(--text-tertiary);
+  }
   .form-error { font-size: var(--text-xs); color: var(--error); }
 
   /* ── Filter bar ──────────────────────────── */

--- a/frontend/console/src/lib/types.ts
+++ b/frontend/console/src/lib/types.ts
@@ -236,6 +236,9 @@ export type CreateProjectRequest = {
   git_repo?: string
   objective?: string
   instructions?: string
+  execution_mode?: string
+  max_phases?: number
+  sub_agents?: string[]
 }
 
 export type UpdateProjectRequest = {

--- a/internal/tarsserver/helpers_project_progress.go
+++ b/internal/tarsserver/helpers_project_progress.go
@@ -82,11 +82,25 @@ func advanceAutonomousProject(ctx context.Context, store *project.Store, runner 
 	// Count task statuses
 	counts := countTaskStatuses(board)
 
-	// Case 1: Board empty or all done → plan next phase
-	if len(board.Tasks) == 0 || (counts["done"] == len(board.Tasks) && len(board.Tasks) > 0) {
+	// Case 1: Board empty → plan first phase
+	if len(board.Tasks) == 0 {
 		if ask == nil {
 			logger.Debug().Str("project_id", p.ID).Msg("autonomous: skip planning (no LLM)")
 			return
+		}
+		nextPhase := state.PhaseNumber + 1
+		planAutonomousTasks(ctx, store, ask, p, nextPhase, logger)
+		return
+	}
+
+	// Case 2: All tasks done → critic review (if configured), then next phase
+	if counts["done"] == len(board.Tasks) {
+		if ask == nil {
+			return
+		}
+		// Run critic review if sub_agents includes "critic"
+		if hasCritic(p.SubAgents) {
+			runCriticReview(ctx, store, ask, p, board, state.PhaseNumber, logger)
 		}
 		nextPhase := state.PhaseNumber + 1
 		planAutonomousTasks(ctx, store, ask, p, nextPhase, logger)
@@ -251,3 +265,52 @@ func parseTasksFromLLM(response string) []llmTask {
 	return result
 }
 
+func hasCritic(subAgents []string) bool {
+	for _, a := range subAgents {
+		if strings.EqualFold(strings.TrimSpace(a), "critic") {
+			return true
+		}
+	}
+	return false
+}
+
+// runCriticReview asks the LLM to critically review the completed tasks
+// and logs the feedback to project activity.
+func runCriticReview(ctx context.Context, store *project.Store, ask heartbeat.AskFunc, p project.Project, board project.Board, phaseNumber int, logger zerolog.Logger) {
+	taskSummary := ""
+	for _, t := range board.Tasks {
+		taskSummary += fmt.Sprintf("- [%s] %s\n", t.Status, t.Title)
+	}
+
+	prompt := fmt.Sprintf(
+		`You are a critical reviewer. Review the following completed work for project "%s".
+
+Objective: %s
+
+Completed tasks (phase %d):
+%s
+
+Provide a brief critical review (3-5 sentences):
+1. What was done well?
+2. What is missing or could be improved?
+3. Should the next phase address any gaps?
+
+Be constructive but honest. Reply in plain text only.`,
+		p.Name, p.Objective, phaseNumber, taskSummary,
+	)
+
+	response, err := ask(ctx, prompt)
+	if err != nil {
+		logger.Debug().Err(err).Str("project_id", p.ID).Msg("autonomous: critic review failed")
+		return
+	}
+
+	// Record review as activity
+	_, _ = store.AppendActivity(p.ID, project.ActivityAppendInput{
+		Source:  "critic",
+		Kind:    "review",
+		Status:  "completed",
+		Message: strings.TrimSpace(response),
+	})
+	logger.Info().Str("project_id", p.ID).Int("phase", phaseNumber).Msg("autonomous: critic review completed")
+}


### PR DESCRIPTION
## Summary
Phase 3 — 프로젝트 생성 UI + 서브에이전트 비평 루프

## Changes
1. **프로젝트 생성 폼**: Manual/Autonomous 모드 선택, max_phases, sub_agents 설정
2. **비평 루프**: autonomous 프로젝트에서 phase 완료 시 critic 서브에이전트가 비판적 리뷰 수행 → Activity에 기록 → 다음 phase 계획에 반영

## Autonomous cycle
```
plan → dispatch → execute → [critic review] → plan next phase → ... → max_phases → complete
```

## Test plan
- [x] `go build` / `go test` passes
- [x] `npm run check` — 0 errors