### PR TITLE
feat: unify Home and Sessions into single Chat page

### DIFF
--- a/frontend/console/src/App.svelte
+++ b/frontend/console/src/App.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte'
   import Shell from './components/Shell.svelte'
-  import Home from './components/Home.svelte'
+  import Chat from './components/Chat.svelte'
   import ProjectView from './components/ProjectView.svelte'
-  import Sessions from './components/Sessions.svelte'
   import Projects from './components/Projects.svelte'
   import Ops from './components/Ops.svelte'
   import Config from './components/Config.svelte'
@@ -13,7 +12,7 @@
   import { getEventsHistory, streamEvents } from './lib/api'
 
   let currentPath = $state('/console')
-  let route: Route = $state({ view: 'home' })
+  let route: Route = $state({ view: 'chat' })
   let serverHealth = $state('connecting')
   let unreadCount = $state(0)
   let aiPrompt = $state('')
@@ -28,7 +27,7 @@
 
   function navigateWithPrompt(prompt: string) {
     aiPrompt = prompt
-    navigate('/console')
+    navigate('/console/chat')
   }
 
   function syncFromBrowser() {
@@ -78,9 +77,9 @@
   onNavigate={navigate}
   onUnreadChange={(count) => { unreadCount = count }}
 >
-  {#if route.view === 'home'}
+  {#if route.view === 'chat'}
     {#key aiPrompt}
-      <Home onNavigate={navigate} initialPrompt={aiPrompt} />
+      <Chat sessionId={route.sessionId} onNavigate={navigate} initialPrompt={aiPrompt} />
     {/key}
   {:else if route.view === 'project'}
     {#key route.projectId}
@@ -88,8 +87,6 @@
     {/key}
   {:else if route.view === 'projects'}
     <Projects onNavigate={navigate} onAskAI={navigateWithPrompt} />
-  {:else if route.view === 'sessions'}
-    <Sessions />
   {:else if route.view === 'ops'}
     <Ops onAskAI={navigateWithPrompt} />
   {:else if route.view === 'config'}
@@ -100,4 +97,3 @@
     <Extensions />
   {/if}
 </Shell>
-

--- a/frontend/console/src/components/Chat.svelte
+++ b/frontend/console/src/components/Chat.svelte
@@ -1,0 +1,220 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte'
+  import { getEventsHistory, getHeartbeatStatus, listProjects, streamEvents } from '../lib/api'
+  import type { HeartbeatStatus, NotificationMessage, Project, Session } from '../lib/types'
+  import SessionSidebar from './SessionSidebar.svelte'
+  import ChatPanel from './ChatPanel.svelte'
+
+  interface Props {
+    sessionId?: string
+    onNavigate: (path: string) => void
+    initialPrompt?: string
+  }
+
+  let { sessionId, onNavigate, initialPrompt }: Props = $props()
+
+  // Dashboard mini state
+  let projects: Project[] = $state([])
+  let heartbeat: HeartbeatStatus | null = $state(null)
+  let unreadCount = $state(0)
+
+  // Session selection — synced via $effect from sessionId prop
+  let selectedSessionId: string | null = $state(null)
+  let chatKey = $state(0) // force ChatPanel re-mount
+  // Initialize from prop on first render
+  $effect(() => {
+    selectedSessionId = sessionId || null
+    chatKey++
+  })
+
+  let sidebarRef: SessionSidebar | undefined = $state()
+  let stopStream: (() => void) | null = null
+
+  function relativeTime(value?: string): string {
+    if (!value?.trim()) return 'never'
+    const date = new Date(value)
+    if (Number.isNaN(date.getTime())) return value
+    const seconds = Math.floor((Date.now() - date.getTime()) / 1000)
+    if (seconds < 60) return `${seconds}s ago`
+    if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`
+    if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`
+    return `${Math.floor(seconds / 86400)}d ago`
+  }
+
+  function handleSelectSession(session: Session) {
+    selectedSessionId = session.id
+    chatKey++
+    onNavigate(`/console/chat/${encodeURIComponent(session.id)}`)
+  }
+
+  function handleNewSession() {
+    selectedSessionId = null
+    chatKey++
+    onNavigate('/console/chat')
+  }
+
+  function handleSessionChange() {
+    sidebarRef?.load()
+  }
+
+
+  async function loadDashboard() {
+    const [p, h, e] = await Promise.allSettled([
+      listProjects(),
+      getHeartbeatStatus(),
+      getEventsHistory(1),
+    ])
+    projects = p.status === 'fulfilled' ? p.value : []
+    heartbeat = h.status === 'fulfilled' ? h.value : null
+    if (e.status === 'fulfilled') {
+      unreadCount = e.value.unread_count ?? 0
+    }
+  }
+
+  onMount(() => {
+    void loadDashboard()
+    stopStream = streamEvents(
+      undefined,
+      () => { unreadCount++ },
+    )
+  })
+
+  onDestroy(() => {
+    stopStream?.()
+  })
+</script>
+
+<div class="chat-page">
+  <!-- Mini dashboard pulse -->
+  <div class="chat-pulse">
+    <div class="pulse-item">
+      <span class="pulse-val">{projects.length}</span>
+      <span class="pulse-lbl">Projects</span>
+    </div>
+    <div class="pulse-sep"></div>
+    <div class="pulse-item">
+      <span class="pulse-val" class:warn={!!heartbeat?.last_error}>
+        {heartbeat?.interval || 'off'}
+      </span>
+      <span class="pulse-lbl">Heartbeat</span>
+    </div>
+    <div class="pulse-sep"></div>
+    <div class="pulse-item">
+      <span class="pulse-val">{heartbeat?.last_run_at ? relativeTime(heartbeat.last_run_at) : 'never'}</span>
+      <span class="pulse-lbl">Last run</span>
+    </div>
+    <div class="pulse-sep"></div>
+    <div class="pulse-item">
+      <span class="pulse-val">{unreadCount}</span>
+      <span class="pulse-lbl">Unread</span>
+    </div>
+  </div>
+
+  <div class="chat-layout">
+    <!-- Session sidebar -->
+    <aside class="chat-sidebar">
+      <SessionSidebar
+        bind:this={sidebarRef}
+        selectedSessionId={selectedSessionId}
+        onSelect={handleSelectSession}
+        onNewSession={handleNewSession}
+      />
+    </aside>
+
+    <!-- Chat area -->
+    <main class="chat-main">
+      {#key chatKey}
+        <ChatPanel
+          sessionId={selectedSessionId || undefined}
+          {initialPrompt}
+          onSessionChange={handleSessionChange}
+        />
+      {/key}
+    </main>
+  </div>
+</div>
+
+<style>
+  .chat-page {
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - var(--header-height));
+    animation: fadeIn var(--duration-normal) var(--ease-out);
+  }
+
+  @keyframes fadeIn {
+    from { opacity: 0; transform: translateY(8px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  /* Mini dashboard */
+  .chat-pulse {
+    display: flex;
+    align-items: center;
+    gap: var(--space-4);
+    padding: var(--space-2) var(--space-4);
+    background: var(--bg-surface);
+    border-bottom: 1px solid var(--border-subtle);
+    flex-shrink: 0;
+  }
+
+  .pulse-item {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+  .pulse-val {
+    font-family: var(--font-display);
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+  .pulse-val.warn { color: var(--error); }
+  .pulse-lbl {
+    font-size: var(--text-xs);
+    color: var(--text-ghost);
+  }
+  .pulse-sep {
+    width: 1px;
+    height: 16px;
+    background: var(--border-subtle);
+    flex-shrink: 0;
+  }
+
+  /* Layout */
+  .chat-layout {
+    flex: 1;
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    min-height: 0;
+  }
+
+  .chat-sidebar {
+    border-right: 1px solid var(--border-subtle);
+    background: var(--bg-surface);
+    padding: var(--space-3);
+    overflow: hidden;
+  }
+
+  .chat-main {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    padding: var(--space-4);
+    overflow: hidden;
+  }
+
+  @media (max-width: 768px) {
+    .chat-layout {
+      grid-template-columns: 1fr;
+    }
+    .chat-sidebar {
+      display: none;
+    }
+    .chat-pulse {
+      flex-wrap: wrap;
+      gap: var(--space-2);
+    }
+    .pulse-sep { display: none; }
+  }
+</style>

--- a/frontend/console/src/components/ChatPanel.svelte
+++ b/frontend/console/src/components/ChatPanel.svelte
@@ -438,6 +438,7 @@
     display: flex;
     flex-direction: column;
     min-height: 0;
+    flex: 1;
   }
 
   .chat-toolbar-row {
@@ -464,10 +465,11 @@
   .chat-log {
     display: grid;
     gap: var(--space-2);
-    max-height: 480px;
+    flex: 1;
     overflow-y: auto;
     margin-bottom: var(--space-3);
     scroll-behavior: smooth;
+    min-height: 0;
   }
 
   .chat-msg {

--- a/frontend/console/src/components/Nav.svelte
+++ b/frontend/console/src/components/Nav.svelte
@@ -14,9 +14,8 @@
   let { currentPath, onNavigate }: Props = $props()
 
   const items: NavItem[] = [
-    { id: 'home', label: 'Home', path: '/console', icon: '\u2302' },
+    { id: 'chat', label: 'Chat', path: '/console/chat', icon: '\u25ce' },
     { id: 'projects', label: 'Projects', path: '/console/projects', icon: '\u25eb' },
-    { id: 'sessions', label: 'Sessions', path: '/console/sessions', icon: '\u25ce' },
     { id: 'ops', label: 'Operations', path: '/console/ops', icon: '\u2699' },
     { id: 'heartbeat', label: 'Heartbeat', path: '/console/heartbeat', icon: '\u2661' },
     { id: 'extensions', label: 'Extensions', path: '/console/extensions', icon: '\u2756' },
@@ -24,8 +23,8 @@
   ]
 
   function isActive(itemPath: string, current: string): boolean {
-    if (itemPath === '/console') {
-      return current === '/console' || current === '/console/'
+    if (itemPath === '/console/chat') {
+      return current === '/console' || current === '/console/' || current.startsWith('/console/chat') || current.startsWith('/console/sessions')
     }
     return current.startsWith(itemPath)
   }

--- a/frontend/console/src/components/SessionSidebar.svelte
+++ b/frontend/console/src/components/SessionSidebar.svelte
@@ -1,0 +1,430 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import { listSessions, deleteSession, compactSession, renameSession, getSessionHistory } from '../lib/api'
+  import type { Session } from '../lib/types'
+
+  interface Props {
+    selectedSessionId: string | null
+    onSelect: (session: Session) => void
+    onNewSession: () => void
+  }
+
+  let { selectedSessionId, onSelect, onNewSession }: Props = $props()
+
+  let sessions: Session[] = $state([])
+  let loading = $state(true)
+  let error = $state('')
+  let showHidden = $state(false)
+
+  let searchQuery = $state('')
+  let sortBy: 'updated' | 'name' = $state('updated')
+  let filterKind: 'all' | 'session' | 'main' | 'worker' | 'project' = $state('all')
+
+  let renamingId: string | null = $state(null)
+  let renameValue = $state('')
+  let deleteConfirmId: string | null = $state(null)
+  let actionBusy = $state('')
+  let actionError = $state('')
+
+  function relativeTime(value?: string): string {
+    if (!value?.trim()) return ''
+    const date = new Date(value)
+    if (Number.isNaN(date.getTime())) return value
+    const seconds = Math.floor((Date.now() - date.getTime()) / 1000)
+    if (seconds < 60) return `${seconds}s ago`
+    if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`
+    if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`
+    return `${Math.floor(seconds / 86400)}d ago`
+  }
+
+  function sessionKind(session: Session): string {
+    if (session.kind === 'main') return 'main'
+    if (session.hidden) return 'worker'
+    if (session.project_id) return 'project'
+    return 'session'
+  }
+
+  function kindBadge(session: Session): string {
+    switch (sessionKind(session)) {
+      case 'main': return 'badge-accent'
+      case 'worker': return 'badge-default'
+      case 'project': return 'badge-info'
+      default: return 'badge-info'
+    }
+  }
+
+  function isMainSession(session: Session): boolean {
+    return session.kind === 'main'
+  }
+
+  function filteredSessions(): Session[] {
+    let result = sessions
+    if (filterKind !== 'all') {
+      result = result.filter((s) => sessionKind(s) === filterKind)
+    }
+    const q = searchQuery.trim().toLowerCase()
+    if (q) {
+      result = result.filter((s) =>
+        (s.title || '').toLowerCase().includes(q) ||
+        s.id.toLowerCase().includes(q) ||
+        (s.project_id || '').toLowerCase().includes(q)
+      )
+    }
+    if (sortBy === 'name') {
+      result = [...result].sort((a, b) => (a.title || a.id).localeCompare(b.title || b.id))
+    } else {
+      result = [...result].sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime())
+    }
+    return result
+  }
+
+  export async function load() {
+    loading = true
+    error = ''
+    try {
+      sessions = await listSessions(showHidden)
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Failed to load sessions'
+    } finally {
+      loading = false
+    }
+  }
+
+  function toggleHidden() {
+    showHidden = !showHidden
+    void load()
+  }
+
+  function startRename(s: Session) {
+    if (isMainSession(s)) return
+    renamingId = s.id
+    renameValue = s.title || s.id.slice(0, 12)
+  }
+
+  async function commitRename() {
+    if (!renamingId || !renameValue.trim()) { renamingId = null; return }
+    try {
+      await renameSession(renamingId, renameValue.trim())
+      await load()
+    } catch { /* ignore */ }
+    renamingId = null
+  }
+
+  function requestDelete(id: string) {
+    if (deleteConfirmId === id) {
+      void handleDelete(id)
+    } else {
+      deleteConfirmId = id
+    }
+  }
+
+  async function handleDelete(id: string) {
+    actionBusy = id
+    actionError = ''
+    deleteConfirmId = null
+    try {
+      await deleteSession(id)
+      if (selectedSessionId === id) onNewSession()
+      await load()
+    } catch (e) {
+      actionError = e instanceof Error ? e.message : 'Delete failed'
+    } finally {
+      actionBusy = ''
+    }
+  }
+
+  async function handleCompact(id: string) {
+    actionBusy = id
+    actionError = ''
+    try {
+      await compactSession(id)
+      await load()
+    } catch (e) {
+      actionError = e instanceof Error ? e.message : 'Compact failed'
+    } finally {
+      actionBusy = ''
+    }
+  }
+
+  async function handleGenerateTitle(s: Session) {
+    actionBusy = s.id
+    actionError = ''
+    try {
+      const history = await getSessionHistory(s.id)
+      const userMsgs = history.filter((m) => m.role === 'user')
+      const assistantMsgs = history.filter((m) => m.role === 'assistant')
+      let title = ''
+      if (userMsgs.length > 0) {
+        const raw = userMsgs[0].content.trim()
+        const clean = raw.replace(/\n/g, ' ').replace(/\s+/g, ' ')
+        title = clean.length > 50 ? clean.slice(0, 47) + '...' : clean
+      } else if (assistantMsgs.length > 0) {
+        const raw = assistantMsgs[0].content.trim()
+        const clean = raw.replace(/\n/g, ' ').replace(/\s+/g, ' ')
+        title = clean.length > 50 ? clean.slice(0, 47) + '...' : clean
+      }
+      if (title) {
+        await renameSession(s.id, title)
+        await load()
+      }
+    } catch (e) {
+      actionError = e instanceof Error ? e.message : 'Generate title failed'
+    } finally {
+      actionBusy = ''
+    }
+  }
+
+  onMount(() => { void load() })
+</script>
+
+<div class="sidebar">
+  <div class="sidebar-header">
+    <button type="button" class="btn btn-primary btn-sm new-chat-btn" onclick={onNewSession}>
+      + New Chat
+    </button>
+    <label class="sidebar-toggle" title="Show worker sessions">
+      <input type="checkbox" checked={showHidden} onchange={toggleHidden} />
+      <span class="toggle-icon">{showHidden ? '\u25C9' : '\u25CB'}</span>
+    </label>
+  </div>
+
+  <input type="text" class="sidebar-search" placeholder="Search..." bind:value={searchQuery} />
+
+  <div class="sidebar-filters">
+    {#each ['all', 'session', 'main', 'worker', 'project'] as kind}
+      <button
+        class="filter-btn"
+        class:active={filterKind === kind}
+        onclick={() => { filterKind = kind as typeof filterKind }}
+      >{kind}</button>
+    {/each}
+    <div class="sort-btns">
+      <button class="filter-btn" class:active={sortBy === 'updated'} onclick={() => { sortBy = 'updated' }} title="Sort by recent">{'\u2193'}</button>
+      <button class="filter-btn" class:active={sortBy === 'name'} onclick={() => { sortBy = 'name' }} title="Sort by name">A</button>
+    </div>
+  </div>
+
+  {#if error}
+    <div class="error-banner" style="margin:var(--space-2);font-size:var(--text-xs)">{error}</div>
+  {/if}
+  {#if actionError}
+    <div class="error-banner" style="margin:var(--space-2);font-size:var(--text-xs)">{actionError}</div>
+  {/if}
+
+  <div class="session-list">
+    {#if loading}
+      <div class="sidebar-loading">Loading...</div>
+    {:else if filteredSessions().length === 0}
+      <div class="sidebar-empty">{searchQuery || filterKind !== 'all' ? 'No matches.' : 'No sessions.'}</div>
+    {:else}
+      {#each filteredSessions() as session}
+        <div class="session-item" class:active={selectedSessionId === session.id}>
+          <button
+            type="button"
+            class="session-btn"
+            onclick={() => onSelect(session)}
+          >
+            {#if renamingId === session.id}
+              <!-- svelte-ignore a11y_autofocus -->
+              <input
+                class="rename-input"
+                bind:value={renameValue}
+                autofocus
+                onkeydown={(e) => { if (e.key === 'Enter') commitRename(); if (e.key === 'Escape') { renamingId = null } }}
+                onblur={() => commitRename()}
+                onclick={(e) => e.stopPropagation()}
+              />
+            {:else}
+              <span class="session-title">{session.title || session.id.slice(0, 12)}</span>
+            {/if}
+            <div class="session-meta">
+              <span class="badge {kindBadge(session)}" style="font-size:9px;padding:1px 5px">{sessionKind(session)}</span>
+              <span class="session-time">{relativeTime(session.updated_at)}</span>
+            </div>
+          </button>
+          <div class="session-actions">
+            {#if !isMainSession(session)}
+              <button class="act-btn" title="Rename" onclick={(e) => { e.stopPropagation(); startRename(session) }}>&#9998;</button>
+              <button class="act-btn" title="Auto title" disabled={actionBusy === session.id} onclick={(e) => { e.stopPropagation(); handleGenerateTitle(session) }}>&#9733;</button>
+            {/if}
+            <button class="act-btn" title="Compact" disabled={actionBusy === session.id} onclick={(e) => { e.stopPropagation(); handleCompact(session.id) }}>&#8858;</button>
+            {#if !isMainSession(session)}
+              <button
+                class="act-btn act-btn-danger"
+                title={deleteConfirmId === session.id ? 'Confirm' : 'Delete'}
+                disabled={actionBusy === session.id}
+                onclick={(e) => { e.stopPropagation(); requestDelete(session.id) }}
+              >{deleteConfirmId === session.id ? '!!' : '\u00d7'}</button>
+            {/if}
+          </div>
+        </div>
+      {/each}
+    {/if}
+  </div>
+</div>
+
+<style>
+  .sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    height: 100%;
+    overflow: hidden;
+  }
+
+  .sidebar-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .new-chat-btn {
+    flex: 1;
+  }
+
+  .sidebar-toggle {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+  .sidebar-toggle input { display: none; }
+  .toggle-icon {
+    font-size: var(--text-md);
+    color: var(--text-tertiary);
+  }
+
+  .sidebar-search {
+    padding: var(--space-1) var(--space-2) !important;
+    font-size: var(--text-xs) !important;
+    min-height: 0 !important;
+    border-radius: var(--radius-sm) !important;
+  }
+
+  .sidebar-filters {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    flex-wrap: wrap;
+  }
+
+  .filter-btn {
+    background: none;
+    border: none;
+    color: var(--text-ghost);
+    font-size: 10px;
+    font-family: var(--font-mono);
+    padding: 2px 5px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: color var(--duration-fast);
+  }
+  .filter-btn:hover { color: var(--text-secondary); }
+  .filter-btn.active { color: var(--accent); }
+
+  .sort-btns {
+    margin-left: auto;
+    display: flex;
+    gap: 2px;
+  }
+
+  .session-list {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+
+  .sidebar-loading, .sidebar-empty {
+    padding: var(--space-4);
+    text-align: center;
+    color: var(--text-ghost);
+    font-size: var(--text-xs);
+  }
+
+  .session-item {
+    display: flex;
+    align-items: stretch;
+    border-radius: var(--radius-sm);
+    transition: background var(--duration-fast) var(--ease-out);
+  }
+  .session-item:hover {
+    background: var(--bg-hover);
+  }
+  .session-item.active {
+    background: var(--accent-muted);
+  }
+
+  .session-btn {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: var(--space-2);
+    background: none;
+    border: none;
+    text-align: left;
+    cursor: pointer;
+    min-width: 0;
+  }
+
+  .session-title {
+    font-family: var(--font-display);
+    font-size: var(--text-xs);
+    font-weight: 500;
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .session-meta {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .session-time {
+    font-size: 10px;
+    color: var(--text-ghost);
+  }
+
+  .session-actions {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 1px;
+    padding: 0 2px;
+    opacity: 0;
+    transition: opacity var(--duration-fast);
+  }
+  .session-item:hover .session-actions {
+    opacity: 1;
+  }
+
+  .act-btn {
+    background: none;
+    border: none;
+    color: var(--text-ghost);
+    cursor: pointer;
+    font-size: 11px;
+    padding: 1px 3px;
+    border-radius: 2px;
+    line-height: 1;
+  }
+  .act-btn:hover { color: var(--accent); background: rgba(255,255,255,0.04); }
+  .act-btn-danger:hover { color: var(--error); }
+
+  .rename-input {
+    flex: 1;
+    padding: 1px var(--space-1);
+    font-size: var(--text-xs);
+    background: var(--bg-base);
+    border: 1px solid var(--accent);
+    border-radius: 2px;
+    color: var(--text-primary);
+    outline: none;
+    min-width: 0;
+  }
+</style>

--- a/frontend/console/src/lib/router.ts
+++ b/frontend/console/src/lib/router.ts
@@ -1,11 +1,11 @@
 const consoleBase = '/console'
 const projectPrefix = `${consoleBase}/projects/`
+const chatPrefix = `${consoleBase}/chat`
 
 export type Route =
-  | { view: 'home' }
+  | { view: 'chat'; sessionId?: string }
   | { view: 'projects' }
   | { view: 'project'; projectId: string }
-  | { view: 'sessions' }
   | { view: 'ops' }
   | { view: 'config' }
   | { view: 'extensions' }
@@ -26,8 +26,19 @@ export function resolveRoute(pathname: string): Route {
     return { view: 'projects' }
   }
 
+  // /console/chat or /console/chat/:sessionId
+  if (path.startsWith(chatPrefix)) {
+    const rest = path.slice(chatPrefix.length)
+    if (rest.startsWith('/') && rest.length > 1) {
+      const sessionId = decodeURIComponent(rest.slice(1).split('/')[0]?.trim() || '')
+      if (sessionId) return { view: 'chat', sessionId }
+    }
+    return { view: 'chat' }
+  }
+
+  // Legacy /console/sessions → redirect to chat
   if (path.startsWith(`${consoleBase}/sessions`)) {
-    return { view: 'sessions' }
+    return { view: 'chat' }
   }
 
   if (path.startsWith(`${consoleBase}/ops`)) {
@@ -46,7 +57,13 @@ export function resolveRoute(pathname: string): Route {
     return { view: 'heartbeat' }
   }
 
-  return { view: 'home' }
+  // Default: /console → chat
+  return { view: 'chat' }
+}
+
+export function chatPath(sessionId?: string): string {
+  if (sessionId) return `${chatPrefix}/${encodeURIComponent(sessionId)}`
+  return chatPrefix
 }
 
 export function currentProjectIdFromPath(pathname: string): string | null {


### PR DESCRIPTION
## Summary
- Merge Home (dashboard + main chat) and Sessions (session list + detail chat) into unified `/console/chat` page
- New `Chat.svelte` with 2-column layout: session sidebar (280px) + chat area, with mini dashboard pulse strip
- New `SessionSidebar.svelte` with search, filter (kind), sort, rename/delete/compact actions
- Router changes: `/console` and `/console/sessions` redirect to `/console/chat`, deep-link via `/console/chat/:sessionId`
- Nav updated: "Home" + "Sessions" replaced with single "Chat" item
- ChatPanel now uses flex-based full-height layout (removes 480px max-height)

**Depends on:** #266 (feat/chat-markdown)

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npm run build` — successful
- [x] `make build` — Go binary builds
- [ ] Manual: navigate to `/console` → Chat page renders
- [ ] Manual: session sidebar lists sessions, click to select
- [ ] Manual: "New Chat" creates new session
- [ ] Manual: session rename/delete/compact actions work
- [ ] Manual: `/console/chat/:sessionId` deep link works