### PR TITLE
fix: resolve infinite loop in Chat.svelte effect

### DIFF
--- a/frontend/console/src/components/Chat.svelte
+++ b/frontend/console/src/components/Chat.svelte
@@ -20,13 +20,18 @@
   let heartbeat: HeartbeatStatus | null = $state(null)
   let unreadCount = $state(0)
 
-  // Session selection — synced via $effect from sessionId prop
+  // Session selection — synced from sessionId prop
   let selectedSessionId: string | null = $state(null)
   let chatKey = $state(0) // force ChatPanel re-mount
-  // Initialize from prop on first render
+  let lastPropSessionId: string | undefined = undefined
+
   $effect(() => {
-    selectedSessionId = sessionId || null
-    chatKey++
+    const sid = sessionId // read prop dependency
+    if (sid !== lastPropSessionId) {
+      lastPropSessionId = sid
+      selectedSessionId = sid || null
+      chatKey++
+    }
   })
 
   // Artifact panel


### PR DESCRIPTION
## Summary
- Fix `effect_update_depth_exceeded` error in `Chat.svelte` that broke the entire chat page
- Root cause: `$effect` at line 28 wrote to `selectedSessionId` and `chatKey++` on every run, triggering itself in an infinite loop
- Fix: guard with `lastPropSessionId` to only update when the `sessionId` prop actually changes

## Test plan
- [x] `npm run check` — 0 errors
- [ ] Manual: open `/console/chat` → no console errors, chat renders
- [ ] Manual: send message → response streams and displays correctly