### PR TITLE
feat: inject project-scoped skills into autonomous task prompts

### DIFF
--- a/frontend/console/src/components/ProjectView.svelte
+++ b/frontend/console/src/components/ProjectView.svelte
@@ -48,6 +48,7 @@
   let editName = $state('')
   let editObjective = $state('')
   let editGitRepo = $state('')
+  let editSkillsAllow = $state('')
   let editSaving = $state(false)
   let editError = $state('')
   let deleting = $state(false)
@@ -147,6 +148,7 @@
     editName = project.name
     editObjective = project.objective || ''
     editGitRepo = project.git_repo || ''
+    editSkillsAllow = (project.skills_allow || []).join(', ')
     editError = ''
     editing = true
   }
@@ -161,10 +163,14 @@
     editSaving = true
     editError = ''
     try {
+      const skillsAllow = editSkillsAllow.trim()
+        ? editSkillsAllow.split(',').map((s: string) => s.trim()).filter(Boolean)
+        : undefined
       project = await updateProject(projectId, {
         name: editName.trim(),
         objective: editObjective.trim() || undefined,
         git_repo: editGitRepo.trim() || undefined,
+        skills_allow: skillsAllow,
       })
       editing = false
     } catch (e) {
@@ -296,6 +302,7 @@
             <input type="text" placeholder="Project name *" bind:value={editName} class="form-input" />
             <input type="text" placeholder="Objective" bind:value={editObjective} class="form-input" />
             <input type="text" placeholder="Git repo URL" bind:value={editGitRepo} class="form-input" />
+            <input type="text" placeholder="Skills (comma-separated, e.g. github-dev)" bind:value={editSkillsAllow} class="form-input" />
             <div style="display:flex;gap:var(--space-2)">
               <button class="btn btn-primary btn-sm" disabled={!editName.trim() || editSaving} onclick={handleSaveEdit}>
                 {editSaving ? 'Saving...' : 'Save'}
@@ -314,6 +321,11 @@
           <span class="badge badge-accent">autonomous</span>
         {:else}
           <span class="badge badge-default">manual</span>
+        {/if}
+        {#if project.skills_allow?.length}
+          {#each project.skills_allow as skill}
+            <span class="badge badge-info">{skill}</span>
+          {/each}
         {/if}
         {#if !editing}
           <button class="btn btn-ghost btn-sm" onclick={enterEdit}>Edit</button>

--- a/frontend/console/src/components/Projects.svelte
+++ b/frontend/console/src/components/Projects.svelte
@@ -49,6 +49,7 @@
   let newProjectMode: 'manual' | 'autonomous' = $state('manual')
   let newProjectMaxPhases = $state(3)
   let newProjectSubAgents = $state('')
+  let newProjectSkillsAllow = $state('')
   let newProjectSaving = $state(false)
   let newProjectError = $state('')
 
@@ -88,6 +89,9 @@
       const subAgents = newProjectSubAgents.trim()
         ? newProjectSubAgents.split(',').map((s) => s.trim()).filter(Boolean).map((role) => ({ role, run_after: 'phase_done' as const }))
         : undefined
+      const skillsAllow = newProjectSkillsAllow.trim()
+        ? newProjectSkillsAllow.split(',').map((s) => s.trim()).filter(Boolean)
+        : undefined
       const p = await createProject({
         name: newProjectName.trim(),
         type: newProjectType.trim() || undefined,
@@ -96,6 +100,7 @@
         execution_mode: newProjectMode,
         max_phases: newProjectMode === 'autonomous' ? newProjectMaxPhases : undefined,
         sub_agents: subAgents,
+        skills_allow: skillsAllow,
       })
       projects = [p, ...projects]
       showNewProject = false
@@ -106,6 +111,7 @@
       newProjectMode = 'manual'
       newProjectMaxPhases = 3
       newProjectSubAgents = ''
+      newProjectSkillsAllow = ''
       goToProject(p.id)
     } catch (e) {
       newProjectError = e instanceof Error ? e.message : 'Failed to create project'
@@ -181,6 +187,7 @@
         <input type="text" placeholder="Type (optional)" bind:value={newProjectType} class="form-input" />
         <input type="text" placeholder="Objective (optional)" bind:value={newProjectObjective} class="form-input form-span-2" />
         <input type="text" placeholder="Git repo URL (optional)" bind:value={newProjectGitRepo} class="form-input form-span-2" />
+        <input type="text" placeholder="Skills (comma-separated, e.g. github-dev, testing)" bind:value={newProjectSkillsAllow} class="form-input form-span-2" />
         <div class="form-span-2 form-row">
           <label class="form-label">
             Execution mode

--- a/frontend/console/src/lib/types.ts
+++ b/frontend/console/src/lib/types.ts
@@ -41,6 +41,7 @@ export type Project = {
   execution_mode?: string
   max_phases?: number
   sub_agents?: SubAgentConfig[]
+  skills_allow?: string[]
   session_id?: string
 }
 
@@ -245,6 +246,7 @@ export type CreateProjectRequest = {
   execution_mode?: string
   max_phases?: number
   sub_agents?: SubAgentConfig[]
+  skills_allow?: string[]
 }
 
 export type UpdateProjectRequest = {
@@ -254,6 +256,7 @@ export type UpdateProjectRequest = {
   git_repo?: string
   objective?: string
   instructions?: string
+  skills_allow?: string[]
 }
 
 export type CreateCronJobRequest = {

--- a/internal/project/orchestrator.go
+++ b/internal/project/orchestrator.go
@@ -51,6 +51,7 @@ type Orchestrator struct {
 	store             *Store
 	runner            TaskRunner
 	githubAuthChecker GitHubAuthChecker
+	skillResolver     SkillResolver
 	mu                sync.Mutex
 }
 
@@ -67,6 +68,12 @@ func NewOrchestratorWithGitHubAuthChecker(store *Store, runner TaskRunner, check
 		runner:            runner,
 		githubAuthChecker: checker,
 	}
+}
+
+// SetSkillResolver sets the resolver used to inject project skill content
+// into task prompts. May be nil.
+func (o *Orchestrator) SetSkillResolver(r SkillResolver) {
+	o.skillResolver = r
 }
 
 func (o *Orchestrator) DispatchTodo(ctx context.Context, projectID string) (DispatchReport, error) {
@@ -147,7 +154,8 @@ func (o *Orchestrator) dispatchTask(ctx context.Context, projectID string, task 
 		return TaskRun{}, err
 	}
 
-	run, err := o.startTaskRun(ctx, projectID, task, profile)
+	skills := o.resolveProjectSkills(projectItem)
+	run, err := o.startTaskRun(ctx, projectID, task, profile, skills)
 	if err != nil {
 		return TaskRun{}, err
 	}
@@ -233,12 +241,19 @@ func (o *Orchestrator) prepareTaskDispatch(ctx context.Context, projectID string
 	return profile, nil
 }
 
-func (o *Orchestrator) startTaskRun(ctx context.Context, projectID string, task BoardTask, profile WorkerProfile) (TaskRun, error) {
+func (o *Orchestrator) resolveProjectSkills(p Project) []SkillContent {
+	if o.skillResolver == nil || len(p.SkillsAllow) == 0 {
+		return nil
+	}
+	return o.skillResolver.ResolveSkills(p.SkillsAllow)
+}
+
+func (o *Orchestrator) startTaskRun(ctx context.Context, projectID string, task BoardTask, profile WorkerProfile, skills []SkillContent) (TaskRun, error) {
 	run, err := o.runner.Start(ctx, TaskRunRequest{
 		ProjectID:  strings.TrimSpace(projectID),
 		TaskID:     task.ID,
 		Title:      task.Title,
-		Prompt:     BuildTaskPrompt(task, projectID, profile),
+		Prompt:     BuildTaskPrompt(task, projectID, profile, skills...),
 		Agent:      task.Assignee,
 		Role:       task.Role,
 		WorkerKind: profile.Kind,
@@ -458,7 +473,8 @@ func (o *Orchestrator) dispatchReviewTask(ctx context.Context, projectID string,
 	if err != nil {
 		return TaskRun{}, err
 	}
-	prompt := BuildTaskPrompt(reviewTask, projectID, profile) +
+	skills := o.resolveProjectSkills(projectItem)
+	prompt := BuildTaskPrompt(reviewTask, projectID, profile, skills...) +
 		"\n\nCurrent task status: review" +
 		"\nImplementation worker_kind: " + strings.TrimSpace(task.WorkerKind)
 

--- a/internal/project/orchestrator_test.go
+++ b/internal/project/orchestrator_test.go
@@ -635,3 +635,121 @@ func hasAgentReport(items []Activity, taskID, status, errorText string) bool {
 	}
 	return false
 }
+
+// stubSkillResolver implements SkillResolver for testing.
+type stubSkillResolver struct {
+	skills []SkillContent
+}
+
+func (s *stubSkillResolver) ResolveSkills(_ []string) []SkillContent {
+	return s.skills
+}
+
+func TestOrchestratorDispatchTodo_InjectsProjectSkillsIntoPrompt(t *testing.T) {
+	store := NewStore(t.TempDir(), func() time.Time {
+		return time.Date(2026, 3, 14, 13, 0, 0, 0, time.UTC)
+	})
+	created, err := store.Create(CreateInput{
+		Name:        "Skill Project",
+		SkillsAllow: []string{"github-dev"},
+	})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	if _, err := store.UpdateBoard(created.ID, BoardUpdateInput{
+		Tasks: []BoardTask{
+			{ID: "task-1", Title: "Create issue", Status: "todo", Assignee: "planner", Role: "developer", ReviewRequired: true},
+		},
+	}); err != nil {
+		t.Fatalf("seed board: %v", err)
+	}
+
+	runner := newStubTaskRunner()
+	orch := NewOrchestratorWithGitHubAuthChecker(store, runner, func(context.Context) error { return nil })
+	orch.SetSkillResolver(&stubSkillResolver{
+		skills: []SkillContent{
+			{Name: "github-dev", Content: "Always use `gh issue create` for issue creation."},
+		},
+	})
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, runErr := orch.DispatchTodo(context.Background(), created.ID)
+		errCh <- runErr
+	}()
+
+	select {
+	case <-runner.startedCh:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected task run to start")
+	}
+	close(runner.waitGate)
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+
+	runner.mu.Lock()
+	defer runner.mu.Unlock()
+	if len(runner.started) != 1 {
+		t.Fatalf("expected 1 started task, got %d", len(runner.started))
+	}
+	prompt := runner.started[0].Prompt
+	if !strings.Contains(prompt, "## Project Skills") {
+		t.Fatalf("expected skills section in prompt, got:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "### github-dev") {
+		t.Fatalf("expected github-dev skill header in prompt")
+	}
+	if !strings.Contains(prompt, "gh issue create") {
+		t.Fatalf("expected skill content in prompt")
+	}
+}
+
+func TestOrchestratorDispatchTodo_NoSkillsWhenResolverNil(t *testing.T) {
+	store := NewStore(t.TempDir(), func() time.Time {
+		return time.Date(2026, 3, 14, 13, 0, 0, 0, time.UTC)
+	})
+	created, err := store.Create(CreateInput{
+		Name:        "No Skill Project",
+		SkillsAllow: []string{"github-dev"},
+	})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	if _, err := store.UpdateBoard(created.ID, BoardUpdateInput{
+		Tasks: []BoardTask{
+			{ID: "task-1", Title: "Do work", Status: "todo", Assignee: "dev", Role: "developer", ReviewRequired: true},
+		},
+	}); err != nil {
+		t.Fatalf("seed board: %v", err)
+	}
+
+	runner := newStubTaskRunner()
+	orch := NewOrchestratorWithGitHubAuthChecker(store, runner, func(context.Context) error { return nil })
+	// No SetSkillResolver — resolver is nil
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, runErr := orch.DispatchTodo(context.Background(), created.ID)
+		errCh <- runErr
+	}()
+
+	select {
+	case <-runner.startedCh:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected task run to start")
+	}
+	close(runner.waitGate)
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+
+	runner.mu.Lock()
+	defer runner.mu.Unlock()
+	prompt := runner.started[0].Prompt
+	if strings.Contains(prompt, "## Project Skills") {
+		t.Fatalf("expected no skills section when resolver is nil, got:\n%s", prompt)
+	}
+}

--- a/internal/project/skill_resolver.go
+++ b/internal/project/skill_resolver.go
@@ -1,0 +1,14 @@
+package project
+
+// SkillContent holds the resolved name and body of a single skill.
+type SkillContent struct {
+	Name    string
+	Content string
+}
+
+// SkillResolver resolves skill names into their content for injection into
+// task prompts. Implementations live outside the project package to avoid
+// importing the skill or extensions packages.
+type SkillResolver interface {
+	ResolveSkills(names []string) []SkillContent
+}

--- a/internal/project/store.go
+++ b/internal/project/store.go
@@ -61,6 +61,7 @@ type CreateInput struct {
 	ExecutionMode   string
 	MaxPhases       int
 	SubAgents       []SubAgentConfig
+	SkillsAllow     []string
 }
 
 type UpdateInput struct {
@@ -133,6 +134,7 @@ func (s *Store) Create(input CreateInput) (Project, error) {
 		ExecutionMode:   normalizeExecutionMode(input.ExecutionMode),
 		MaxPhases:       normalizeMaxPhases(input.MaxPhases, input.ExecutionMode),
 		SubAgents:       normalizeSubAgents(input.SubAgents),
+		SkillsAllow:    normalizeList(input.SkillsAllow),
 		Body:            strings.TrimSpace(input.Instructions),
 	}
 	if err := s.write(project); err != nil {

--- a/internal/project/worker_profiles.go
+++ b/internal/project/worker_profiles.go
@@ -165,7 +165,16 @@ func ResolveWorkerProfileForProject(project Project, task BoardTask) (WorkerProf
 	return profile, nil
 }
 
-func BuildTaskPrompt(task BoardTask, projectID string, profile WorkerProfile) string {
+// maxSkillContentChars is the per-skill character cap when injecting skill
+// content into task prompts.
+const maxSkillContentChars = 4000
+
+// maxSkillsInPrompt is the upper bound on skills injected into a single prompt.
+const maxSkillsInPrompt = 5
+
+// BuildTaskPrompt assembles the initial instruction for a task worker.
+// Optional skills are appended as a ## Project Skills section.
+func BuildTaskPrompt(task BoardTask, projectID string, profile WorkerProfile, skills ...SkillContent) string {
 	var builder strings.Builder
 	workerKind := firstNonEmpty(strings.TrimSpace(task.WorkerKind), profile.Kind)
 	role := firstNonEmpty(strings.TrimSpace(task.Role), "developer")
@@ -198,6 +207,8 @@ func BuildTaskPrompt(task BoardTask, projectID string, profile WorkerProfile) st
 		builder.WriteString(buildCmd)
 	}
 
+	writeSkillsSection(&builder, skills)
+
 	builder.WriteString("\n\n")
 	switch strings.ToLower(role) {
 	case "reviewer", "review":
@@ -228,4 +239,31 @@ func BuildTaskPrompt(task BoardTask, projectID string, profile WorkerProfile) st
 		builder.WriteString("</task-report>")
 	}
 	return builder.String()
+}
+
+func writeSkillsSection(builder *strings.Builder, skills []SkillContent) {
+	if len(skills) == 0 {
+		return
+	}
+	cap := len(skills)
+	if cap > maxSkillsInPrompt {
+		cap = maxSkillsInPrompt
+	}
+	builder.WriteString("\n\n## Project Skills\n")
+	builder.WriteString("The following skills define how to perform domain-specific operations in this project. Follow these instructions strictly.\n")
+	for _, sk := range skills[:cap] {
+		name := strings.TrimSpace(sk.Name)
+		content := strings.TrimSpace(sk.Content)
+		if name == "" || content == "" {
+			continue
+		}
+		if len(content) > maxSkillContentChars {
+			content = content[:maxSkillContentChars] + "\n…(truncated)"
+		}
+		builder.WriteString("\n### ")
+		builder.WriteString(name)
+		builder.WriteString("\n")
+		builder.WriteString(content)
+		builder.WriteString("\n")
+	}
 }

--- a/internal/project/worker_profiles_test.go
+++ b/internal/project/worker_profiles_test.go
@@ -159,3 +159,83 @@ func TestBuildTaskPrompt_UsesFixedReportContract(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildTaskPrompt_InjectsSkillContent(t *testing.T) {
+	profile, _ := ResolveWorkerProfile(BoardTask{Role: "developer"})
+
+	t.Run("no skills produces no section", func(t *testing.T) {
+		prompt := BuildTaskPrompt(BoardTask{ID: "t1", Title: "do stuff"}, "proj", profile)
+		if strings.Contains(prompt, "## Project Skills") {
+			t.Fatal("unexpected skills section in prompt without skills")
+		}
+	})
+
+	t.Run("skills injected between metadata and report", func(t *testing.T) {
+		skills := []SkillContent{
+			{Name: "github-dev", Content: "Use gh CLI to create issues."},
+			{Name: "testing", Content: "Run go test ./... after changes."},
+		}
+		prompt := BuildTaskPrompt(BoardTask{ID: "t1", Title: "do stuff"}, "proj", profile, skills...)
+		if !strings.Contains(prompt, "## Project Skills") {
+			t.Fatal("expected skills section header")
+		}
+		if !strings.Contains(prompt, "### github-dev") {
+			t.Fatal("expected github-dev skill header")
+		}
+		if !strings.Contains(prompt, "Use gh CLI to create issues.") {
+			t.Fatal("expected github-dev skill content")
+		}
+		if !strings.Contains(prompt, "### testing") {
+			t.Fatal("expected testing skill header")
+		}
+		// Skills should appear before the report format
+		skillsIdx := strings.Index(prompt, "## Project Skills")
+		reportIdx := strings.Index(prompt, "<task-report>")
+		if skillsIdx >= reportIdx {
+			t.Fatal("skills section should appear before task-report")
+		}
+	})
+
+	t.Run("skill content truncated at limit", func(t *testing.T) {
+		longContent := strings.Repeat("x", maxSkillContentChars+500)
+		skills := []SkillContent{{Name: "big", Content: longContent}}
+		prompt := BuildTaskPrompt(BoardTask{ID: "t1", Title: "do stuff"}, "proj", profile, skills...)
+		if !strings.Contains(prompt, "…(truncated)") {
+			t.Fatal("expected truncation marker")
+		}
+		// Should not contain the full content
+		if strings.Contains(prompt, longContent) {
+			t.Fatal("full content should be truncated")
+		}
+	})
+
+	t.Run("max skills cap applied", func(t *testing.T) {
+		skills := make([]SkillContent, 7)
+		for i := range skills {
+			skills[i] = SkillContent{Name: "skill-" + string(rune('a'+i)), Content: "content"}
+		}
+		prompt := BuildTaskPrompt(BoardTask{ID: "t1", Title: "do stuff"}, "proj", profile, skills...)
+		count := strings.Count(prompt, "### skill-")
+		if count > maxSkillsInPrompt {
+			t.Fatalf("expected at most %d skills, got %d", maxSkillsInPrompt, count)
+		}
+	})
+
+	t.Run("empty skills skipped", func(t *testing.T) {
+		skills := []SkillContent{
+			{Name: "", Content: "no name"},
+			{Name: "valid", Content: ""},
+			{Name: "ok", Content: "good content"},
+		}
+		prompt := BuildTaskPrompt(BoardTask{ID: "t1", Title: "do stuff"}, "proj", profile, skills...)
+		if strings.Contains(prompt, "no name") {
+			t.Fatal("nameless skill should be skipped")
+		}
+		if strings.Contains(prompt, "### valid") {
+			t.Fatal("empty content skill should be skipped")
+		}
+		if !strings.Contains(prompt, "### ok") {
+			t.Fatal("valid skill should be included")
+		}
+	})
+}

--- a/internal/tarsserver/handler_project.go
+++ b/internal/tarsserver/handler_project.go
@@ -18,6 +18,7 @@ func newProjectAPIHandler(
 	mainSessionID string,
 	taskRunner project.TaskRunner,
 	githubAuthChecker project.GitHubAuthChecker,
+	skillResolver project.SkillResolver,
 	logger zerolog.Logger,
 ) http.Handler {
 	mux := http.NewServeMux()
@@ -181,6 +182,7 @@ func newProjectAPIHandler(
 				ExecutionMode   string                      `json:"execution_mode,omitempty"`
 				MaxPhases       int                         `json:"max_phases,omitempty"`
 				SubAgents       []project.SubAgentConfig    `json:"sub_agents,omitempty"`
+				SkillsAllow     []string                    `json:"skills_allow,omitempty"`
 			}
 			if !decodeJSONBody(w, r, &req) {
 				return
@@ -197,6 +199,7 @@ func newProjectAPIHandler(
 				ExecutionMode:   req.ExecutionMode,
 				MaxPhases:       req.MaxPhases,
 				SubAgents:       req.SubAgents,
+				SkillsAllow:     req.SkillsAllow,
 			})
 			if err != nil {
 				if strings.Contains(strings.ToLower(err.Error()), "required") || strings.Contains(strings.ToLower(err.Error()), "invalid") {
@@ -482,6 +485,7 @@ func newProjectAPIHandler(
 				return
 			}
 			orchestrator := project.NewOrchestratorWithGitHubAuthChecker(store, taskRunner, githubAuthChecker)
+			orchestrator.SetSkillResolver(skillResolver)
 			stage, ok := project.DefaultWorkflowPolicy.NormalizeDispatchStage(req.Stage)
 			if !ok {
 				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "stage must be todo or review"})

--- a/internal/tarsserver/handler_project_test.go
+++ b/internal/tarsserver/handler_project_test.go
@@ -30,7 +30,7 @@ func TestProjectAPI_CRUDAndActivate(t *testing.T) {
 	}
 
 	projectStore := project.NewStore(root, nil)
-	handler := newProjectAPIHandler(projectStore, store, mainSess.ID, nil, nil, zerolog.New(io.Discard))
+	handler := newProjectAPIHandler(projectStore, store, mainSess.ID, nil, nil, nil, zerolog.New(io.Discard))
 
 	createReq := httptest.NewRequest(http.MethodPost, "/v1/projects", strings.NewReader(`{
 		"name":"Ops A",
@@ -125,7 +125,7 @@ func TestProjectAPI_RejectsDisallowedMethods(t *testing.T) {
 	}
 
 	projectStore := project.NewStore(root, nil)
-	handler := newProjectAPIHandler(projectStore, store, mainSess.ID, nil, nil, zerolog.New(io.Discard))
+	handler := newProjectAPIHandler(projectStore, store, mainSess.ID, nil, nil, nil, zerolog.New(io.Discard))
 
 	createReq := httptest.NewRequest(http.MethodPost, "/v1/projects", strings.NewReader(`{"name":"Ops A","type":"operations"}`))
 	createReq.Header.Set("Content-Type", "application/json")
@@ -179,7 +179,7 @@ func TestProjectAPI_PatchUpdatesPolicyFields(t *testing.T) {
 	}
 	store := session.NewStore(root)
 	projectStore := project.NewStore(root, nil)
-	handler := newProjectAPIHandler(projectStore, store, "", nil, nil, zerolog.New(io.Discard))
+	handler := newProjectAPIHandler(projectStore, store, "", nil, nil, nil, zerolog.New(io.Discard))
 
 	created, err := projectStore.Create(project.CreateInput{Name: "Ops A", Type: "operations"})
 	if err != nil {
@@ -243,7 +243,7 @@ func TestProjectAPI_BriefFinalizeAndStateRoutes(t *testing.T) {
 	}
 
 	projectStore := project.NewStore(root, nil)
-	handler := newProjectAPIHandler(projectStore, store, mainSess.ID, nil, nil, zerolog.New(io.Discard))
+	handler := newProjectAPIHandler(projectStore, store, mainSess.ID, nil, nil, nil, zerolog.New(io.Discard))
 
 	briefReq := httptest.NewRequest(http.MethodPatch, "/v1/project-briefs/"+mainSess.ID, strings.NewReader(`{
 		"title":"Orbit Hearts",
@@ -327,7 +327,7 @@ func TestProjectAPI_ActivityRoutes(t *testing.T) {
 	}
 	store := session.NewStore(root)
 	projectStore := project.NewStore(root, nil)
-	handler := newProjectAPIHandler(projectStore, store, "", nil, nil, zerolog.New(io.Discard))
+	handler := newProjectAPIHandler(projectStore, store, "", nil, nil, nil, zerolog.New(io.Discard))
 
 	created, err := projectStore.Create(project.CreateInput{Name: "Ops A", Type: "operations"})
 	if err != nil {
@@ -394,7 +394,7 @@ func TestProjectAPI_BoardRoutes(t *testing.T) {
 	}
 	store := session.NewStore(root)
 	projectStore := project.NewStore(root, nil)
-	handler := newProjectAPIHandler(projectStore, store, "", nil, nil, zerolog.New(io.Discard))
+	handler := newProjectAPIHandler(projectStore, store, "", nil, nil, nil, zerolog.New(io.Discard))
 
 	created, err := projectStore.Create(project.CreateInput{Name: "Ops A", Type: "operations"})
 	if err != nil {
@@ -515,7 +515,7 @@ notes: approved
 	})
 
 	taskRunner := gateway.NewProjectTaskRunner(runtime, "")
-	handler := newProjectAPIHandler(projectStore, store, "", taskRunner, func(context.Context) error { return nil }, zerolog.New(io.Discard))
+	handler := newProjectAPIHandler(projectStore, store, "", taskRunner, func(context.Context) error { return nil }, nil, zerolog.New(io.Discard))
 
 	created, err := projectStore.Create(project.CreateInput{Name: "Dispatch Project", Type: "operations"})
 	if err != nil {

--- a/internal/tarsserver/helpers_project_progress.go
+++ b/internal/tarsserver/helpers_project_progress.go
@@ -19,6 +19,7 @@ func newProjectProgressAfterHeartbeat(
 	store *project.Store,
 	runner project.TaskRunner,
 	ask heartbeat.AskFunc,
+	skillResolver project.SkillResolver,
 	logger zerolog.Logger,
 ) func(ctx context.Context) error {
 	if store == nil || runner == nil {
@@ -34,9 +35,9 @@ func newProjectProgressAfterHeartbeat(
 				continue
 			}
 			if strings.TrimSpace(p.ExecutionMode) == "autonomous" {
-				advanceAutonomousProject(ctx, store, runner, ask, p, logger)
+				advanceAutonomousProject(ctx, store, runner, ask, skillResolver, p, logger)
 			} else {
-				advanceManualProject(ctx, store, runner, p, logger)
+				advanceManualProject(ctx, store, runner, skillResolver, p, logger)
 			}
 		}
 		return nil
@@ -44,12 +45,12 @@ func newProjectProgressAfterHeartbeat(
 }
 
 // advanceManualProject dispatches existing todo/review tasks only.
-func advanceManualProject(ctx context.Context, store *project.Store, runner project.TaskRunner, p project.Project, logger zerolog.Logger) {
+func advanceManualProject(ctx context.Context, store *project.Store, runner project.TaskRunner, skillResolver project.SkillResolver, p project.Project, logger zerolog.Logger) {
 	board, err := store.GetBoard(p.ID)
 	if err != nil {
 		return
 	}
-	dispatchBoardTasks(ctx, store, runner, p.ID, board, logger)
+	dispatchBoardTasks(ctx, store, runner, skillResolver, p.ID, board, logger)
 }
 
 // advanceAutonomousProject runs the full autonomous cycle:
@@ -57,7 +58,7 @@ func advanceManualProject(ctx context.Context, store *project.Store, runner proj
 // 2. If board empty → LLM generates tasks (planning)
 // 3. If has todo/review → dispatch
 // 4. If all done → advance phase or complete project
-func advanceAutonomousProject(ctx context.Context, store *project.Store, runner project.TaskRunner, ask heartbeat.AskFunc, p project.Project, logger zerolog.Logger) {
+func advanceAutonomousProject(ctx context.Context, store *project.Store, runner project.TaskRunner, ask heartbeat.AskFunc, skillResolver project.SkillResolver, p project.Project, logger zerolog.Logger) {
 	state, err := store.GetState(p.ID)
 	if err != nil {
 		state = project.ProjectState{ProjectID: p.ID}
@@ -123,7 +124,7 @@ func advanceAutonomousProject(ctx context.Context, store *project.Store, runner 
 
 	// Case 3: Has todo/review → dispatch
 	if counts["todo"] > 0 || counts["review"] > 0 {
-		dispatchBoardTasks(ctx, store, runner, p.ID, board, logger)
+		dispatchBoardTasks(ctx, store, runner, skillResolver, p.ID, board, logger)
 		return
 	}
 }
@@ -247,7 +248,7 @@ func completeProject(store *project.Store, projectID string, reason string, logg
 }
 
 // dispatchBoardTasks dispatches todo and review tasks via orchestrator.
-func dispatchBoardTasks(ctx context.Context, store *project.Store, runner project.TaskRunner, projectID string, board project.Board, logger zerolog.Logger) {
+func dispatchBoardTasks(ctx context.Context, store *project.Store, runner project.TaskRunner, skillResolver project.SkillResolver, projectID string, board project.Board, logger zerolog.Logger) {
 	hasTodo := false
 	hasReview := false
 	for _, task := range board.Tasks {
@@ -262,6 +263,7 @@ func dispatchBoardTasks(ctx context.Context, store *project.Store, runner projec
 		return
 	}
 	orch := project.NewOrchestrator(store, runner)
+	orch.SetSkillResolver(skillResolver)
 	if hasTodo {
 		report, err := orch.DispatchTodo(ctx, projectID)
 		if err != nil {

--- a/internal/tarsserver/main_serve_api.go
+++ b/internal/tarsserver/main_serve_api.go
@@ -406,7 +406,8 @@ func buildAPIMux(
 	}
 	projectStore := project.NewStore(cfg.WorkspaceDir, nil)
 	projectTaskRunner := gateway.NewProjectTaskRunner(gatewayRuntime, "")
-	projectProgressAfterHeartbeat = newProjectProgressAfterHeartbeat(projectStore, projectTaskRunner, deps.ask, logger)
+	projectSkillResolver := newExtensionsSkillResolver(extensionsManager)
+	projectProgressAfterHeartbeat = newProjectProgressAfterHeartbeat(projectStore, projectTaskRunner, deps.ask, projectSkillResolver, logger)
 	chatHandler := newChatAPIHandlerWithRuntimeConfig(
 		cfg.WorkspaceDir,
 		sessionStore,
@@ -419,7 +420,7 @@ func buildAPIMux(
 		chatTools...,
 	)
 	sessionHandler := newSessionAPIHandler(sessionStore, logger)
-	projectHandler := newProjectAPIHandler(projectStore, sessionStore, mainSessionID, projectTaskRunner, nil, logger)
+	projectHandler := newProjectAPIHandler(projectStore, sessionStore, mainSessionID, projectTaskRunner, nil, projectSkillResolver, logger)
 	consoleHandler, err := newConsoleHandler(logger)
 	if err != nil {
 		return nil, err

--- a/internal/tarsserver/skill_adapter.go
+++ b/internal/tarsserver/skill_adapter.go
@@ -1,0 +1,48 @@
+package tarsserver
+
+import (
+	"strings"
+
+	"github.com/devlikebear/tars/internal/extensions"
+	"github.com/devlikebear/tars/internal/project"
+)
+
+// extensionsSkillResolver adapts extensions.Manager into the
+// project.SkillResolver interface so that the orchestrator can inject
+// project-scoped skill content into task prompts.
+type extensionsSkillResolver struct {
+	manager *extensions.Manager
+}
+
+func newExtensionsSkillResolver(m *extensions.Manager) project.SkillResolver {
+	if m == nil {
+		return nil
+	}
+	return &extensionsSkillResolver{manager: m}
+}
+
+func (r *extensionsSkillResolver) ResolveSkills(names []string) []project.SkillContent {
+	if r == nil || r.manager == nil || len(names) == 0 {
+		return nil
+	}
+	out := make([]project.SkillContent, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		def, ok := r.manager.FindSkill(name)
+		if !ok {
+			continue
+		}
+		content := strings.TrimSpace(def.Content)
+		if content == "" {
+			continue
+		}
+		out = append(out, project.SkillContent{
+			Name:    def.Name,
+			Content: content,
+		})
+	}
+	return out
+}

--- a/internal/tool/tool_project.go
+++ b/internal/tool/tool_project.go
@@ -59,6 +59,7 @@ func NewProjectCreateTool(store *project.Store) Tool {
 				ExecutionMode   string                      `json:"execution_mode,omitempty"`
 				MaxPhases       int                         `json:"max_phases,omitempty"`
 				SubAgents       []project.SubAgentConfig    `json:"sub_agents,omitempty"`
+				SkillsAllow     []string                    `json:"skills_allow,omitempty"`
 			}
 			if err := json.Unmarshal(params, &input); err != nil {
 				return JSONTextResult(map[string]any{"message": fmt.Sprintf("invalid arguments: %v", err)}, true), nil
@@ -75,6 +76,7 @@ func NewProjectCreateTool(store *project.Store) Tool {
 				ExecutionMode:   input.ExecutionMode,
 				MaxPhases:       input.MaxPhases,
 				SubAgents:       input.SubAgents,
+				SkillsAllow:     input.SkillsAllow,
 			})
 			if err != nil {
 				return JSONTextResult(map[string]any{"message": err.Error()}, true), nil

--- a/pkg/tarsclient/types.go
+++ b/pkg/tarsclient/types.go
@@ -287,12 +287,13 @@ type Project struct {
 }
 
 type ProjectCreateRequest struct {
-	Name         string `json:"name"`
-	Type         string `json:"type,omitempty"`
-	GitRepo      string `json:"git_repo,omitempty"`
-	Objective    string `json:"objective,omitempty"`
-	Instructions string `json:"instructions,omitempty"`
-	CloneRepo    bool   `json:"clone_repo,omitempty"`
+	Name         string   `json:"name"`
+	Type         string   `json:"type,omitempty"`
+	GitRepo      string   `json:"git_repo,omitempty"`
+	Objective    string   `json:"objective,omitempty"`
+	Instructions string   `json:"instructions,omitempty"`
+	CloneRepo    bool     `json:"clone_repo,omitempty"`
+	SkillsAllow  []string `json:"skills_allow,omitempty"`
 }
 
 type ProjectUpdateRequest struct {


### PR DESCRIPTION
## Summary

- 프로젝트 생성 시 `skills_allow`를 지정하면, 자율 실행 태스크 프롬프트에 해당 스킬의 콘텐츠가 `## Project Skills` 섹션으로 주입됨
- `SkillResolver` 인터페이스로 dependency inversion — `project` 패키지가 `skill`/`extensions` 의존 없음
- 스킬당 4000자 cap, 최대 5개 스킬 제한으로 토큰 예산 관리
- 콘솔 UI에서 프로젝트 생성/편집 시 스킬 입력 필드 + 상세 뷰에 뱃지 표시

**배경**: `break-reminder` 프로젝트에서 codex-cli 에이전트가 GitHub 이슈 생성을 환각(gh CLI 미사용). 프로젝트별 스킬로 도메인 도구 사용법을 에이전트에게 전달하여 해결.

## Changes

- `internal/project/skill_resolver.go` — `SkillContent` + `SkillResolver` 인터페이스
- `internal/project/worker_profiles.go` — `BuildTaskPrompt`에 skills 가변인자, `writeSkillsSection` 헬퍼
- `internal/project/orchestrator.go` — `SetSkillResolver()`, `resolveProjectSkills()` 추가
- `internal/tarsserver/skill_adapter.go` — `extensions.Manager` → `SkillResolver` 어댑터
- `internal/tarsserver/` — heartbeat → dispatch 체인에 resolver threading
- `internal/project/store.go` — `CreateInput.SkillsAllow`
- `internal/tarsserver/handler_project.go` — POST API에 `skills_allow`
- `frontend/console/` — 생성/편집 폼 + 뱃지 UI

## Test plan

- [x] `TestBuildTaskPrompt_InjectsSkillContent` — 5개 서브테스트 (no skills, inject, truncation, cap, empty skip)
- [x] `TestOrchestratorDispatchTodo_InjectsProjectSkillsIntoPrompt` — mock resolver로 프롬프트 검증
- [x] `TestOrchestratorDispatchTodo_NoSkillsWhenResolverNil` — nil resolver 안전 확인
- [x] `make test` 전체 통과
- [x] `svelte-check` 0 errors