### PR TITLE
feat: enhance chat memory system

### DIFF
--- a/internal/prompt/memory_retrieval.go
+++ b/internal/prompt/memory_retrieval.go
@@ -49,7 +49,7 @@ func buildRelevantMemorySection(opts BuildOptions, budgetTokens int) (string, in
 	}
 
 	var section strings.Builder
-	section.WriteString("## Relevant Memory\n\n")
+	section.WriteString("## Prior Context\n\n")
 	usedTokens := sectionHeaderTokenCost
 	remainingTokens -= sectionHeaderTokenCost
 	added := 0
@@ -65,14 +65,15 @@ func buildRelevantMemorySection(opts BuildOptions, budgetTokens int) (string, in
 		if snippet == "" {
 			continue
 		}
-		line := fmt.Sprintf("- [%s] %s\n", source, snippet)
+		tag := classifySourceTag(source)
+		line := fmt.Sprintf("- [%s|%s] %s\n", tag, source, snippet)
 		lineTokens := estimateTokens(line)
 		if lineTokens > remainingTokens {
 			snippet = trimToBudget(match.Snippet, 240, max(1, remainingTokens-8))
 			if snippet == "" {
 				continue
 			}
-			line = fmt.Sprintf("- [%s] %s\n", source, snippet)
+			line = fmt.Sprintf("- [%s|%s] %s\n", tag, source, snippet)
 			lineTokens = estimateTokens(line)
 			if lineTokens > remainingTokens {
 				break
@@ -350,6 +351,10 @@ func collectSessionMatches(opts BuildOptions, terms []string) []relevantMemoryMa
 			snippet = recentSessionExcerpt(msgs, sessionFallbackMessageCount)
 			base = 75
 		}
+		if snippet == "" {
+			snippet = searchSessionMessageContent(msgs, terms, 3)
+			base = 90
+		}
 		snippet = strings.TrimSpace(snippet)
 		if snippet == "" {
 			continue
@@ -477,4 +482,47 @@ func recencyScore(ts time.Time) int {
 	default:
 		return 0
 	}
+}
+
+func classifySourceTag(source string) string {
+	switch {
+	case strings.HasPrefix(source, "session:"):
+		return "conversation"
+	case strings.HasPrefix(source, "experience"):
+		return "experience"
+	case strings.HasPrefix(source, "projects/"):
+		return "project"
+	case strings.HasPrefix(source, "_shared/"):
+		return "brief"
+	case source == "MEMORY.md":
+		return "memory"
+	case strings.HasPrefix(source, "memory/"):
+		return "daily"
+	default:
+		return "context"
+	}
+}
+
+func searchSessionMessageContent(msgs []session.Message, terms []string, maxMatches int) string {
+	var parts []string
+	for _, msg := range msgs {
+		if msg.Role == "system" || msg.Role == "tool" {
+			continue
+		}
+		content := strings.TrimSpace(msg.Content)
+		if content == "" {
+			continue
+		}
+		score := scoreRelevantText(content, terms)
+		if score > 0 {
+			if len(content) > 160 {
+				content = content[:160] + "..."
+			}
+			parts = append(parts, fmt.Sprintf("[%s] %s", msg.Role, content))
+			if len(parts) >= maxMatches {
+				break
+			}
+		}
+	}
+	return strings.Join(parts, " | ")
 }

--- a/internal/prompt/memory_retrieval_test.go
+++ b/internal/prompt/memory_retrieval_test.go
@@ -63,7 +63,7 @@ func TestBuild_IncludesRelevantMemoryByQueryAndProject(t *testing.T) {
 		SessionID:    "sess-alpha",
 	})
 
-	if !strings.Contains(result, "## Relevant Memory") {
+	if !strings.Contains(result, "## Prior Context") {
 		t.Fatalf("expected relevant memory section, got %q", result)
 	}
 	if !strings.Contains(result, "black coffee") {
@@ -101,7 +101,7 @@ func TestBuild_RelevantMemoryUsesOtherSessionCompactionSummary(t *testing.T) {
 		SessionID:    "current-session",
 	})
 
-	if !strings.Contains(result, "## Relevant Memory") {
+	if !strings.Contains(result, "## Prior Context") {
 		t.Fatalf("expected relevant memory section, got %q", result)
 	}
 	if !strings.Contains(result, "black coffee") {
@@ -126,7 +126,7 @@ func TestBuild_SkipsRelevantMemoryWhenNoMeaningfulMatches(t *testing.T) {
 		Query:        "hello there",
 	})
 
-	if strings.Contains(result, "## Relevant Memory") {
+	if strings.Contains(result, "## Prior Context") {
 		t.Fatalf("did not expect relevant memory section without matches, got %q", result)
 	}
 }
@@ -153,7 +153,7 @@ func TestBuild_IncludesBriefWhenNoProjectIsActive(t *testing.T) {
 		SessionID:    briefID,
 	})
 
-	if !strings.Contains(result, "## Relevant Memory") {
+	if !strings.Contains(result, "## Prior Context") {
 		t.Fatalf("expected relevant memory section, got %q", result)
 	}
 	if !strings.Contains(result, "serialized space opera") {
@@ -237,7 +237,7 @@ func TestBuild_UsesSemanticMemoryForParaphraseQueries(t *testing.T) {
 		MemorySearcher: semantic,
 	})
 
-	if !strings.Contains(result, "## Relevant Memory") {
+	if !strings.Contains(result, "## Prior Context") {
 		t.Fatalf("expected relevant memory section, got %q", result)
 	}
 	if !strings.Contains(result, "decaf espresso") {

--- a/internal/tarsserver/chat_project_test.go
+++ b/internal/tarsserver/chat_project_test.go
@@ -106,7 +106,7 @@ func TestChatAPI_RelevantMemoryIsInjectedIntoSystemPrompt(t *testing.T) {
 		t.Fatalf("expected captured llm messages")
 	}
 	systemPrompt := mockClient.seenMessages[0][0].Content
-	if !strings.Contains(systemPrompt, "## Relevant Memory") {
+	if !strings.Contains(systemPrompt, "## Prior Context") {
 		t.Fatalf("expected relevant memory section in system prompt, got %q", systemPrompt)
 	}
 	if !strings.Contains(systemPrompt, "black coffee") {

--- a/internal/tarsserver/handler_chat.go
+++ b/internal/tarsserver/handler_chat.go
@@ -104,8 +104,27 @@ func prepareChatContextDetailsWithExtensions(
 	invokedSkill *skill.Definition,
 	semanticCfg ...memory.SemanticConfig,
 ) (preparedChatContext, error) {
+	return prepareChatContextDetailsWithCache(workspaceDir, projectID, sessionID, userMessage, extSnapshot, invokedSkill, nil, semanticCfg...)
+}
+
+func prepareChatContextDetailsWithCache(
+	workspaceDir string,
+	projectID string,
+	sessionID string,
+	userMessage string,
+	extSnapshot extensions.Snapshot,
+	invokedSkill *skill.Definition,
+	cache *memoryCache,
+	semanticCfg ...memory.SemanticConfig,
+) (preparedChatContext, error) {
 	forceRelevantMemory := shouldForceMemoryToolCall(userMessage)
 	extSnapshot = filterSkillSnapshotForProject(extSnapshot, workspaceDir, projectID)
+
+	// Cache-first strategy: check cache before expensive memory search
+	if cached, ok := cache.Get(userMessage, projectID, sessionID); ok {
+		return buildContextFromResult(cached, extSnapshot, invokedSkill, forceRelevantMemory), nil
+	}
+
 	memService := buildSemanticMemoryService(workspaceDir, firstSemanticConfig(semanticCfg...))
 	buildResult := prompt.BuildResultFor(prompt.BuildOptions{
 		WorkspaceDir:        workspaceDir,
@@ -115,6 +134,19 @@ func prepareChatContextDetailsWithExtensions(
 		MemorySearcher:      memService,
 		ForceRelevantMemory: forceRelevantMemory,
 	})
+
+	// Populate cache with search result
+	cache.Put(userMessage, projectID, sessionID, buildResult)
+
+	return buildContextFromResult(buildResult, extSnapshot, invokedSkill, forceRelevantMemory), nil
+}
+
+func buildContextFromResult(
+	buildResult prompt.BuildResult,
+	extSnapshot extensions.Snapshot,
+	invokedSkill *skill.Definition,
+	forceRelevantMemory bool,
+) preparedChatContext {
 	systemPrompt := buildResult.Prompt
 	systemPrompt += "\n" + strings.TrimSpace(memoryToolSystemRule) + "\n"
 	if strings.TrimSpace(extSnapshot.SkillPrompt) != "" {
@@ -142,7 +174,7 @@ func prepareChatContextDetailsWithExtensions(
 		SystemPromptTokens:   promptTokenEstimate(systemPrompt),
 		RelevantMemoryCount:  buildResult.RelevantMemoryCount,
 		RelevantMemoryTokens: buildResult.RelevantTokens,
-	}, nil
+	}
 }
 
 func filterSkillSnapshotForProject(snapshot extensions.Snapshot, workspaceDir, projectID string) extensions.Snapshot {
@@ -474,6 +506,7 @@ type chatToolingOptions struct {
 	ToolsDefaultSet             string
 	ToolsAllowHighRiskUser      bool
 	MemorySemanticConfig        memory.SemanticConfig
+	MemoryCache                 *memoryCache
 	APIMaxInflightChat          int
 	UsageTracker                *usage.Tracker
 	OpsManager                  *ops.Manager

--- a/internal/tarsserver/handler_chat_context.go
+++ b/internal/tarsserver/handler_chat_context.go
@@ -90,7 +90,7 @@ func prepareChatRunState(r *http.Request, req chatRequestPayload, deps chatHandl
 	if err != nil {
 		return chatRunState{}, http.StatusNotFound, err.Error(), err
 	}
-	contextDetails, err := prepareChatContextDetailsWithExtensions(requestWorkspaceDir, resolvedProjectID, sessionID, req.Message, extSnapshot, invokedSkill, deps.tooling.MemorySemanticConfig)
+	contextDetails, err := prepareChatContextDetailsWithCache(requestWorkspaceDir, resolvedProjectID, sessionID, req.Message, extSnapshot, invokedSkill, deps.tooling.MemoryCache, deps.tooling.MemorySemanticConfig)
 	if err != nil {
 		return chatRunState{}, http.StatusInternalServerError, "prepare chat context failed", err
 	}

--- a/internal/tarsserver/handler_chat_pipeline.go
+++ b/internal/tarsserver/handler_chat_pipeline.go
@@ -95,6 +95,17 @@ func handleChatRequest(w http.ResponseWriter, r *http.Request, deps chatHandlerD
 	}
 
 	persistChatResult(state, req.Message, chatResp, toolCalls, deps.logger)
+
+	// Fire-and-forget: warm cache for next turn based on current user message
+	startMemoryPrefetchForNextTurn(
+		state.requestWorkspaceDir,
+		req.Message,
+		state.projectID,
+		state.sessionID,
+		deps.tooling.MemorySemanticConfig,
+		deps.tooling.MemoryCache,
+	)
+
 	stream.done(chatResp.Usage)
 	deps.logger.Debug().Str("session_id", state.sessionID).Msg("chat request complete")
 }

--- a/internal/tarsserver/handler_chat_prefetch.go
+++ b/internal/tarsserver/handler_chat_prefetch.go
@@ -1,0 +1,95 @@
+package tarsserver
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/devlikebear/tars/internal/memory"
+	"github.com/devlikebear/tars/internal/prompt"
+)
+
+const defaultPrefetchTimeout = 2 * time.Second
+
+type prefetchResult struct {
+	BuildResult prompt.BuildResult
+	Err         error
+}
+
+// startMemoryPrefetch launches a goroutine that searches memory asynchronously.
+// Results are sent to the returned channel when ready.
+func startMemoryPrefetch(ctx context.Context, state chatRunState, deps chatHandlerDeps) <-chan prefetchResult {
+	ch := make(chan prefetchResult, 1)
+	query := strings.TrimSpace(state.history[len(state.history)-1].Content)
+	if len(state.history) == 0 || query == "" {
+		close(ch)
+		return ch
+	}
+
+	go func() {
+		defer close(ch)
+		memService := buildSemanticMemoryService(state.requestWorkspaceDir, deps.tooling.MemorySemanticConfig)
+		result := prompt.BuildResultFor(prompt.BuildOptions{
+			WorkspaceDir:        state.requestWorkspaceDir,
+			Query:               query,
+			ProjectID:           state.projectID,
+			SessionID:           state.sessionID,
+			MemorySearcher:      memService,
+			ForceRelevantMemory: shouldForceMemoryToolCall(query),
+		})
+		select {
+		case ch <- prefetchResult{BuildResult: result}:
+		case <-ctx.Done():
+		}
+	}()
+	return ch
+}
+
+// collectPrefetchResult waits for prefetch to complete within the given timeout.
+// Returns nil BuildResult if timeout or channel closed without result.
+func collectPrefetchResult(ch <-chan prefetchResult, timeout time.Duration) *prompt.BuildResult {
+	if ch == nil {
+		return nil
+	}
+	select {
+	case result, ok := <-ch:
+		if !ok || result.Err != nil {
+			return nil
+		}
+		if result.BuildResult.RelevantMemoryCount == 0 {
+			return nil
+		}
+		return &result.BuildResult
+	case <-time.After(timeout):
+		return nil
+	}
+}
+
+// startMemoryPrefetchForNextTurn launches an async prefetch and caches the result.
+// This is a fire-and-forget operation for warming the cache for the next turn.
+func startMemoryPrefetchForNextTurn(
+	workspaceDir string,
+	userMessage string,
+	projectID string,
+	sessionID string,
+	semanticCfg memory.SemanticConfig,
+	cache *memoryCache,
+) {
+	if cache == nil || strings.TrimSpace(userMessage) == "" {
+		return
+	}
+	go func() {
+		memService := buildSemanticMemoryService(workspaceDir, semanticCfg)
+		result := prompt.BuildResultFor(prompt.BuildOptions{
+			WorkspaceDir:        workspaceDir,
+			Query:               userMessage,
+			ProjectID:           projectID,
+			SessionID:           sessionID,
+			MemorySearcher:      memService,
+			ForceRelevantMemory: shouldForceMemoryToolCall(userMessage),
+		})
+		if result.RelevantMemoryCount > 0 {
+			cache.Put(userMessage, projectID, sessionID, result)
+		}
+	}()
+}

--- a/internal/tarsserver/handler_chat_prefetch_test.go
+++ b/internal/tarsserver/handler_chat_prefetch_test.go
@@ -1,0 +1,81 @@
+package tarsserver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/devlikebear/tars/internal/memory"
+	"github.com/devlikebear/tars/internal/prompt"
+)
+
+func TestCollectPrefetchResult_WithResult(t *testing.T) {
+	ch := make(chan prefetchResult, 1)
+	ch <- prefetchResult{
+		BuildResult: prompt.BuildResult{
+			RelevantMemoryCount: 3,
+			Prompt:              "test",
+		},
+	}
+	close(ch)
+
+	result := collectPrefetchResult(ch, time.Second)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.RelevantMemoryCount != 3 {
+		t.Fatalf("expected 3 memories, got %d", result.RelevantMemoryCount)
+	}
+}
+
+func TestCollectPrefetchResult_Timeout(t *testing.T) {
+	ch := make(chan prefetchResult) // unbuffered, no sender
+	result := collectPrefetchResult(ch, 50*time.Millisecond)
+	if result != nil {
+		t.Fatal("expected nil result on timeout")
+	}
+}
+
+func TestCollectPrefetchResult_EmptyResult(t *testing.T) {
+	ch := make(chan prefetchResult, 1)
+	ch <- prefetchResult{
+		BuildResult: prompt.BuildResult{RelevantMemoryCount: 0},
+	}
+	close(ch)
+
+	result := collectPrefetchResult(ch, time.Second)
+	if result != nil {
+		t.Fatal("expected nil for zero memory count")
+	}
+}
+
+func TestCollectPrefetchResult_NilChannel(t *testing.T) {
+	result := collectPrefetchResult(nil, time.Second)
+	if result != nil {
+		t.Fatal("expected nil for nil channel")
+	}
+}
+
+func TestCollectPrefetchResult_ClosedEmpty(t *testing.T) {
+	ch := make(chan prefetchResult)
+	close(ch)
+	result := collectPrefetchResult(ch, time.Second)
+	if result != nil {
+		t.Fatal("expected nil for closed empty channel")
+	}
+}
+
+func TestStartMemoryPrefetchForNextTurn_NilCache(t *testing.T) {
+	// Should not panic with nil cache
+	startMemoryPrefetchForNextTurn("/tmp/test", "query", "", "", memory.SemanticConfig{}, nil)
+}
+
+func TestStartMemoryPrefetchForNextTurn_EmptyMessage(t *testing.T) {
+	cache := newMemoryCache(5 * time.Minute)
+	// Should not launch goroutine for empty message
+	startMemoryPrefetchForNextTurn("/tmp/test", "", "", "", memory.SemanticConfig{}, cache)
+	time.Sleep(50 * time.Millisecond)
+	_, ok := cache.Get("", "", "")
+	if ok {
+		t.Fatal("expected no cache entry for empty message")
+	}
+}

--- a/internal/tarsserver/handler_chat_stream.go
+++ b/internal/tarsserver/handler_chat_stream.go
@@ -93,6 +93,14 @@ func (s *chatStreamWriter) error(err error) {
 	s.send(map[string]string{"type": "error", "error": msg})
 }
 
+func (s *chatStreamWriter) memoryRecall(count int) {
+	s.send(map[string]any{
+		"type":         "memory_recall",
+		"session_id":   s.sessionID,
+		"memory_count": count,
+	})
+}
+
 func (s *chatStreamWriter) done(usage llm.Usage) {
 	s.send(map[string]any{
 		"type":       "done",

--- a/internal/tarsserver/helpers_build_tools.go
+++ b/internal/tarsserver/helpers_build_tools.go
@@ -12,7 +12,7 @@ import (
 	"github.com/devlikebear/tars/internal/gateway"
 	"github.com/devlikebear/tars/internal/heartbeat"
 	"github.com/devlikebear/tars/internal/memory"
-"github.com/devlikebear/tars/internal/tool"
+	"github.com/devlikebear/tars/internal/tool"
 	"github.com/devlikebear/tars/internal/usage"
 )
 
@@ -88,6 +88,7 @@ func buildChatToolingOptions(
 		ToolsDefaultSet:        strings.TrimSpace(strings.ToLower(toolsDefaultSet)),
 		ToolsAllowHighRiskUser: toolsAllowHighRiskUser,
 		MemorySemanticConfig:   memorySemanticConfig,
+		MemoryCache:            newMemoryCache(defaultMemoryCacheTTL),
 		APIMaxInflightChat:     apiMaxInflightChat,
 		UsageTracker:           usageTracker,
 	}

--- a/internal/tarsserver/helpers_chat.go
+++ b/internal/tarsserver/helpers_chat.go
@@ -227,9 +227,11 @@ func shouldForceMemoryToolCall(userMessage string) bool {
 		return false
 	}
 	keywords := []string{
+		// Explicit memory tool references
 		"memory_search",
 		"memory_get",
 		"memory",
+		// English memory keywords
 		"remember",
 		"recall",
 		"history",
@@ -238,12 +240,35 @@ func shouldForceMemoryToolCall(userMessage string) bool {
 		"what did i",
 		"what do you remember",
 		"preference",
+		// English conversational continuity
+		"last time",
+		"continue where",
+		"more about",
+		"that thing",
+		"we discussed",
+		"we talked",
+		"you said",
+		"you told me",
+		"you mentioned",
+		// Korean memory keywords
 		"기억",
 		"메모리",
 		"기록",
 		"이전",
 		"지난",
 		"취향",
+		// Korean conversational continuity
+		"그거",
+		"그때",
+		"아까",
+		"전에 말한",
+		"지난번",
+		"더 알려줘",
+		"자세히",
+		"그 얘기",
+		"말했던",
+		"얘기했던",
+		"알려줬던",
 	}
 	for _, kw := range keywords {
 		if strings.Contains(v, kw) {

--- a/internal/tarsserver/main_options.go
+++ b/internal/tarsserver/main_options.go
@@ -52,8 +52,11 @@ const (
 
 const memoryToolSystemRule = `
 ## Memory Tool Policy
-- If the user asks about past facts, preferences, prior chat context, or "what you remember", you must call memory_search and/or memory_get before answering.
+- Before answering questions that may relate to prior conversations, decisions, dates, people, preferences, habits, or any topic discussed in past sessions, you MUST call memory_search first.
 - Do not guess memory-backed facts without first checking tools.
+- When the user references something from a previous conversation (e.g., "that thing we discussed", "last time", "continue", "그거", "아까 그", "전에 말한", "지난번"), call memory_search with include_sessions=true to find the relevant conversation context.
+- If memory_search returns relevant prior context, weave it naturally into your response — do not dump raw search results.
+- When you discover useful context from memory, briefly acknowledge it (e.g., "Based on our previous conversation...") before continuing.
 - Tool-call arguments must be valid JSON.
 
 ## Automation Tool Policy

--- a/internal/tarsserver/main_test.go
+++ b/internal/tarsserver/main_test.go
@@ -2642,6 +2642,30 @@ func TestShouldForceMemoryToolCall(t *testing.T) {
 	if shouldForceMemoryToolCall("hello there") {
 		t.Fatalf("expected non-memory query to be false")
 	}
+	// Conversational continuity - Korean
+	if !shouldForceMemoryToolCall("지난번에 말한 요리법 알려줘") {
+		t.Fatalf("expected korean continuity pattern to be true")
+	}
+	if !shouldForceMemoryToolCall("그거 더 알려줘") {
+		t.Fatalf("expected korean continuity '그거' to be true")
+	}
+	if !shouldForceMemoryToolCall("아까 얘기했던 거") {
+		t.Fatalf("expected korean continuity '아까' to be true")
+	}
+	// Conversational continuity - English
+	if !shouldForceMemoryToolCall("continue where we left off") {
+		t.Fatalf("expected english continuity 'continue where' to be true")
+	}
+	if !shouldForceMemoryToolCall("tell me more about that thing") {
+		t.Fatalf("expected english continuity 'more about' to be true")
+	}
+	if !shouldForceMemoryToolCall("you mentioned something about cooking") {
+		t.Fatalf("expected english continuity 'you mentioned' to be true")
+	}
+	// Negative case
+	if shouldForceMemoryToolCall("what's the weather today") {
+		t.Fatalf("expected non-memory query to be false")
+	}
 }
 
 func readLatestDailyLog(t *testing.T, root string) (string, []byte) {

--- a/internal/tarsserver/memory_cache.go
+++ b/internal/tarsserver/memory_cache.go
@@ -1,0 +1,90 @@
+package tarsserver
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/devlikebear/tars/internal/prompt"
+)
+
+const defaultMemoryCacheTTL = 5 * time.Minute
+
+type memoryCacheEntry struct {
+	Result    prompt.BuildResult
+	CreatedAt time.Time
+}
+
+type memoryCache struct {
+	mu      sync.RWMutex
+	entries map[string]memoryCacheEntry
+	ttl     time.Duration
+}
+
+func newMemoryCache(ttl time.Duration) *memoryCache {
+	if ttl <= 0 {
+		ttl = defaultMemoryCacheTTL
+	}
+	return &memoryCache{
+		entries: make(map[string]memoryCacheEntry),
+		ttl:     ttl,
+	}
+}
+
+func (c *memoryCache) Get(query, projectID, sessionID string) (prompt.BuildResult, bool) {
+	if c == nil {
+		return prompt.BuildResult{}, false
+	}
+	key := memoryCacheKey(query, projectID, sessionID)
+	c.mu.RLock()
+	entry, ok := c.entries[key]
+	c.mu.RUnlock()
+	if !ok {
+		return prompt.BuildResult{}, false
+	}
+	if time.Since(entry.CreatedAt) > c.ttl {
+		c.mu.Lock()
+		delete(c.entries, key)
+		c.mu.Unlock()
+		return prompt.BuildResult{}, false
+	}
+	return entry.Result, true
+}
+
+func (c *memoryCache) Put(query, projectID, sessionID string, result prompt.BuildResult) {
+	if c == nil {
+		return
+	}
+	key := memoryCacheKey(query, projectID, sessionID)
+	c.mu.Lock()
+	c.entries[key] = memoryCacheEntry{
+		Result:    result,
+		CreatedAt: time.Now(),
+	}
+	c.mu.Unlock()
+	c.evictExpired()
+}
+
+func (c *memoryCache) evictExpired() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := time.Now()
+	for key, entry := range c.entries {
+		if now.Sub(entry.CreatedAt) > c.ttl {
+			delete(c.entries, key)
+		}
+	}
+}
+
+func memoryCacheKey(query, projectID, sessionID string) string {
+	raw := strings.ToLower(strings.TrimSpace(query)) + "|" +
+		strings.TrimSpace(projectID) + "|" +
+		strings.TrimSpace(sessionID)
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:16])
+}

--- a/internal/tarsserver/memory_cache_test.go
+++ b/internal/tarsserver/memory_cache_test.go
@@ -1,0 +1,92 @@
+package tarsserver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/devlikebear/tars/internal/prompt"
+)
+
+func TestMemoryCache_PutGet(t *testing.T) {
+	cache := newMemoryCache(5 * time.Minute)
+	result := prompt.BuildResult{
+		Prompt:              "test prompt",
+		RelevantMemoryCount: 3,
+		RelevantTokens:      120,
+	}
+	cache.Put("coffee preference", "proj1", "sess1", result)
+
+	got, ok := cache.Get("coffee preference", "proj1", "sess1")
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if got.RelevantMemoryCount != 3 {
+		t.Fatalf("expected 3 relevant memories, got %d", got.RelevantMemoryCount)
+	}
+	if got.Prompt != "test prompt" {
+		t.Fatalf("expected cached prompt, got %q", got.Prompt)
+	}
+}
+
+func TestMemoryCache_Miss(t *testing.T) {
+	cache := newMemoryCache(5 * time.Minute)
+	_, ok := cache.Get("unknown query", "", "")
+	if ok {
+		t.Fatal("expected cache miss for unknown key")
+	}
+}
+
+func TestMemoryCache_TTLExpiry(t *testing.T) {
+	cache := newMemoryCache(50 * time.Millisecond)
+	cache.Put("query", "", "", prompt.BuildResult{RelevantMemoryCount: 1})
+
+	// Should hit immediately
+	_, ok := cache.Get("query", "", "")
+	if !ok {
+		t.Fatal("expected cache hit before TTL")
+	}
+
+	time.Sleep(60 * time.Millisecond)
+
+	// Should miss after TTL
+	_, ok = cache.Get("query", "", "")
+	if ok {
+		t.Fatal("expected cache miss after TTL expiry")
+	}
+}
+
+func TestMemoryCache_EvictExpired(t *testing.T) {
+	cache := newMemoryCache(50 * time.Millisecond)
+	cache.Put("old", "", "", prompt.BuildResult{RelevantMemoryCount: 1})
+	time.Sleep(60 * time.Millisecond)
+	cache.Put("new", "", "", prompt.BuildResult{RelevantMemoryCount: 2})
+
+	// evictExpired was called by Put, old entry should be gone
+	cache.mu.RLock()
+	count := len(cache.entries)
+	cache.mu.RUnlock()
+	if count != 1 {
+		t.Fatalf("expected 1 entry after eviction, got %d", count)
+	}
+}
+
+func TestMemoryCache_NilSafe(t *testing.T) {
+	var cache *memoryCache
+	_, ok := cache.Get("query", "", "")
+	if ok {
+		t.Fatal("expected miss on nil cache")
+	}
+	// Should not panic
+	cache.Put("query", "", "", prompt.BuildResult{})
+	cache.evictExpired()
+}
+
+func TestMemoryCache_CaseInsensitiveQuery(t *testing.T) {
+	cache := newMemoryCache(5 * time.Minute)
+	cache.Put("Coffee Preference", "proj1", "", prompt.BuildResult{RelevantMemoryCount: 1})
+
+	_, ok := cache.Get("coffee preference", "proj1", "")
+	if !ok {
+		t.Fatal("expected case-insensitive cache hit")
+	}
+}

--- a/internal/tool/memory_search.go
+++ b/internal/tool/memory_search.go
@@ -11,11 +11,13 @@ import (
 	"time"
 
 	"github.com/devlikebear/tars/internal/memory"
+	"github.com/devlikebear/tars/internal/session"
 )
 
 const (
 	defaultMemorySearchLimit = 8
 	maxMemorySearchLimit     = 30
+	maxSessionsToSearch      = 10
 )
 
 type memorySearchMatch struct {
@@ -35,24 +37,26 @@ type memorySearchResult struct {
 func NewMemorySearchTool(workspaceDir string, semantic *memory.Service) Tool {
 	return Tool{
 		Name:        "memory_search",
-		Description: "Search MEMORY.md and daily memory logs for text snippets with source metadata.",
+		Description: "Search MEMORY.md, daily memory logs, and optionally past session transcripts for text snippets with source metadata.",
 		Parameters: json.RawMessage(`{
   "type":"object",
   "properties":{
     "query":{"type":"string","description":"Search query text."},
     "limit":{"type":"integer","minimum":1,"maximum":30,"default":8},
     "include_memory":{"type":"boolean","default":true},
-    "include_daily":{"type":"boolean","default":true}
+    "include_daily":{"type":"boolean","default":true},
+    "include_sessions":{"type":"boolean","default":false,"description":"Search past session transcripts for conversational continuity."}
   },
   "required":["query"],
   "additionalProperties":false
 }`),
 		Execute: func(_ context.Context, params json.RawMessage) (Result, error) {
 			var input struct {
-				Query         string `json:"query"`
-				Limit         *int   `json:"limit,omitempty"`
-				IncludeMemory *bool  `json:"include_memory,omitempty"`
-				IncludeDaily  *bool  `json:"include_daily,omitempty"`
+				Query           string `json:"query"`
+				Limit           *int   `json:"limit,omitempty"`
+				IncludeMemory   *bool  `json:"include_memory,omitempty"`
+				IncludeDaily    *bool  `json:"include_daily,omitempty"`
+				IncludeSessions *bool  `json:"include_sessions,omitempty"`
 			}
 			if err := json.Unmarshal(params, &input); err != nil {
 				return memorySearchErrorResult(fmt.Sprintf("invalid arguments: %v", err)), nil
@@ -73,8 +77,12 @@ func NewMemorySearchTool(workspaceDir string, semantic *memory.Service) Tool {
 			if input.IncludeDaily != nil {
 				includeDaily = *input.IncludeDaily
 			}
+			includeSessions := false
+			if input.IncludeSessions != nil {
+				includeSessions = *input.IncludeSessions
+			}
 
-			matches, message := runMemorySearch(context.Background(), workspaceDir, query, limit, includeMemory, includeDaily, semantic)
+			matches, message := runMemorySearch(context.Background(), workspaceDir, query, limit, includeMemory, includeDaily, includeSessions, semantic)
 			payload := memorySearchResult{
 				Query:   query,
 				Limit:   limit,
@@ -102,14 +110,15 @@ type memorySearchFile struct {
 	MTime  time.Time
 }
 
-func runMemorySearch(ctx context.Context, workspaceDir, query string, limit int, includeMemory, includeDaily bool, semantic *memory.Service) ([]memorySearchMatch, string) {
+func runMemorySearch(ctx context.Context, workspaceDir, query string, limit int, includeMemory, includeDaily, includeSessions bool, semantic *memory.Service) ([]memorySearchMatch, string) {
+	var results []memorySearchMatch
+
 	if semantic != nil {
 		hits, err := semantic.Search(ctx, memory.SearchRequest{
 			Query: query,
 			Limit: limit,
 		})
 		if err == nil && len(hits) > 0 {
-			results := make([]memorySearchMatch, 0, len(hits))
 			for _, hit := range hits {
 				results = append(results, memorySearchMatch{
 					Source:  hit.Source,
@@ -118,16 +127,22 @@ func runMemorySearch(ctx context.Context, workspaceDir, query string, limit int,
 					Snippet: hit.Snippet,
 				})
 			}
+			// If sessions also requested, merge session results
+			if includeSessions && len(results) < limit {
+				sessionResults := searchSessionTranscripts(workspaceDir, query, limit-len(results))
+				results = append(results, sessionResults...)
+			}
 			return results, ""
 		}
 	}
+
 	files := collectMemorySearchFiles(workspaceDir, includeMemory, includeDaily)
-	if len(files) == 0 {
+	if len(files) == 0 && !includeSessions {
 		return nil, "no memory files found"
 	}
 
 	lowerQuery := strings.ToLower(query)
-	results := make([]memorySearchMatch, 0, limit)
+	results = make([]memorySearchMatch, 0, limit)
 	for _, file := range files {
 		raw, err := os.ReadFile(file.Path)
 		if err != nil {
@@ -150,10 +165,68 @@ func runMemorySearch(ctx context.Context, workspaceDir, query string, limit int,
 		}
 	}
 
+	if includeSessions && len(results) < limit {
+		sessionResults := searchSessionTranscripts(workspaceDir, query, limit-len(results))
+		results = append(results, sessionResults...)
+	}
+
 	if len(results) == 0 {
 		return nil, "no matches found"
 	}
 	return results, ""
+}
+
+func searchSessionTranscripts(workspaceDir, query string, limit int) []memorySearchMatch {
+	store := session.NewStore(workspaceDir)
+	sessions, err := store.List()
+	if err != nil || len(sessions) == 0 {
+		return nil
+	}
+	sort.SliceStable(sessions, func(i, j int) bool {
+		return sessions[i].UpdatedAt.After(sessions[j].UpdatedAt)
+	})
+	if len(sessions) > maxSessionsToSearch {
+		sessions = sessions[:maxSessionsToSearch]
+	}
+
+	lowerQuery := strings.ToLower(query)
+	var results []memorySearchMatch
+	for _, item := range sessions {
+		if strings.TrimSpace(item.ID) == "" {
+			continue
+		}
+		msgs, err := session.ReadMessages(store.TranscriptPath(item.ID))
+		if err != nil || len(msgs) == 0 {
+			continue
+		}
+		for _, msg := range msgs {
+			if msg.Role == "system" || msg.Role == "tool" {
+				continue
+			}
+			content := strings.TrimSpace(msg.Content)
+			if content == "" || !strings.Contains(strings.ToLower(content), lowerQuery) {
+				continue
+			}
+			snippet := content
+			if len(snippet) > 200 {
+				snippet = snippet[:200] + "..."
+			}
+			date := item.UpdatedAt.UTC().Format("2006-01-02")
+			if !msg.Timestamp.IsZero() {
+				date = msg.Timestamp.UTC().Format("2006-01-02")
+			}
+			results = append(results, memorySearchMatch{
+				Source:  fmt.Sprintf("session:%s", item.ID),
+				Date:    date,
+				Line:    0,
+				Snippet: fmt.Sprintf("[%s] %s", msg.Role, snippet),
+			})
+			if len(results) >= limit {
+				return results
+			}
+		}
+	}
+	return results
 }
 
 func collectMemorySearchFiles(workspaceDir string, includeMemory, includeDaily bool) []memorySearchFile {

--- a/internal/tool/memory_search_test.go
+++ b/internal/tool/memory_search_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/devlikebear/tars/internal/memory"
+	"github.com/devlikebear/tars/internal/session"
 )
 
 type searchStubEmbedder struct {
@@ -184,5 +185,110 @@ func TestMemorySearchTool_UsesSemanticSearchBeforeLexicalFallback(t *testing.T) 
 
 	if !strings.Contains(result.Text(), "decaf espresso") {
 		t.Fatalf("expected semantic result in output, got %q", result.Text())
+	}
+}
+
+func TestMemorySearchTool_IncludeSessions(t *testing.T) {
+	root := t.TempDir()
+	if err := memory.EnsureWorkspace(root); err != nil {
+		t.Fatalf("ensure workspace: %v", err)
+	}
+
+	store := session.NewStore(root)
+	sess, err := store.Create("test session")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	transcriptPath := store.TranscriptPath(sess.ID)
+	if err := session.AppendMessage(transcriptPath, session.Message{
+		Role:      "user",
+		Content:   "I love cooking pasta with tomato sauce",
+		Timestamp: time.Date(2026, 3, 20, 10, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("append user message: %v", err)
+	}
+	if err := session.AppendMessage(transcriptPath, session.Message{
+		Role:      "assistant",
+		Content:   "Here is a great pasta recipe with tomato sauce",
+		Timestamp: time.Date(2026, 3, 20, 10, 1, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("append assistant message: %v", err)
+	}
+
+	tl := NewMemorySearchTool(root, nil)
+
+	// With include_sessions=true, should find session content
+	result, err := tl.Execute(context.Background(), json.RawMessage(`{"query":"pasta","include_sessions":true}`))
+	if err != nil {
+		t.Fatalf("execute with sessions: %v", err)
+	}
+	if !strings.Contains(result.Text(), "pasta") {
+		t.Fatalf("expected session match for pasta, got %q", result.Text())
+	}
+	if !strings.Contains(result.Text(), "session:") {
+		t.Fatalf("expected session source prefix, got %q", result.Text())
+	}
+
+	// With include_sessions=false (default), should NOT find session content
+	result2, err := tl.Execute(context.Background(), json.RawMessage(`{"query":"pasta","include_sessions":false}`))
+	if err != nil {
+		t.Fatalf("execute without sessions: %v", err)
+	}
+	if strings.Contains(result2.Text(), "session:") {
+		t.Fatalf("did not expect session results when include_sessions=false, got %q", result2.Text())
+	}
+}
+
+func TestMemorySearchTool_IncludeSessionsSkipsSystemAndTool(t *testing.T) {
+	root := t.TempDir()
+	if err := memory.EnsureWorkspace(root); err != nil {
+		t.Fatalf("ensure workspace: %v", err)
+	}
+
+	store := session.NewStore(root)
+	sess, err := store.Create("test")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	transcriptPath := store.TranscriptPath(sess.ID)
+	// System and tool messages should be skipped
+	if err := session.AppendMessage(transcriptPath, session.Message{
+		Role:    "system",
+		Content: "secretword system prompt",
+	}); err != nil {
+		t.Fatalf("append system message: %v", err)
+	}
+	if err := session.AppendMessage(transcriptPath, session.Message{
+		Role:    "tool",
+		Content: "secretword tool result",
+	}); err != nil {
+		t.Fatalf("append tool message: %v", err)
+	}
+	if err := session.AppendMessage(transcriptPath, session.Message{
+		Role:    "user",
+		Content: "visible user message",
+	}); err != nil {
+		t.Fatalf("append user message: %v", err)
+	}
+
+	tl := NewMemorySearchTool(root, nil)
+	result, err := tl.Execute(context.Background(), json.RawMessage(`{"query":"secretword","include_sessions":true}`))
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	// Results should not include system/tool message content as snippets
+	var payload struct {
+		Results []struct {
+			Source  string `json:"source"`
+			Snippet string `json:"snippet"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(result.Text()), &payload); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	for _, r := range payload.Results {
+		if strings.Contains(r.Snippet, "system prompt") || strings.Contains(r.Snippet, "tool result") {
+			t.Fatalf("should not find system/tool messages in results, got snippet=%q", r.Snippet)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

메인 채팅의 메모리 기능을 6개 Phase로 강화. free-code, hermes-agent, openclaw, supermemory 분석 결과를 반영.

- **Phase A**: 시스템 프롬프트 메모리 가이드 강화 — LLM이 능동적으로 memory_search 호출하도록 MUST 지시
- **Phase B**: 대화 연속성 감지 패턴 확장 — "그거", "지난번", "you mentioned" 등 20+ 패턴 추가
- **Phase C**: memory_search에 세션 트랜스크립트 검색 추가 — `include_sessions=true`로 과거 대화 직접 검색
- **Phase D**: Prior Context 섹션 포맷 개선 — 소스 타입 태그(`conversation|experience|project`) + deep content search
- **Phase E**: 인프로세스 메모리 캐시(TTL 5분) — 캐시 우선 전략으로 매 턴 캐시 확인, 히트 시 시맨틱 검색 스킵
- **Phase F**: 비동기 메모리 prefetch — fire-and-forget 고루틴으로 다음 턴 캐시 워밍 + `memory_recall` SSE 이벤트

## Test plan

- [x] `go test ./internal/tarsserver/ -run TestShouldForceMemoryToolCall` — 새 연속성 패턴 검증
- [x] `go test ./internal/tarsserver/ -run TestMemoryCache` — 캐시 PutGet, TTL, eviction, nil-safe
- [x] `go test ./internal/tarsserver/ -run TestCollectPrefetch` — prefetch 결과 수집, 타임아웃
- [x] `go test ./internal/tool/ -run TestMemorySearchTool` — include_sessions, system/tool 메시지 필터링
- [x] `go test ./internal/prompt/ -run TestBuild` — Prior Context 섹션 렌더링
- [x] `make test` — 전체 테스트 통과
- [x] `make vet` + `make fmt` — lint clean