### PR TITLE
chore: ignore local logs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ coverage.out
 # Runtime
 *.db
 *.log
+logs/
 workspace/
 
 # Secrets


### PR DESCRIPTION
## Summary

- What problem does this PR solve?
  Prevents local runtime logs from showing up as untracked files in the repository.
- Why is this approach correct?
  Adding `logs/` to `.gitignore` ignores the local logs directory without affecting tracked files.

## Changes

- Main user-visible or developer-visible changes:
  Added `logs/` to `.gitignore`.
- API, config, or compatibility changes:
  None.

## Validation

- [ ] `make test`
- [ ] `make security-scan`
- [x] Additional manual verification, if needed

## Checklist

- [ ] Commit messages follow `feat/fix/chore`
- [ ] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [ ] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [ ] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level:
  Low
- Rollback plan:
  Revert the `.gitignore` entry if `logs/` should be tracked.