### PR TITLE
fix: gracefully handle deleted project in chat session

### DIFF
--- a/internal/tarsserver/handler_chat_context.go
+++ b/internal/tarsserver/handler_chat_context.go
@@ -1,7 +1,6 @@
 package tarsserver
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -176,7 +175,8 @@ func resolveChatProjectContext(
 	projectStore := project.NewStore(workspaceDir, nil)
 	item, err := projectStore.Get(resolvedID)
 	if err != nil {
-		return "", nil, "", fmt.Errorf("project not found: %s", resolvedID)
+		// Project deleted or not found — continue chat without project context
+		return "", nil, "", nil
 	}
 	if store != nil && strings.TrimSpace(sessionID) != "" && strings.TrimSpace(requestProjectID) != "" {
 		_ = store.SetProjectID(strings.TrimSpace(sessionID), item.ID)


### PR DESCRIPTION
삭제된 프로젝트를 참조하는 세션에서 채팅 시 에러 대신 프로젝트 컨텍스트 없이 진행