### PR TITLE
feat: use ~/.tars as default home for config and workspace

### DIFF
--- a/cmd/tars/doctor_main.go
+++ b/cmd/tars/doctor_main.go
@@ -90,7 +90,7 @@ func buildDoctorReport(opts doctorOptions) (doctorReport, error) {
 		report.add("fixed", "config file", fmt.Sprintf("created starter config at %s", configPath))
 	default:
 		report.add("fail", "config file", fmt.Sprintf("missing: %s", configPath))
-		report.addHint(fmt.Sprintf("run `tars doctor --workspace-dir %s --fix` to create starter files", workspaceAbs))
+		report.addHint("run `tars doctor --fix` to create starter files")
 	}
 
 	cfg, cfgLoaded := config.Config{}, false
@@ -127,7 +127,7 @@ func buildDoctorReport(opts doctorOptions) (doctorReport, error) {
 			}
 		default:
 			report.add("fail", "workspace", fmt.Sprintf("missing starter paths in %s: %s", runtimeWorkspaceAbs, strings.Join(missing, ", ")))
-			report.addHint(fmt.Sprintf("run `tars doctor --workspace-dir %s --fix` to create missing workspace files", runtimeWorkspaceAbs))
+			report.addHint("run `tars doctor --fix` to create missing workspace files")
 		}
 	}
 

--- a/cmd/tars/doctor_main_test.go
+++ b/cmd/tars/doctor_main_test.go
@@ -6,9 +6,13 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/devlikebear/tars/internal/config"
 )
 
 func TestRootCommand_DoctorFailsForMissingStarterState(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
 	clearDoctorEnv(t)
 
 	workspaceDir := filepath.Join(t.TempDir(), "doctor-workspace")
@@ -34,6 +38,8 @@ func TestRootCommand_DoctorFailsForMissingStarterState(t *testing.T) {
 }
 
 func TestRootCommand_DoctorFixCreatesStarterWorkspaceButStillRequiresBYOK(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
 	clearDoctorEnv(t)
 	t.Setenv("TARS_PLUGINS_BUNDLED_DIR", writeBundledPluginSource(t))
 
@@ -55,7 +61,7 @@ func TestRootCommand_DoctorFixCreatesStarterWorkspaceButStillRequiresBYOK(t *tes
 		t.Fatalf("expected failing checks error, got %v", err)
 	}
 
-	configPath := filepath.Join(workspaceAbs, "config", "tars.config.yaml")
+	configPath := config.FixedConfigPath()
 	assertPathExists(t, configPath)
 	assertPathExists(t, filepath.Join(workspaceAbs, "memory"))
 	assertPathExists(t, filepath.Join(workspaceAbs, "MEMORY.md"))
@@ -72,6 +78,8 @@ func TestRootCommand_DoctorFixCreatesStarterWorkspaceButStillRequiresBYOK(t *tes
 }
 
 func TestRootCommand_DoctorPassesWhenStarterWorkspaceAndBYOKPresent(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
 	clearDoctorEnv(t)
 	t.Setenv("OPENAI_API_KEY", "test-openai-key")
 	t.Setenv("TARS_PLUGINS_BUNDLED_DIR", writeBundledPluginSource(t))
@@ -101,6 +109,8 @@ func TestRootCommand_DoctorPassesWhenStarterWorkspaceAndBYOKPresent(t *testing.T
 }
 
 func TestRootCommand_DoctorFixRestoresBundledWorkspacePlugin(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
 	clearDoctorEnv(t)
 	t.Setenv("OPENAI_API_KEY", "test-openai-key")
 	t.Setenv("TARS_PLUGINS_BUNDLED_DIR", writeBundledPluginSource(t))
@@ -134,6 +144,8 @@ func TestRootCommand_DoctorFixRestoresBundledWorkspacePlugin(t *testing.T) {
 }
 
 func TestRootCommand_DoctorWarnsWhenGatewayDisabledForProjectWorkflow(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
 	clearDoctorEnv(t)
 	t.Setenv("OPENAI_API_KEY", "test-openai-key")
 	t.Setenv("TARS_PLUGINS_BUNDLED_DIR", writeBundledPluginSource(t))
@@ -146,11 +158,7 @@ func TestRootCommand_DoctorWarnsWhenGatewayDisabledForProjectWorkflow(t *testing
 		t.Fatalf("init command: %v", err)
 	}
 
-	workspaceAbs, err := filepath.Abs(workspaceDir)
-	if err != nil {
-		t.Fatalf("workspace abs path: %v", err)
-	}
-	configPath := filepath.Join(workspaceAbs, "config", "tars.config.yaml")
+	configPath := config.FixedConfigPath()
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("read config: %v", err)
@@ -177,6 +185,8 @@ func TestRootCommand_DoctorWarnsWhenGatewayDisabledForProjectWorkflow(t *testing
 }
 
 func TestRootCommand_DoctorFailsWhenClaudeCodeCLIIsMissing(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
 	clearDoctorEnv(t)
 	t.Setenv("TARS_PLUGINS_BUNDLED_DIR", writeBundledPluginSource(t))
 	t.Setenv("CLAUDE_CODE_CLI_PATH", filepath.Join(t.TempDir(), "missing-claude"))
@@ -189,11 +199,7 @@ func TestRootCommand_DoctorFailsWhenClaudeCodeCLIIsMissing(t *testing.T) {
 		t.Fatalf("init command: %v", err)
 	}
 
-	workspaceAbs, err := filepath.Abs(workspaceDir)
-	if err != nil {
-		t.Fatalf("workspace abs path: %v", err)
-	}
-	configPath := filepath.Join(workspaceAbs, "config", "tars.config.yaml")
+	configPath := config.FixedConfigPath()
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("read config: %v", err)
@@ -221,6 +227,8 @@ func TestRootCommand_DoctorFailsWhenClaudeCodeCLIIsMissing(t *testing.T) {
 }
 
 func TestRootCommand_DoctorFailsWhenGatewayDefaultAgentUsesMissingWorkspaceCommand(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
 	clearDoctorEnv(t)
 	t.Setenv("OPENAI_API_KEY", "test-openai-key")
 	t.Setenv("TARS_PLUGINS_BUNDLED_DIR", writeBundledPluginSource(t))
@@ -237,7 +245,7 @@ func TestRootCommand_DoctorFailsWhenGatewayDefaultAgentUsesMissingWorkspaceComma
 	if err != nil {
 		t.Fatalf("workspace abs path: %v", err)
 	}
-	configPath := filepath.Join(workspaceAbs, "config", "tars.config.yaml")
+	configPath := config.FixedConfigPath()
 	content := strings.TrimSpace(strings.Join([]string{
 		"mode: standalone",
 		"workspace_dir: " + workspaceAbs,
@@ -274,6 +282,8 @@ func TestRootCommand_DoctorFailsWhenGatewayDefaultAgentUsesMissingWorkspaceComma
 }
 
 func TestRootCommand_DoctorFailsWhenSemanticMemoryProviderIsUnsupported(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
 	clearDoctorEnv(t)
 	t.Setenv("OPENAI_API_KEY", "test-openai-key")
 	t.Setenv("TARS_PLUGINS_BUNDLED_DIR", writeBundledPluginSource(t))
@@ -286,11 +296,7 @@ func TestRootCommand_DoctorFailsWhenSemanticMemoryProviderIsUnsupported(t *testi
 		t.Fatalf("init command: %v", err)
 	}
 
-	workspaceAbs, err := filepath.Abs(workspaceDir)
-	if err != nil {
-		t.Fatalf("workspace abs path: %v", err)
-	}
-	configPath := filepath.Join(workspaceAbs, "config", "tars.config.yaml")
+	configPath := config.FixedConfigPath()
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("read config: %v", err)

--- a/cmd/tars/init_main.go
+++ b/cmd/tars/init_main.go
@@ -15,13 +15,19 @@ import (
 	"github.com/devlikebear/tars/internal/memory"
 	"github.com/devlikebear/tars/internal/plugin"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 type initOptions struct {
 	workspaceDir string
 }
 
+type initMoveOptions struct {
+	to string
+}
+
 var initRunner = runInitCommand
+var initMoveRunner = runInitMoveCommand
 
 func defaultInitOptions() initOptions {
 	return initOptions{
@@ -39,6 +45,23 @@ func newInitCommand(stdout, stderr io.Writer) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&opts.workspaceDir, "workspace-dir", opts.workspaceDir, "workspace directory")
+
+	moveCmd := newInitMoveCommand(stdout, stderr)
+	cmd.AddCommand(moveCmd)
+	return cmd
+}
+
+func newInitMoveCommand(stdout, stderr io.Writer) *cobra.Command {
+	moveOpts := initMoveOptions{}
+	cmd := &cobra.Command{
+		Use:   "move",
+		Short: "Move the workspace directory to a new location",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return initMoveRunner(cmd.Context(), moveOpts, stdout, stderr)
+		},
+	}
+	cmd.Flags().StringVar(&moveOpts.to, "to", "", "target directory for the workspace (required)")
+	_ = cmd.MarkFlagRequired("to")
 	return cmd
 }
 
@@ -47,12 +70,22 @@ func runInitCommand(_ context.Context, opts initOptions, stdout, _ io.Writer) er
 	if err != nil {
 		return fmt.Errorf("resolve workspace dir: %w", err)
 	}
-	configPath := starterConfigPath(workspaceAbs)
+	configPath := config.FixedConfigPath()
 
+	// Check if config already exists at the fixed path.
 	if _, err := os.Stat(configPath); err == nil {
 		return fmt.Errorf("config already exists: %s", configPath)
 	} else if !os.IsNotExist(err) {
 		return fmt.Errorf("stat config path %s: %w", configPath, err)
+	}
+
+	// Try to migrate legacy config if found.
+	if migrated, legacyPath := tryMigrateLegacyConfig(configPath, stdout); migrated {
+		// Update workspace_dir in migrated config if it was relative.
+		updateMigratedWorkspaceDir(configPath, workspaceAbs)
+		_, _ = fmt.Fprintf(stdout, "migrated legacy config\n  from: %s\n  to:   %s\n\n", legacyPath, configPath)
+		_, _ = fmt.Fprintf(stdout, "the original file has been kept. you can remove it manually:\n  rm %s\n\n", legacyPath)
+		return nil
 	}
 
 	if err := ensureStarterWorkspaceLayout(workspaceAbs, defaultStarterBundledPluginsDir()); err != nil {
@@ -69,31 +102,185 @@ func runInitCommand(_ context.Context, opts initOptions, stdout, _ io.Writer) er
 	_, _ = fmt.Fprintf(stdout, "  or set llm_provider: claude-code-cli in %s to use the local Claude Code CLI\n", configPath)
 	_, _ = fmt.Fprintf(stdout, "  or edit llm_provider / llm_api_key in %s for anthropic or gemini\n\n", configPath)
 	_, _ = fmt.Fprintf(stdout, "Next:\n")
-	_, _ = fmt.Fprintf(stdout, "  tars serve --config %s\n", configPath)
-	_, _ = fmt.Fprintf(stdout, "  tars\n")
+	_, _ = fmt.Fprintf(stdout, "  tars serve\n")
+	_, _ = fmt.Fprintf(stdout, "  tars service install && tars service start\n")
 	return nil
 }
 
+// tryMigrateLegacyConfig checks for legacy config locations and copies to the
+// fixed config path. Returns true and the source path if migration occurred.
+func tryMigrateLegacyConfig(fixedPath string, stdout io.Writer) (bool, string) {
+	legacyCandidates := []string{
+		"workspace/config/tars.config.yaml",
+		"config/standalone.yaml",
+	}
+	for _, candidate := range legacyCandidates {
+		abs, err := filepath.Abs(candidate)
+		if err != nil {
+			continue
+		}
+		if _, err := os.Stat(abs); err != nil {
+			continue
+		}
+		data, err := os.ReadFile(abs)
+		if err != nil {
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(fixedPath), 0o755); err != nil {
+			_, _ = fmt.Fprintf(stdout, "warning: failed to create config dir: %v\n", err)
+			return false, ""
+		}
+		if err := os.WriteFile(fixedPath, data, 0o644); err != nil {
+			_, _ = fmt.Fprintf(stdout, "warning: failed to write migrated config: %v\n", err)
+			return false, ""
+		}
+		return true, abs
+	}
+	return false, ""
+}
+
+// updateMigratedWorkspaceDir reads the migrated config and converts a relative
+// workspace_dir to an absolute path.
+func updateMigratedWorkspaceDir(configPath, defaultWorkspace string) {
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		return
+	}
+	parsed := map[string]any{}
+	if err := yaml.Unmarshal(raw, &parsed); err != nil {
+		return
+	}
+	wsRaw, ok := parsed["workspace_dir"]
+	if !ok {
+		parsed["workspace_dir"] = defaultWorkspace
+	} else if ws, ok := wsRaw.(string); ok && !filepath.IsAbs(ws) {
+		abs, err := filepath.Abs(ws)
+		if err != nil {
+			return
+		}
+		parsed["workspace_dir"] = abs
+	}
+	out, err := yaml.Marshal(parsed)
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(configPath, out, 0o644)
+}
+
+func runInitMoveCommand(_ context.Context, opts initMoveOptions, stdout, _ io.Writer) error {
+	configPath := config.FixedConfigPath()
+
+	// Load current workspace_dir from config.
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return fmt.Errorf("load config %s: %w", configPath, err)
+	}
+	currentWorkspace := cfg.WorkspaceDir
+	if currentWorkspace == "" {
+		return fmt.Errorf("workspace_dir not set in config %s", configPath)
+	}
+	currentAbs, err := filepath.Abs(currentWorkspace)
+	if err != nil {
+		return fmt.Errorf("resolve current workspace: %w", err)
+	}
+
+	targetAbs, err := filepath.Abs(strings.TrimSpace(opts.to))
+	if err != nil {
+		return fmt.Errorf("resolve target path: %w", err)
+	}
+
+	if currentAbs == targetAbs {
+		return fmt.Errorf("target is the same as current workspace: %s", currentAbs)
+	}
+
+	// Verify source exists.
+	if _, err := os.Stat(currentAbs); os.IsNotExist(err) {
+		return fmt.Errorf("current workspace does not exist: %s", currentAbs)
+	}
+	// Verify target does not exist.
+	if _, err := os.Stat(targetAbs); err == nil {
+		return fmt.Errorf("target already exists: %s", targetAbs)
+	}
+
+	// Ensure parent dir of target exists.
+	if err := os.MkdirAll(filepath.Dir(targetAbs), 0o755); err != nil {
+		return fmt.Errorf("create target parent dir: %w", err)
+	}
+
+	// Move workspace.
+	if err := os.Rename(currentAbs, targetAbs); err != nil {
+		// Cross-device: copy + delete.
+		if err := copyDirAll(currentAbs, targetAbs); err != nil {
+			return fmt.Errorf("copy workspace: %w", err)
+		}
+		if err := os.RemoveAll(currentAbs); err != nil {
+			_, _ = fmt.Fprintf(stdout, "warning: workspace copied but failed to remove original: %v\n", err)
+		}
+	}
+
+	// Update workspace_dir in config.
+	if err := config.PatchYAML(configPath, map[string]any{"workspace_dir": targetAbs}); err != nil {
+		return fmt.Errorf("update config workspace_dir: %w", err)
+	}
+
+	_, _ = fmt.Fprintf(stdout, "workspace moved\n  from: %s\n  to:   %s\n  config updated: %s\n", currentAbs, targetAbs, configPath)
+
+	// Check if LaunchAgent plist exists and advise restart.
+	home, err := os.UserHomeDir()
+	if err == nil {
+		plistPath := filepath.Join(home, "Library", "LaunchAgents", "io.tars.server.plist")
+		if _, err := os.Stat(plistPath); err == nil {
+			_, _ = fmt.Fprintf(stdout, "\nLaunchAgent detected. restart the service:\n  tars service stop && tars service install && tars service start\n")
+		}
+	}
+	return nil
+}
+
+// copyDirAll recursively copies a directory tree (used for cross-device moves).
+func copyDirAll(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return os.MkdirAll(target, info.Mode().Perm())
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, info.Mode().Perm())
+	})
+}
+
 func defaultWorkspaceDir() string {
-	return strings.TrimSpace(firstNonEmpty(os.Getenv("TARS_WORKSPACE_DIR"), "./workspace"))
+	return strings.TrimSpace(firstNonEmpty(os.Getenv("TARS_WORKSPACE_DIR"), config.DefaultWorkspaceDir()))
 }
 
 func resolveWorkspaceDir(raw string) (string, error) {
 	workspaceDir := strings.TrimSpace(raw)
 	if workspaceDir == "" {
-		workspaceDir = "./workspace"
+		workspaceDir = config.DefaultWorkspaceDir()
 	}
 	return filepath.Abs(workspaceDir)
 }
 
-func starterConfigPath(workspaceAbs string) string {
-	return filepath.Join(workspaceAbs, "config", "tars.config.yaml")
-}
-
-func resolveConfigPath(raw, workspaceAbs string) (string, error) {
+func resolveConfigPath(raw, _ string) (string, error) {
 	configPath := strings.TrimSpace(raw)
 	if configPath == "" {
-		configPath = starterConfigPath(workspaceAbs)
+		return config.FixedConfigPath(), nil
 	}
 	configPath = os.ExpandEnv(configPath)
 	if filepath.IsAbs(configPath) {

--- a/cmd/tars/init_main_test.go
+++ b/cmd/tars/init_main_test.go
@@ -6,9 +6,14 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/devlikebear/tars/internal/config"
 )
 
 func TestRootCommand_InitCreatesStarterWorkspace(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
 	bundledPluginsDir := writeBundledPluginSource(t)
 	t.Setenv("TARS_PLUGINS_BUNDLED_DIR", bundledPluginsDir)
 
@@ -25,7 +30,7 @@ func TestRootCommand_InitCreatesStarterWorkspace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("workspace abs path: %v", err)
 	}
-	configPath := filepath.Join(workspaceAbs, "config", "tars.config.yaml")
+	configPath := config.FixedConfigPath()
 	assertPathExists(t, configPath)
 	assertPathExists(t, filepath.Join(workspaceAbs, "memory"))
 	assertPathExists(t, filepath.Join(workspaceAbs, "MEMORY.md"))
@@ -55,18 +60,16 @@ func TestRootCommand_InitCreatesStarterWorkspace(t *testing.T) {
 	if !strings.Contains(out, "OPENAI_API_KEY") {
 		t.Fatalf("expected BYOK guidance in output, got:\n%s", out)
 	}
-	if !strings.Contains(out, "tars serve --config") {
+	if !strings.Contains(out, "tars serve") {
 		t.Fatalf("expected next-step serve command in output, got:\n%s", out)
 	}
 }
 
 func TestRootCommand_InitRefusesToOverwriteExistingConfig(t *testing.T) {
-	workspaceDir := filepath.Join(t.TempDir(), "starter-workspace")
-	workspaceAbs, err := filepath.Abs(workspaceDir)
-	if err != nil {
-		t.Fatalf("workspace abs path: %v", err)
-	}
-	configPath := filepath.Join(workspaceAbs, "config", "tars.config.yaml")
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	configPath := config.FixedConfigPath()
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
 		t.Fatalf("mkdir config dir: %v", err)
 	}
@@ -74,11 +77,12 @@ func TestRootCommand_InitRefusesToOverwriteExistingConfig(t *testing.T) {
 		t.Fatalf("write sentinel config: %v", err)
 	}
 
+	workspaceDir := filepath.Join(t.TempDir(), "starter-workspace")
 	var stdout strings.Builder
 	cmd := newRootCommand(strings.NewReader(""), &stdout, io.Discard)
 	cmd.SetArgs([]string{"init", "--workspace-dir", workspaceDir})
 
-	err = cmd.Execute()
+	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected init to fail when config already exists")
 	}
@@ -92,6 +96,97 @@ func TestRootCommand_InitRefusesToOverwriteExistingConfig(t *testing.T) {
 	}
 	if string(data) != "sentinel-config" {
 		t.Fatalf("expected existing config to stay unchanged, got %q", string(data))
+	}
+}
+
+func TestRootCommand_InitMigratesLegacyConfig(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	// Create legacy config in CWD.
+	legacyDir := t.TempDir()
+	legacyConfigDir := filepath.Join(legacyDir, "workspace", "config")
+	if err := os.MkdirAll(legacyConfigDir, 0o755); err != nil {
+		t.Fatalf("mkdir legacy config dir: %v", err)
+	}
+	legacyConfig := filepath.Join(legacyConfigDir, "tars.config.yaml")
+	if err := os.WriteFile(legacyConfig, []byte("mode: standalone\nworkspace_dir: ./workspace\n"), 0o644); err != nil {
+		t.Fatalf("write legacy config: %v", err)
+	}
+
+	// Change to the directory with legacy config.
+	wd, _ := os.Getwd()
+	_ = os.Chdir(legacyDir)
+	defer func() { _ = os.Chdir(wd) }()
+
+	var stdout strings.Builder
+	cmd := newRootCommand(strings.NewReader(""), &stdout, io.Discard)
+	cmd.SetArgs([]string{"init"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init command: %v", err)
+	}
+
+	// Fixed config should exist with migrated content.
+	fixedPath := config.FixedConfigPath()
+	assertPathExists(t, fixedPath)
+
+	out := stdout.String()
+	if !strings.Contains(out, "migrated legacy config") {
+		t.Fatalf("expected migration output, got:\n%s", out)
+	}
+
+	// Original should still exist.
+	assertPathExists(t, legacyConfig)
+}
+
+func TestRootCommand_InitMoveWorkspace(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	bundledPluginsDir := writeBundledPluginSource(t)
+	t.Setenv("TARS_PLUGINS_BUNDLED_DIR", bundledPluginsDir)
+
+	// First init.
+	workspaceDir := filepath.Join(t.TempDir(), "orig-workspace")
+	var stdout strings.Builder
+	cmd := newRootCommand(strings.NewReader(""), &stdout, io.Discard)
+	cmd.SetArgs([]string{"init", "--workspace-dir", workspaceDir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init command: %v", err)
+	}
+
+	workspaceAbs, _ := filepath.Abs(workspaceDir)
+	assertPathExists(t, workspaceAbs)
+
+	// Move workspace.
+	targetDir := filepath.Join(t.TempDir(), "new-workspace")
+	stdout.Reset()
+	cmd = newRootCommand(strings.NewReader(""), &stdout, io.Discard)
+	cmd.SetArgs([]string{"init", "move", "--to", targetDir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init move command: %v", err)
+	}
+
+	// Old workspace should be gone, new one should exist.
+	if _, err := os.Stat(workspaceAbs); !os.IsNotExist(err) {
+		t.Fatalf("expected old workspace to be removed, got err=%v", err)
+	}
+	targetAbs, _ := filepath.Abs(targetDir)
+	assertPathExists(t, targetAbs)
+
+	// Config should point to new workspace.
+	cfg, err := config.Load(config.FixedConfigPath())
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.WorkspaceDir != targetAbs {
+		t.Fatalf("expected workspace_dir=%q, got %q", targetAbs, cfg.WorkspaceDir)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "workspace moved") {
+		t.Fatalf("expected move output, got:\n%s", out)
 	}
 }
 

--- a/cmd/tars/service_main.go
+++ b/cmd/tars/service_main.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/devlikebear/tars/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -21,8 +22,6 @@ const (
 
 type serviceOptions struct {
 	action          string
-	workspaceDir    string
-	configPath      string
 	label           string
 	plistPath       string
 	stdoutLog       string
@@ -51,7 +50,6 @@ var (
 
 func defaultServiceOptions() serviceOptions {
 	return serviceOptions{
-		workspaceDir:    defaultWorkspaceDir(),
 		label:           defaultServiceLabel,
 		launchctlDomain: "gui/" + strconv.Itoa(serviceGetuid()),
 		launchPath:      defaultServiceLaunchPath,
@@ -123,8 +121,6 @@ func newServiceCommand(stdout, stderr io.Writer) *cobra.Command {
 }
 
 func bindServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
-	cmd.Flags().StringVar(&opts.workspaceDir, "workspace-dir", opts.workspaceDir, "workspace directory")
-	cmd.Flags().StringVar(&opts.configPath, "config", "", "config file path")
 	cmd.Flags().StringVar(&opts.label, "label", opts.label, "launch agent label")
 	cmd.Flags().StringVar(&opts.plistPath, "plist-path", opts.plistPath, "override launch agent plist path")
 	cmd.Flags().StringVar(&opts.stdoutLog, "stdout-log", opts.stdoutLog, "stdout log file path")
@@ -137,13 +133,14 @@ func runServiceCommand(ctx context.Context, opts serviceOptions, stdout, _ io.Wr
 		return fmt.Errorf("service commands are only supported on macOS")
 	}
 
-	workspaceAbs, err := resolveWorkspaceDir(opts.workspaceDir)
+	configPath := config.FixedConfigPath()
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return fmt.Errorf("load config %s: %w", configPath, err)
+	}
+	workspaceAbs, err := resolveWorkspaceDir(cfg.WorkspaceDir)
 	if err != nil {
 		return fmt.Errorf("resolve workspace dir: %w", err)
-	}
-	configPath, err := resolveConfigPath(opts.configPath, workspaceAbs)
-	if err != nil {
-		return fmt.Errorf("resolve config path: %w", err)
 	}
 	label := strings.TrimSpace(firstNonEmpty(opts.label, defaultServiceLabel))
 	plistPath, err := defaultedServicePlistPath(opts.plistPath, label)
@@ -191,7 +188,7 @@ func runServiceCommand(ctx context.Context, opts serviceOptions, stdout, _ io.Wr
 		if err := os.WriteFile(plistPath, []byte(content), 0o644); err != nil {
 			return fmt.Errorf("write launchagent plist: %w", err)
 		}
-		_, _ = fmt.Fprintf(stdout, "service installed\nlabel: %s\nplist: %s\nconfig: %s\nstdout log: %s\nstderr log: %s\nnext: tars service start --config %s --workspace-dir %s\n", label, plistPath, configPath, stdoutLog, stderrLog, configPath, workspaceAbs)
+		_, _ = fmt.Fprintf(stdout, "service installed\nlabel: %s\nplist: %s\nconfig: %s\nworkspace: %s\nstdout log: %s\nstderr log: %s\nnext: tars service start\n", label, plistPath, configPath, workspaceAbs, stdoutLog, stderrLog)
 		return nil
 	case "start":
 		if exists, err := pathExists(plistPath); err != nil {

--- a/cmd/tars/service_main_test.go
+++ b/cmd/tars/service_main_test.go
@@ -8,9 +8,14 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/devlikebear/tars/internal/config"
 )
 
 func TestRootCommand_ServiceInstallWritesLaunchAgentPlist(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
 	clearDoctorEnv(t)
 	t.Setenv("OPENAI_API_KEY", "test-openai-key")
 
@@ -29,7 +34,6 @@ func TestRootCommand_ServiceInstallWritesLaunchAgentPlist(t *testing.T) {
 	cmd := newRootCommand(strings.NewReader(""), &stdout, io.Discard)
 	cmd.SetArgs([]string{
 		"service", "install",
-		"--workspace-dir", workspaceDir,
 		"--plist-path", plistPath,
 		"--stdout-log", stdoutLog,
 		"--stderr-log", stderrLog,
@@ -43,11 +47,7 @@ func TestRootCommand_ServiceInstallWritesLaunchAgentPlist(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read plist: %v", err)
 	}
-	workspaceAbs, err := filepath.Abs(workspaceDir)
-	if err != nil {
-		t.Fatalf("workspace abs: %v", err)
-	}
-	configPath := starterConfigPath(workspaceAbs)
+	configPath := config.FixedConfigPath()
 	plist := string(data)
 	for _, token := range []string{
 		"io.tars.server",
@@ -75,6 +75,16 @@ func TestRootCommand_ServiceStartBootstrapsAndKickstartsLaunchAgent(t *testing.T
 	plistPath := filepath.Join(t.TempDir(), "io.tars.server.plist")
 	if err := os.WriteFile(plistPath, []byte("<plist/>"), 0o644); err != nil {
 		t.Fatalf("write plist: %v", err)
+	}
+
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	fixedCfg := config.FixedConfigPath()
+	if err := os.MkdirAll(filepath.Dir(fixedCfg), 0o755); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	if err := os.WriteFile(fixedCfg, []byte("mode: standalone\nworkspace_dir: /tmp/ws\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
 	}
 
 	var calls [][]string
@@ -124,6 +134,16 @@ func TestRootCommand_ServiceStopBootsOutLaunchAgent(t *testing.T) {
 		t.Fatalf("write plist: %v", err)
 	}
 
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	fixedCfg := config.FixedConfigPath()
+	if err := os.MkdirAll(filepath.Dir(fixedCfg), 0o755); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	if err := os.WriteFile(fixedCfg, []byte("mode: standalone\nworkspace_dir: /tmp/ws\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
 	var calls [][]string
 	serviceLaunchctlRun = func(_ context.Context, args ...string) (string, error) {
 		calls = append(calls, append([]string{}, args...))
@@ -161,6 +181,16 @@ func TestRootCommand_ServiceStatusReportsInstalledButNotLoaded(t *testing.T) {
 		t.Fatalf("write plist: %v", err)
 	}
 
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	fixedCfg := config.FixedConfigPath()
+	if err := os.MkdirAll(filepath.Dir(fixedCfg), 0o755); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	if err := os.WriteFile(fixedCfg, []byte("mode: standalone\nworkspace_dir: /tmp/ws\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
 	serviceLaunchctlRun = func(_ context.Context, args ...string) (string, error) {
 		if len(args) > 0 && args[0] == "print" {
 			return "Could not find service", errors.New("exit status 113")
@@ -193,6 +223,9 @@ func TestRootCommand_ServiceStatusReportsInstalledButNotLoaded(t *testing.T) {
 
 func runInitForTest(t *testing.T, workspaceDir string) {
 	t.Helper()
+	bundledPluginsDir := writeBundledPluginSource(t)
+	t.Setenv("TARS_PLUGINS_BUNDLED_DIR", bundledPluginsDir)
+
 	var stdout strings.Builder
 	cmd := newRootCommand(strings.NewReader(""), &stdout, io.Discard)
 	cmd.SetArgs([]string{"init", "--workspace-dir", workspaceDir})

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -1,8 +1,32 @@
 package config
 
+import (
+	"os"
+	"path/filepath"
+)
+
+// TarsHomeDir returns the base directory for TARS data (~/.tars).
+func TarsHomeDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".", ".tars")
+	}
+	return filepath.Join(home, ".tars")
+}
+
+// FixedConfigPath returns the fixed config file path (~/.tars/config/config.yaml).
+// This path is not user-overridable; all commands use it.
+func FixedConfigPath() string {
+	return filepath.Join(TarsHomeDir(), "config", "config.yaml")
+}
+
+// DefaultWorkspaceDir returns the default workspace directory (~/.tars/workspace).
+func DefaultWorkspaceDir() string {
+	return filepath.Join(TarsHomeDir(), "workspace")
+}
+
 const (
 	defaultMode                          = "standalone"
-	defaultWorkspaceDir                  = "./workspace"
 	defaultSessionTelegramScope          = "main"
 	defaultAPIAuthMode                   = "required"
 	defaultDashboardAuthMode             = "inherit"
@@ -65,7 +89,7 @@ func defaultConfigValues() Config {
 	return Config{
 		RuntimeConfig: RuntimeConfig{
 			Mode:                 defaultMode,
-			WorkspaceDir:         defaultWorkspaceDir,
+			WorkspaceDir:         DefaultWorkspaceDir(),
 			SessionTelegramScope: defaultSessionTelegramScope,
 		},
 		APIConfig: APIConfig{

--- a/internal/config/defaults_test.go
+++ b/internal/config/defaults_test.go
@@ -178,8 +178,8 @@ func TestLoad_DefaultOnly(t *testing.T) {
 		t.Fatalf("expected mode standalone, got %q", cfg.Mode)
 	}
 
-	if cfg.WorkspaceDir != "./workspace" {
-		t.Fatalf("expected WorkspaceDir ./workspace, got %q", cfg.WorkspaceDir)
+	if cfg.WorkspaceDir != DefaultWorkspaceDir() {
+		t.Fatalf("expected WorkspaceDir %q, got %q", DefaultWorkspaceDir(), cfg.WorkspaceDir)
 	}
 	if cfg.LLMProvider != "anthropic" {
 		t.Fatalf("expected LLMProvider anthropic, got %q", cfg.LLMProvider)
@@ -617,6 +617,35 @@ func TestResolveConfigPath_DefaultCandidate(t *testing.T) {
 
 	if got := ResolveConfigPath(""); got != DefaultConfigFilename {
 		t.Fatalf("expected default candidate %q, got %q", DefaultConfigFilename, got)
+	}
+}
+
+func TestResolveConfigPath_FixedPathFallback(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	// No config/standalone.yaml in CWD, create fixed config.
+	emptyDir := t.TempDir()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(emptyDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(wd) }()
+
+	fixedPath := FixedConfigPath()
+	if err := os.MkdirAll(filepath.Dir(fixedPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(fixedPath, []byte("mode: standalone\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got := ResolveConfigPath("")
+	if got != fixedPath {
+		t.Fatalf("expected fixed path %q, got %q", fixedPath, got)
 	}
 }
 
@@ -1498,8 +1527,8 @@ func TestDefaultConfigValues_SharedBaseline(t *testing.T) {
 	if defaults.Mode != "standalone" {
 		t.Fatalf("expected mode standalone, got %q", defaults.Mode)
 	}
-	if defaults.WorkspaceDir != "./workspace" {
-		t.Fatalf("expected workspace default ./workspace, got %q", defaults.WorkspaceDir)
+	if defaults.WorkspaceDir != DefaultWorkspaceDir() {
+		t.Fatalf("expected workspace default %q, got %q", DefaultWorkspaceDir(), defaults.WorkspaceDir)
 	}
 	if defaults.APIAuthMode != "required" {
 		t.Fatalf("expected api auth mode required, got %q", defaults.APIAuthMode)

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -85,5 +85,10 @@ func ResolveConfigPath(raw string) string {
 	if _, err := os.Stat(DefaultConfigFilename); err == nil {
 		return DefaultConfigFilename
 	}
+	if fixed := FixedConfigPath(); fixed != "" {
+		if _, err := os.Stat(fixed); err == nil {
+			return fixed
+		}
+	}
 	return ""
 }


### PR DESCRIPTION
## Summary
- Config 경로를 `~/.tars/config/config.yaml`로 고정 (사용자 override 불가)
- 기본 워크스페이스를 `./workspace` → `~/.tars/workspace`로 변경
- `tars init move --to <dir>` 서브커맨드 추가 (워크스페이스 이동 + config 갱신 + 데몬 재시작 안내)
- `tars init` 시 레거시 config 자동 마이그레이션
- `tars service` 플래그 간소화 (`--workspace-dir`, `--config` 제거)
- `ResolveConfigPath` fallback: explicit → env → `./config/standalone.yaml` → `~/.tars/config/config.yaml`

## Test plan
- [x] make test (전체 통과)
- [x] make vet
- [x] make fmt
- [x] init/service/doctor 테스트 HOME 격리
- [x] migration 테스트
- [x] move 테스트
- [x] ResolveConfigPath fixed fallback 테스트