### PR TITLE
feat: add artifact tracking and management panel

### DIFF
--- a/frontend/console/src/components/ArtifactPanel.svelte
+++ b/frontend/console/src/components/ArtifactPanel.svelte
@@ -1,0 +1,181 @@
+<script lang="ts">
+  import type { Artifact } from '../lib/artifacts'
+  import { fileIcon } from '../lib/artifacts'
+
+  interface Props {
+    artifacts: Artifact[]
+    onClose: () => void
+  }
+
+  let { artifacts, onClose }: Props = $props()
+
+  function relativeTime(ts: number): string {
+    const seconds = Math.floor((Date.now() - ts) / 1000)
+    if (seconds < 60) return `${seconds}s ago`
+    if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`
+    return `${Math.floor(seconds / 3600)}h ago`
+  }
+
+  function basename(path: string): string {
+    return path.split('/').pop() || path
+  }
+
+  function dirname(path: string): string {
+    const parts = path.split('/')
+    if (parts.length <= 1) return ''
+    return parts.slice(0, -1).join('/')
+  }
+</script>
+
+<aside class="artifact-panel">
+  <div class="artifact-header">
+    <span class="artifact-title">Artifacts</span>
+    <span class="artifact-count">{artifacts.length}</span>
+    <button type="button" class="artifact-close" onclick={onClose}>&times;</button>
+  </div>
+
+  <div class="artifact-list">
+    {#if artifacts.length === 0}
+      <div class="artifact-empty">No files created yet.</div>
+    {:else}
+      {#each artifacts as artifact}
+        <div class="artifact-item">
+          <span class="artifact-icon">{fileIcon(artifact.path)}</span>
+          <div class="artifact-info">
+            <span class="artifact-name">{basename(artifact.path)}</span>
+            {#if dirname(artifact.path)}
+              <span class="artifact-dir">{dirname(artifact.path)}</span>
+            {/if}
+          </div>
+          <div class="artifact-meta">
+            <span class="badge {artifact.action === 'created' ? 'badge-success' : 'badge-accent'}" style="font-size:9px;padding:1px 5px">
+              {artifact.action}
+            </span>
+            <span class="artifact-time">{relativeTime(artifact.timestamp)}</span>
+          </div>
+        </div>
+      {/each}
+    {/if}
+  </div>
+</aside>
+
+<style>
+  .artifact-panel {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+    width: 280px;
+  }
+
+  .artifact-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-3);
+    border-bottom: 1px solid var(--border-subtle);
+    flex-shrink: 0;
+  }
+
+  .artifact-title {
+    font-family: var(--font-display);
+    font-size: var(--text-sm);
+    font-weight: 500;
+    color: var(--text-primary);
+  }
+
+  .artifact-count {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--text-ghost);
+    background: var(--bg-elevated);
+    padding: 1px 6px;
+    border-radius: var(--radius-sm);
+  }
+
+  .artifact-close {
+    margin-left: auto;
+    background: none;
+    border: none;
+    color: var(--text-ghost);
+    cursor: pointer;
+    font-size: var(--text-md);
+    padding: 0 2px;
+    line-height: 1;
+  }
+  .artifact-close:hover { color: var(--text-primary); }
+
+  .artifact-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--space-2);
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+
+  .artifact-empty {
+    padding: var(--space-4);
+    text-align: center;
+    color: var(--text-ghost);
+    font-size: var(--text-xs);
+  }
+
+  .artifact-item {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-2);
+    padding: var(--space-2);
+    border-radius: var(--radius-sm);
+    transition: background var(--duration-fast) var(--ease-out);
+  }
+  .artifact-item:hover {
+    background: var(--bg-hover);
+  }
+
+  .artifact-icon {
+    font-size: var(--text-md);
+    flex-shrink: 0;
+    width: 20px;
+    text-align: center;
+  }
+
+  .artifact-info {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .artifact-name {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    font-weight: 500;
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .artifact-dir {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-ghost);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .artifact-meta {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 2px;
+    flex-shrink: 0;
+  }
+
+  .artifact-time {
+    font-size: 10px;
+    color: var(--text-ghost);
+  }
+</style>

--- a/frontend/console/src/components/Chat.svelte
+++ b/frontend/console/src/components/Chat.svelte
@@ -2,8 +2,10 @@
   import { onMount, onDestroy } from 'svelte'
   import { getEventsHistory, getHeartbeatStatus, listProjects, streamEvents } from '../lib/api'
   import type { HeartbeatStatus, NotificationMessage, Project, Session } from '../lib/types'
+  import type { Artifact } from '../lib/artifacts'
   import SessionSidebar from './SessionSidebar.svelte'
   import ChatPanel from './ChatPanel.svelte'
+  import ArtifactPanel from './ArtifactPanel.svelte'
 
   interface Props {
     sessionId?: string
@@ -27,6 +29,10 @@
     chatKey++
   })
 
+  // Artifact panel
+  let chatArtifacts: Artifact[] = $state([])
+  let showArtifacts = $state(false)
+
   let sidebarRef: SessionSidebar | undefined = $state()
   let stopStream: (() => void) | null = null
 
@@ -44,12 +50,16 @@
   function handleSelectSession(session: Session) {
     selectedSessionId = session.id
     chatKey++
+    chatArtifacts = []
+    showArtifacts = false
     onNavigate(`/console/chat/${encodeURIComponent(session.id)}`)
   }
 
   function handleNewSession() {
     selectedSessionId = null
     chatKey++
+    chatArtifacts = []
+    showArtifacts = false
     onNavigate('/console/chat')
   }
 
@@ -57,6 +67,12 @@
     sidebarRef?.load()
   }
 
+  function handleArtifactsChange(arts: Artifact[]) {
+    chatArtifacts = arts
+    if (arts.length > 0 && !showArtifacts) {
+      showArtifacts = true
+    }
+  }
 
   async function loadDashboard() {
     const [p, h, e] = await Promise.allSettled([
@@ -108,9 +124,16 @@
       <span class="pulse-val">{unreadCount}</span>
       <span class="pulse-lbl">Unread</span>
     </div>
+    {#if chatArtifacts.length > 0}
+      <div class="pulse-sep"></div>
+      <button type="button" class="pulse-artifact-btn" onclick={() => { showArtifacts = !showArtifacts }}>
+        <span class="pulse-val">{chatArtifacts.length}</span>
+        <span class="pulse-lbl">Artifacts {showArtifacts ? '\u25B8' : '\u25C2'}</span>
+      </button>
+    {/if}
   </div>
 
-  <div class="chat-layout">
+  <div class="chat-layout" class:has-artifacts={showArtifacts}>
     <!-- Session sidebar -->
     <aside class="chat-sidebar">
       <SessionSidebar
@@ -128,9 +151,17 @@
           sessionId={selectedSessionId || undefined}
           {initialPrompt}
           onSessionChange={handleSessionChange}
+          onArtifactsChange={handleArtifactsChange}
         />
       {/key}
     </main>
+
+    <!-- Artifact panel -->
+    {#if showArtifacts}
+      <aside class="chat-artifacts">
+        <ArtifactPanel artifacts={chatArtifacts} onClose={() => { showArtifacts = false }} />
+      </aside>
+    {/if}
   </div>
 </div>
 
@@ -181,12 +212,30 @@
     flex-shrink: 0;
   }
 
+  .pulse-artifact-btn {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 2px var(--space-2);
+    border-radius: var(--radius-sm);
+    transition: background var(--duration-fast) var(--ease-out);
+  }
+  .pulse-artifact-btn:hover {
+    background: var(--bg-elevated);
+  }
+
   /* Layout */
   .chat-layout {
     flex: 1;
     display: grid;
     grid-template-columns: 280px 1fr;
     min-height: 0;
+  }
+  .chat-layout.has-artifacts {
+    grid-template-columns: 280px 1fr 280px;
   }
 
   .chat-sidebar {
@@ -204,11 +253,17 @@
     overflow: hidden;
   }
 
+  .chat-artifacts {
+    border-left: 1px solid var(--border-subtle);
+    background: var(--bg-surface);
+    overflow: hidden;
+  }
+
   @media (max-width: 768px) {
-    .chat-layout {
+    .chat-layout, .chat-layout.has-artifacts {
       grid-template-columns: 1fr;
     }
-    .chat-sidebar {
+    .chat-sidebar, .chat-artifacts {
       display: none;
     }
     .chat-pulse {

--- a/frontend/console/src/components/ChatPanel.svelte
+++ b/frontend/console/src/components/ChatPanel.svelte
@@ -2,6 +2,7 @@
   import { onMount, tick } from 'svelte'
   import { streamChat, listSessions, getSessionHistory, renameSession } from '../lib/api'
   import type { ChatAttachment, ChatEvent, SessionMessage } from '../lib/types'
+  import { extractArtifact, extractArtifactsFromHistory, type Artifact } from '../lib/artifacts'
   import MarkdownContent from './MarkdownContent.svelte'
 
   type ChatMessage = {
@@ -21,9 +22,12 @@
     initialPrompt?: string
     autoSend?: boolean
     onSessionChange?: () => void
+    onArtifactsChange?: (artifacts: Artifact[]) => void
   }
 
-  let { projectId, sessionId, initialPrompt, autoSend, onSessionChange }: Props = $props()
+  let { projectId, sessionId, initialPrompt, autoSend, onSessionChange, onArtifactsChange }: Props = $props()
+
+  let artifacts: Artifact[] = $state([])
 
   let chatInput = $state('')
   let chatBusy = $state(false)
@@ -78,6 +82,8 @@
           }
         }
         chatMessages = [...chatMessages]
+        artifacts = extractArtifactsFromHistory(chatMessages)
+        if (artifacts.length > 0) onArtifactsChange?.(artifacts)
         autoTitled = true
         void scrollToBottom()
       }
@@ -125,6 +131,24 @@
             }
             chatMessages = [...chatMessages]
             void scrollToBottom()
+
+            // Track artifacts
+            const artifact = extractArtifact(
+              event.tool_name || '',
+              event.tool_call_id,
+              event.tool_args_preview,
+              event.tool_result_preview,
+            )
+            if (artifact) {
+              // Update existing or add new
+              const existing = artifacts.findIndex((a) => a.path === artifact.path)
+              if (existing >= 0) {
+                artifacts[existing] = artifact
+              } else {
+                artifacts = [...artifacts, artifact]
+              }
+              onArtifactsChange?.(artifacts)
+            }
           }
         } else if (event.phase === 'skill_selected' && event.skill_name) {
           const skillMsg: ChatMessage = {
@@ -383,6 +407,9 @@
           }
         }
         chatMessages = [...chatMessages]
+        // Extract artifacts from history
+        artifacts = extractArtifactsFromHistory(chatMessages)
+        if (artifacts.length > 0) onArtifactsChange?.(artifacts)
         autoTitled = true
         void scrollToBottom()
       } catch { /* ignore */ }

--- a/frontend/console/src/lib/artifacts.ts
+++ b/frontend/console/src/lib/artifacts.ts
@@ -1,0 +1,87 @@
+/**
+ * Artifact tracking — detects file creation/modification from tool call events.
+ */
+
+export type Artifact = {
+  path: string
+  toolName: string
+  toolCallId: string
+  action: 'created' | 'modified'
+  timestamp: number
+}
+
+const ARTIFACT_TOOLS = new Set(['write', 'write_file', 'edit_file', 'apply_patch'])
+
+/**
+ * Attempt to extract an artifact from a tool call event.
+ * Returns null if the tool is not a file operation or the path can't be parsed.
+ */
+export function extractArtifact(
+  toolName: string,
+  toolCallId: string,
+  toolArgs: string | undefined,
+  toolResult: string | undefined,
+): Artifact | null {
+  if (!ARTIFACT_TOOLS.has(toolName)) return null
+  if (!toolArgs) return null
+
+  // Parse file path from args preview
+  // Formats: {"path":"some/file.ts",...} or {"file_path":"some/file.ts",...}
+  const pathMatch = toolArgs.match(/"(?:path|file_path)"\s*:\s*"([^"]+)"/)
+  if (!pathMatch) return null
+
+  const path = pathMatch[1]
+  const created = toolResult ? toolResult.includes('"created":true') || toolResult.includes('created') : false
+  const action = (toolName === 'write' || toolName === 'write_file') && created ? 'created' : 'modified'
+
+  return {
+    path,
+    toolName,
+    toolCallId,
+    action,
+    timestamp: Date.now(),
+  }
+}
+
+/**
+ * Extract artifacts from a list of historical tool messages.
+ */
+export function extractArtifactsFromHistory(
+  messages: Array<{ role: string; toolName?: string; toolCallId?: string; toolArgs?: string; toolResult?: string }>,
+): Artifact[] {
+  const artifacts: Artifact[] = []
+  const seen = new Set<string>()
+
+  for (const msg of messages) {
+    if (msg.role !== 'tool' || !msg.toolName) continue
+    const artifact = extractArtifact(msg.toolName, msg.toolCallId || '', msg.toolArgs, msg.toolResult)
+    if (artifact && !seen.has(artifact.path)) {
+      seen.add(artifact.path)
+      artifacts.push(artifact)
+    }
+  }
+
+  return artifacts
+}
+
+/**
+ * Get a file extension icon based on the file path.
+ */
+export function fileIcon(path: string): string {
+  const ext = path.split('.').pop()?.toLowerCase() || ''
+  switch (ext) {
+    case 'ts': case 'tsx': return '\ud83d\udcd8' // blue book
+    case 'js': case 'jsx': return '\ud83d\udcd9' // orange book
+    case 'go': return '\ud83d\udc39' // hamster (gopher-like)
+    case 'py': return '\ud83d\udc0d' // snake
+    case 'rs': return '\u2699' // gear
+    case 'md': return '\ud83d\udcdd' // memo
+    case 'json': case 'yaml': case 'yml': case 'toml': return '\u2699' // gear
+    case 'css': case 'scss': return '\ud83c\udfa8' // palette
+    case 'html': case 'svelte': case 'vue': return '\ud83c\udf10' // globe
+    case 'sql': return '\ud83d\uddc3' // file cabinet
+    case 'sh': case 'bash': return '\ud83d\udcbb' // laptop
+    case 'png': case 'jpg': case 'jpeg': case 'gif': case 'svg': return '\ud83d\uddbc' // frame
+    default: return '\ud83d\udcc4' // page
+  }
+}


### PR DESCRIPTION
## Summary
- New `artifacts.ts` module: detects file creation/modification from SSE tool call events (`write_file`, `edit_file`, `apply_patch`)
- New `ArtifactPanel.svelte`: collapsible right panel showing tracked files with extension-based icons, created/modified badges, and relative timestamps
- `ChatPanel` now tracks artifacts from live SSE events and reconstructs from session history
- `Chat.svelte` upgraded to 3-column layout (`280px | 1fr | 280px`) with auto-show artifact panel
- Pulse strip shows artifact count with toggle button

**Depends on:** #268 (feat/chat-context)

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npm run build` — successful
- [ ] Manual: ask TARS to create a file → artifact appears in panel
- [ ] Manual: artifact panel auto-shows when first artifact detected
- [ ] Manual: load existing session with file operations → artifacts reconstructed
- [ ] Manual: toggle artifact panel via pulse strip button