### PR TITLE
fix: prevent IME composing residue on Enter in chat

### DIFF
--- a/frontend/console/src/components/ChatPanel.svelte
+++ b/frontend/console/src/components/ChatPanel.svelte
@@ -247,7 +247,7 @@
   }
 
   function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
       e.preventDefault()
       void submitChat()
     }


### PR DESCRIPTION
한글 IME 조합 중 Enter 시 마지막 글자가 남는 문제. e.isComposing 체크 추가.