### PR TITLE
feat: dynamic multi-agent support for autonomous projects

### DIFF
--- a/frontend/console/src/components/ProjectView.svelte
+++ b/frontend/console/src/components/ProjectView.svelte
@@ -485,12 +485,19 @@
           </div>
           <div class="pv-agents-list">
             {#each project.sub_agents as agent}
-              {@const agentActivity = activity.filter((a) => a.source === agent)}
+              {@const role = typeof agent === 'string' ? agent : agent.role}
+              {@const desc = typeof agent === 'string' ? '' : (agent.description || '')}
+              {@const trigger = typeof agent === 'string' ? 'phase_done' : (agent.run_after || 'phase_done')}
+              {@const agentActivity = activity.filter((a) => a.source === role)}
               <div class="pv-agent-item">
                 <div class="pv-agent-top">
-                  <span class="badge badge-info">{agent}</span>
+                  <span class="badge badge-info">{role}</span>
+                  <span class="badge badge-default">{trigger}</span>
                   <span class="pv-agent-count">{agentActivity.length} activities</span>
                 </div>
+                {#if desc}
+                  <div class="pv-agent-desc">{desc}</div>
+                {/if}
                 {#if agentActivity.length > 0}
                   <div class="pv-agent-last">
                     <span class="pv-agent-last-label">Last:</span>
@@ -803,6 +810,14 @@
   .pv-agent-count {
     font-size: var(--text-xs);
     color: var(--text-ghost);
+    margin-left: auto;
+  }
+
+  .pv-agent-desc {
+    font-size: var(--text-xs);
+    color: var(--text-secondary);
+    margin-top: 2px;
+    line-height: 1.4;
   }
 
   .pv-agent-last {

--- a/frontend/console/src/components/Projects.svelte
+++ b/frontend/console/src/components/Projects.svelte
@@ -86,7 +86,7 @@
     newProjectError = ''
     try {
       const subAgents = newProjectSubAgents.trim()
-        ? newProjectSubAgents.split(',').map((s) => s.trim()).filter(Boolean)
+        ? newProjectSubAgents.split(',').map((s) => s.trim()).filter(Boolean).map((role) => ({ role, run_after: 'phase_done' as const }))
         : undefined
       const p = await createProject({
         name: newProjectName.trim(),

--- a/frontend/console/src/lib/types.ts
+++ b/frontend/console/src/lib/types.ts
@@ -21,6 +21,12 @@ export type HeartbeatRunResult = {
   logged?: boolean
 }
 
+export type SubAgentConfig = {
+  role: string
+  description?: string
+  run_after?: string
+}
+
 export type Project = {
   id: string
   name: string
@@ -34,7 +40,7 @@ export type Project = {
   body?: string
   execution_mode?: string
   max_phases?: number
-  sub_agents?: string[]
+  sub_agents?: SubAgentConfig[]
   session_id?: string
 }
 
@@ -238,7 +244,7 @@ export type CreateProjectRequest = {
   instructions?: string
   execution_mode?: string
   max_phases?: number
-  sub_agents?: string[]
+  sub_agents?: SubAgentConfig[]
 }
 
 export type UpdateProjectRequest = {

--- a/internal/project/document_codec.go
+++ b/internal/project/document_codec.go
@@ -43,7 +43,7 @@ func parseDocument(raw string) (Project, error) {
 		SecretsRefs:        mapStringList(parsed, "secrets_refs", "secrets-refs"),
 		ExecutionMode:      mapString(parsed, "execution_mode"),
 		MaxPhases:          mapInt(parsed, "max_phases"),
-		SubAgents:          mapStringList(parsed, "sub_agents"),
+		SubAgents:          mapSubAgentConfigList(parsed, "sub_agents"),
 		SessionID:          mapString(parsed, "session_id"),
 		Body:               strings.TrimSpace(body),
 	}
@@ -98,7 +98,7 @@ func buildDocument(project Project) string {
 	if project.MaxPhases > 0 {
 		_, _ = fmt.Fprintf(&b, "max_phases: %d\n", project.MaxPhases)
 	}
-	writeDocumentList(&b, "sub_agents", project.SubAgents)
+	writeSubAgentConfigList(&b, "sub_agents", project.SubAgents)
 	if v := strings.TrimSpace(project.SessionID); v != "" {
 		_, _ = fmt.Fprintf(&b, "session_id: %s\n", v)
 	}
@@ -211,6 +211,61 @@ func mapStringList(values map[string]any, keys ...string) []string {
 		}
 	}
 	return nil
+}
+
+func mapSubAgentConfigList(values map[string]any, keys ...string) []SubAgentConfig {
+	for _, key := range keys {
+		raw, ok := values[key]
+		if !ok {
+			continue
+		}
+		switch v := raw.(type) {
+		case []any:
+			var configs []SubAgentConfig
+			for _, entry := range v {
+				switch e := entry.(type) {
+				case string:
+					// Old format: plain string → convert to SubAgentConfig
+					role := strings.TrimSpace(e)
+					if role != "" {
+						configs = append(configs, SubAgentConfig{
+							Role:     role,
+							RunAfter: "phase_done",
+						})
+					}
+				case map[string]any:
+					// New format: object with role, description, run_after
+					cfg := SubAgentConfig{
+						Role:        mapString(map[string]any(e), "role"),
+						Description: mapString(map[string]any(e), "description"),
+						RunAfter:    mapString(map[string]any(e), "run_after"),
+					}
+					if cfg.Role != "" {
+						configs = append(configs, cfg)
+					}
+				}
+			}
+			return normalizeSubAgents(configs)
+		}
+	}
+	return nil
+}
+
+func writeSubAgentConfigList(b *strings.Builder, key string, agents []SubAgentConfig) {
+	agents = normalizeSubAgents(agents)
+	if len(agents) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(b, "%s:\n", key)
+	for _, a := range agents {
+		_, _ = fmt.Fprintf(b, "  - role: %s\n", quoteYAML(a.Role))
+		if v := strings.TrimSpace(a.Description); v != "" {
+			_, _ = fmt.Fprintf(b, "    description: %s\n", quoteYAML(v))
+		}
+		if v := strings.TrimSpace(a.RunAfter); v != "" {
+			_, _ = fmt.Fprintf(b, "    run_after: %s\n", quoteYAML(v))
+		}
+	}
 }
 
 func mapWorkflowRuleList(values map[string]any, keys ...string) []WorkflowRule {

--- a/internal/project/store.go
+++ b/internal/project/store.go
@@ -32,7 +32,7 @@ type Project struct {
 	SecretsRefs        []string       `json:"secrets_refs,omitempty" yaml:"secrets_refs,omitempty"`
 	ExecutionMode      string         `json:"execution_mode,omitempty" yaml:"execution_mode,omitempty"`
 	MaxPhases          int            `json:"max_phases,omitempty" yaml:"max_phases,omitempty"`
-	SubAgents          []string       `json:"sub_agents,omitempty" yaml:"sub_agents,omitempty"`
+	SubAgents          []SubAgentConfig `json:"sub_agents,omitempty" yaml:"sub_agents,omitempty"`
 	SessionID          string         `json:"session_id,omitempty" yaml:"session_id,omitempty"`
 	Body               string         `json:"body,omitempty" yaml:"-"`
 	Path               string         `json:"path,omitempty" yaml:"-"`
@@ -41,6 +41,12 @@ type Project struct {
 type WorkflowRule struct {
 	Name   string            `json:"name" yaml:"name"`
 	Params map[string]string `json:"params,omitempty" yaml:"params,omitempty"`
+}
+
+type SubAgentConfig struct {
+	Role        string `json:"role" yaml:"role"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	RunAfter    string `json:"run_after,omitempty" yaml:"run_after,omitempty"`
 }
 
 type CreateInput struct {
@@ -54,7 +60,7 @@ type CreateInput struct {
 	CloneRepo       bool
 	ExecutionMode   string
 	MaxPhases       int
-	SubAgents       []string
+	SubAgents       []SubAgentConfig
 }
 
 type UpdateInput struct {
@@ -66,7 +72,7 @@ type UpdateInput struct {
 	Instructions       *string
 	ExecutionMode      *string
 	MaxPhases          *int
-	SubAgents          []string
+	SubAgents          []SubAgentConfig
 	SessionID          *string
 	ToolsAllow         []string
 	ToolsAllowGroups   []string
@@ -126,7 +132,7 @@ func (s *Store) Create(input CreateInput) (Project, error) {
 		WorkflowRules:   normalizeWorkflowRules(input.WorkflowRules),
 		ExecutionMode:   normalizeExecutionMode(input.ExecutionMode),
 		MaxPhases:       normalizeMaxPhases(input.MaxPhases, input.ExecutionMode),
-		SubAgents:       normalizeList(input.SubAgents),
+		SubAgents:       normalizeSubAgents(input.SubAgents),
 		Body:            strings.TrimSpace(input.Instructions),
 	}
 	if err := s.write(project); err != nil {

--- a/internal/project/store_normalize.go
+++ b/internal/project/store_normalize.go
@@ -74,7 +74,7 @@ func applyUpdateInput(item *Project, input UpdateInput) error {
 		item.MaxPhases = normalizeMaxPhases(*input.MaxPhases, item.ExecutionMode)
 	}
 	if len(input.SubAgents) > 0 {
-		item.SubAgents = normalizeList(input.SubAgents)
+		item.SubAgents = normalizeSubAgents(input.SubAgents)
 	}
 	if input.SessionID != nil {
 		item.SessionID = strings.TrimSpace(*input.SessionID)
@@ -210,6 +210,38 @@ func normalizeStatus(raw string) string {
 	default:
 		return "active"
 	}
+}
+
+func normalizeSubAgents(agents []SubAgentConfig) []SubAgentConfig {
+	if len(agents) == 0 {
+		return nil
+	}
+	out := make([]SubAgentConfig, 0, len(agents))
+	seen := map[string]struct{}{}
+	for _, a := range agents {
+		role := strings.TrimSpace(a.Role)
+		if role == "" {
+			continue
+		}
+		key := strings.ToLower(role)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		runAfter := strings.TrimSpace(a.RunAfter)
+		if runAfter == "" {
+			runAfter = "phase_done"
+		}
+		out = append(out, SubAgentConfig{
+			Role:        role,
+			Description: strings.TrimSpace(a.Description),
+			RunAfter:    runAfter,
+		})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func normalizeList(values []string) []string {

--- a/internal/project/update_payload.go
+++ b/internal/project/update_payload.go
@@ -10,7 +10,7 @@ type UpdatePayload struct {
 	Instructions       *string        `json:"instructions,omitempty"`
 	ExecutionMode      *string        `json:"execution_mode,omitempty"`
 	MaxPhases          *int           `json:"max_phases,omitempty"`
-	SubAgents          []string       `json:"sub_agents,omitempty"`
+	SubAgents          []SubAgentConfig `json:"sub_agents,omitempty"`
 	ToolsAllow         []string       `json:"tools_allow,omitempty"`
 	ToolsAllowGroups   []string       `json:"tools_allow_groups,omitempty"`
 	ToolsAllowPatterns []string       `json:"tools_allow_patterns,omitempty"`

--- a/internal/tarsserver/handler_project.go
+++ b/internal/tarsserver/handler_project.go
@@ -170,17 +170,17 @@ func newProjectAPIHandler(
 			writeJSON(w, http.StatusOK, items)
 		case http.MethodPost:
 			var req struct {
-				Name            string                 `json:"name"`
-				Type            string                 `json:"type,omitempty"`
-				GitRepo         string                 `json:"git_repo,omitempty"`
-				Objective       string                 `json:"objective,omitempty"`
-				WorkflowProfile string                 `json:"workflow_profile,omitempty"`
-				WorkflowRules   []project.WorkflowRule `json:"workflow_rules,omitempty"`
-				Instructions    string                 `json:"instructions,omitempty"`
-				CloneRepo       bool                   `json:"clone_repo,omitempty"`
-				ExecutionMode   string                 `json:"execution_mode,omitempty"`
-				MaxPhases       int                    `json:"max_phases,omitempty"`
-				SubAgents       []string               `json:"sub_agents,omitempty"`
+				Name            string                      `json:"name"`
+				Type            string                      `json:"type,omitempty"`
+				GitRepo         string                      `json:"git_repo,omitempty"`
+				Objective       string                      `json:"objective,omitempty"`
+				WorkflowProfile string                      `json:"workflow_profile,omitempty"`
+				WorkflowRules   []project.WorkflowRule      `json:"workflow_rules,omitempty"`
+				Instructions    string                      `json:"instructions,omitempty"`
+				CloneRepo       bool                        `json:"clone_repo,omitempty"`
+				ExecutionMode   string                      `json:"execution_mode,omitempty"`
+				MaxPhases       int                         `json:"max_phases,omitempty"`
+				SubAgents       []project.SubAgentConfig    `json:"sub_agents,omitempty"`
 			}
 			if !decodeJSONBody(w, r, &req) {
 				return

--- a/internal/tarsserver/helpers_project_progress.go
+++ b/internal/tarsserver/helpers_project_progress.go
@@ -94,18 +94,25 @@ func advanceAutonomousProject(ctx context.Context, store *project.Store, runner 
 		return
 	}
 
-	// Case 2: All tasks done → critic review (if configured), then next phase
+	// Case 2: All tasks done → run phase_done agents (if configured), then next phase
 	if counts["done"] == len(board.Tasks) {
 		if ask == nil {
 			return
 		}
-		// Run critic review if sub_agents includes "critic"
-		var criticFeedback string
-		if hasCritic(p.SubAgents) {
-			criticFeedback = runCriticReview(ctx, store, ask, p, board, state.PhaseNumber, logger)
+		// Run all sub-agents triggered by "phase_done"
+		var agentFeedback string
+		phaseDoneAgents := findAgentsByTrigger(p.SubAgents, "phase_done")
+		for _, agent := range phaseDoneAgents {
+			feedback := runAgentReview(ctx, store, ask, p, board, state.PhaseNumber, agent, logger)
+			if feedback != "" {
+				if agentFeedback != "" {
+					agentFeedback += "\n\n"
+				}
+				agentFeedback += fmt.Sprintf("[%s] %s", agent.Role, feedback)
+			}
 		}
 		nextPhase := state.PhaseNumber + 1
-		planAutonomousTasks(ctx, store, ask, p, nextPhase, criticFeedback, logger)
+		planAutonomousTasks(ctx, store, ask, p, nextPhase, agentFeedback, logger)
 		return
 	}
 
@@ -139,13 +146,27 @@ func planAutonomousTasks(ctx context.Context, store *project.Store, ask heartbea
 		criticContext = fmt.Sprintf("\n\nCRITIC FEEDBACK FROM PREVIOUS PHASE (address these issues):\n%s", strings.TrimSpace(criticFeedback))
 	}
 
+	// Build agent context
+	agentContext := ""
+	if len(p.SubAgents) > 0 {
+		var agentNames []string
+		for _, a := range p.SubAgents {
+			desc := a.Role
+			if a.Description != "" {
+				desc += " (" + a.Description + ")"
+			}
+			agentNames = append(agentNames, desc)
+		}
+		agentContext = fmt.Sprintf("\nAvailable agents: %s", strings.Join(agentNames, ", "))
+	}
+
 	prompt := fmt.Sprintf(
 		`You are a project executor. Generate tasks for phase %d/%d of this project.
 
 Project: %s
 Objective: %s
 Instructions: %s
-%s%s
+%s%s%s
 CRITICAL RULES:
 - Each task MUST produce a concrete deliverable file (not a plan, not a template, not analysis).
 - If the objective is to write stories → tasks should be "Write story X and save as story-X.md"
@@ -153,14 +174,14 @@ CRITICAL RULES:
 - Do NOT generate planning/analysis/template tasks. The output must be the FINAL deliverable.
 - Phase %d of %d: %s
 
-Return a JSON array of task objects. Each task has "id" (string), "title" (string).
+Return a JSON array of task objects. Each task has "id" (string), "title" (string), and optionally "assignee" (string, agent role name).
 Generate 1-3 tasks that produce actual deliverables. Only return the JSON array.
-Example: [{"id":"task-1","title":"Write the complete first short story and save as story-1.md"}]`,
+Example: [{"id":"task-1","title":"Write the complete first short story and save as story-1.md","assignee":"writer"}]`,
 		phaseNumber, maxPhases,
 		strings.TrimSpace(p.Name),
 		strings.TrimSpace(p.Objective),
 		strings.TrimSpace(p.Body),
-		filesContext, criticContext,
+		filesContext, criticContext, agentContext,
 		phaseNumber, maxPhases,
 		phaseGuidance(phaseNumber, maxPhases),
 	)
@@ -182,9 +203,10 @@ Example: [{"id":"task-1","title":"Write the complete first short story and save 
 	boardTasks := make([]project.BoardTask, len(tasks))
 	for i, t := range tasks {
 		boardTasks[i] = project.BoardTask{
-			ID:     fmt.Sprintf("phase%d-task-%d", phaseNumber, i+1),
-			Title:  t.Title,
-			Status: "todo",
+			ID:       fmt.Sprintf("phase%d-task-%d", phaseNumber, i+1),
+			Title:    t.Title,
+			Status:   "todo",
+			Assignee: strings.TrimSpace(t.Assignee),
 		}
 	}
 	if _, err := store.UpdateBoard(p.ID, project.BoardUpdateInput{Tasks: boardTasks}); err != nil {
@@ -267,8 +289,9 @@ func countTaskStatuses(board project.Board) map[string]int {
 }
 
 type llmTask struct {
-	ID    string `json:"id"`
-	Title string `json:"title"`
+	ID       string `json:"id"`
+	Title    string `json:"title"`
+	Assignee string `json:"assignee,omitempty"`
 }
 
 func parseTasksFromLLM(response string) []llmTask {
@@ -293,13 +316,18 @@ func parseTasksFromLLM(response string) []llmTask {
 	return result
 }
 
-func hasCritic(subAgents []string) bool {
-	for _, a := range subAgents {
-		if strings.EqualFold(strings.TrimSpace(a), "critic") {
-			return true
+func findAgentsByTrigger(agents []project.SubAgentConfig, trigger string) []project.SubAgentConfig {
+	var result []project.SubAgentConfig
+	for _, a := range agents {
+		runAfter := strings.TrimSpace(a.RunAfter)
+		if runAfter == "" {
+			runAfter = "phase_done"
+		}
+		if strings.EqualFold(runAfter, trigger) {
+			result = append(result, a)
 		}
 	}
-	return false
+	return result
 }
 
 func phaseGuidance(phase, max int) string {
@@ -335,34 +363,42 @@ func listProjectArtifactNames(store *project.Store, projectID string) []string {
 	return names
 }
 
-// runCriticReview asks the LLM to critically review the completed tasks
+// runAgentReview asks the LLM to perform a review as the given agent role
 // and logs the feedback to project activity.
-func runCriticReview(ctx context.Context, store *project.Store, ask heartbeat.AskFunc, p project.Project, board project.Board, phaseNumber int, logger zerolog.Logger) string {
+func runAgentReview(ctx context.Context, store *project.Store, ask heartbeat.AskFunc, p project.Project, board project.Board, phaseNumber int, agent project.SubAgentConfig, logger zerolog.Logger) string {
 	taskSummary := ""
 	for _, t := range board.Tasks {
 		taskSummary += fmt.Sprintf("- [%s] %s\n", t.Status, t.Title)
 	}
 
+	roleDesc := agent.Role
+	if agent.Description != "" {
+		roleDesc = agent.Description
+	}
+
 	prompt := fmt.Sprintf(
-		`You are a critical reviewer. Review the following completed work for project "%s".
+		`You are a %s. %s
+
+Review the following completed work for project "%s".
 
 Objective: %s
 
 Completed tasks (phase %d):
 %s
 
-Provide a brief critical review (3-5 sentences):
+Provide a brief review (3-5 sentences):
 1. What was done well?
 2. What is missing or could be improved?
 3. Should the next phase address any gaps?
 
 Be constructive but honest. Reply in plain text only.`,
+		agent.Role, roleDesc,
 		p.Name, p.Objective, phaseNumber, taskSummary,
 	)
 
 	response, err := ask(ctx, prompt)
 	if err != nil {
-		logger.Debug().Err(err).Str("project_id", p.ID).Msg("autonomous: critic review failed")
+		logger.Debug().Err(err).Str("project_id", p.ID).Str("agent", agent.Role).Msg("autonomous: agent review failed")
 		return ""
 	}
 
@@ -370,11 +406,11 @@ Be constructive but honest. Reply in plain text only.`,
 
 	// Record review as activity
 	_, _ = store.AppendActivity(p.ID, project.ActivityAppendInput{
-		Source:  "critic",
+		Source:  agent.Role,
 		Kind:    "review",
 		Status:  "completed",
 		Message: feedback,
 	})
-	logger.Info().Str("project_id", p.ID).Int("phase", phaseNumber).Msg("autonomous: critic review completed")
+	logger.Info().Str("project_id", p.ID).Str("agent", agent.Role).Int("phase", phaseNumber).Msg("autonomous: agent review completed")
 	return feedback
 }

--- a/internal/tool/tool_project.go
+++ b/internal/tool/tool_project.go
@@ -38,7 +38,7 @@ func NewProjectCreateTool(store *project.Store) Tool {
     "clone_repo":{"type":"boolean"},
     "execution_mode":{"type":"string","enum":["autonomous","manual"],"description":"Set to 'autonomous' for AI-driven auto-execution, 'manual' for user-driven. Keywords: 자율실행, 자동, autonomous → use 'autonomous'."},
     "max_phases":{"type":"integer","description":"Maximum iteration phases for autonomous mode (default: 3). Each phase plans and executes a batch of tasks."},
-    "sub_agents":{"type":"array","items":{"type":"string"},"description":"Sub-agent roles for autonomous review loop. Use ['critic'] to enable critical review after each phase."}
+    "sub_agents":{"type":"array","items":{"type":"object","properties":{"role":{"type":"string"},"description":{"type":"string"},"run_after":{"type":"string","enum":["phase_done","each_task"]}},"required":["role"]},"description":"Sub-agent configurations for autonomous execution. Each agent has a role, optional description, and run_after trigger (phase_done or each_task)."}
   },
   "required":["name"],
   "additionalProperties":false
@@ -48,17 +48,17 @@ func NewProjectCreateTool(store *project.Store) Tool {
 				return JSONTextResult(map[string]any{"message": "project store is not configured"}, true), nil
 			}
 			var input struct {
-				Name            string                 `json:"name"`
-				Type            string                 `json:"type,omitempty"`
-				GitRepo         string                 `json:"git_repo,omitempty"`
-				Objective       string                 `json:"objective,omitempty"`
-				WorkflowProfile string                 `json:"workflow_profile,omitempty"`
-				WorkflowRules   []project.WorkflowRule `json:"workflow_rules,omitempty"`
-				Instructions    string                 `json:"instructions,omitempty"`
-				CloneRepo       bool                   `json:"clone_repo,omitempty"`
-				ExecutionMode   string                 `json:"execution_mode,omitempty"`
-				MaxPhases       int                    `json:"max_phases,omitempty"`
-				SubAgents       []string               `json:"sub_agents,omitempty"`
+				Name            string                      `json:"name"`
+				Type            string                      `json:"type,omitempty"`
+				GitRepo         string                      `json:"git_repo,omitempty"`
+				Objective       string                      `json:"objective,omitempty"`
+				WorkflowProfile string                      `json:"workflow_profile,omitempty"`
+				WorkflowRules   []project.WorkflowRule      `json:"workflow_rules,omitempty"`
+				Instructions    string                      `json:"instructions,omitempty"`
+				CloneRepo       bool                        `json:"clone_repo,omitempty"`
+				ExecutionMode   string                      `json:"execution_mode,omitempty"`
+				MaxPhases       int                         `json:"max_phases,omitempty"`
+				SubAgents       []project.SubAgentConfig    `json:"sub_agents,omitempty"`
 			}
 			if err := json.Unmarshal(params, &input); err != nil {
 				return JSONTextResult(map[string]any{"message": fmt.Sprintf("invalid arguments: %v", err)}, true), nil
@@ -168,7 +168,7 @@ func NewProjectUpdateTool(store *project.Store) Tool {
     "secrets_refs":{"type":"array","items":{"type":"string"}},
     "execution_mode":{"type":"string"},
     "max_phases":{"type":"integer"},
-    "sub_agents":{"type":"array","items":{"type":"string"}}
+    "sub_agents":{"type":"array","items":{"type":"object","properties":{"role":{"type":"string"},"description":{"type":"string"},"run_after":{"type":"string","enum":["phase_done","each_task"]}},"required":["role"]}}
   },
   "required":["project_id"],
   "additionalProperties":false


### PR DESCRIPTION
## Summary
서브에이전트를 critic 고정에서 동적 다중 에이전트로 확장

## Changes
- `SubAgentConfig` 구조체: role + description + run_after (phase_done/each_task)
- 기존 `["critic"]` 문자열 배열 하위 호환
- 자율실행: 모든 phase_done 에이전트 순차 리뷰 → 합산 피드백 → 다음 phase
- Planning 프롬프트: 에이전트 목록 포함, 태스크에 assignee 배정
- 프론트엔드: Sub-Agents 카드에 description, trigger 표시

## Test plan
- [x] `go build` / `go test ./internal/project/... ./internal/tarsserver/... ./internal/tool/...` passes
- [x] `npm run check` — 0 errors