### PR TITLE
fix: session creation, mermaid toggle, message copy, and chat export

### DIFF
--- a/frontend/console/src/app.css
+++ b/frontend/console/src/app.css
@@ -494,26 +494,35 @@ textarea { resize: vertical; min-height: 80px; }
 
 /* Mermaid diagrams */
 .chat-md .mermaid-block {
-  margin: var(--space-3) 0;
-  padding: var(--space-3);
-  background: var(--bg-surface);
+  margin: var(--space-2) 0;
+}
+.chat-md .mermaid-block .code-toolbar {
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+}
+.chat-md .mermaid-preview {
+  background: var(--bg-base);
   border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-md);
+  border-top: none;
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
+  padding: var(--space-4);
   overflow-x: auto;
   text-align: center;
+  min-height: 60px;
 }
-.chat-md .mermaid-block svg {
+.chat-md .mermaid-preview svg {
   max-width: 100%;
   height: auto;
 }
 .chat-md .mermaid-src {
   background: var(--bg-base);
   border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-sm);
+  border-top: none;
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
   padding: var(--space-3);
   font-family: var(--font-mono);
   font-size: var(--text-xs);
   text-align: left;
+  margin: 0;
 }
 .chat-md .mermaid-error {
   border-color: rgba(248, 113, 113, 0.3);

--- a/frontend/console/src/components/Chat.svelte
+++ b/frontend/console/src/components/Chat.svelte
@@ -177,6 +177,26 @@
     return selectedSession?.kind === 'main'
   }
 
+  let chatPanelRef: ChatPanel | undefined = $state()
+
+  function handleCopyChat() {
+    const md = chatPanelRef?.exportAsMarkdown()
+    if (md) navigator.clipboard.writeText(md).catch(() => {})
+  }
+
+  function handleDownloadChat() {
+    const md = chatPanelRef?.exportAsMarkdown()
+    if (!md) return
+    const title = selectedSession?.title || 'chat'
+    const blob = new Blob([md], { type: 'text/markdown' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `${title.replace(/[^a-zA-Z0-9가-힣-_ ]/g, '').slice(0, 50)}.md`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
   async function loadDashboard() {
     const [p, h, e] = await Promise.allSettled([
       listProjects(),
@@ -272,7 +292,11 @@
               <button class="btn btn-ghost btn-sm" disabled={actionBusy} onclick={handleAutoTitle} title="Generate title from first message">AI Title</button>
             {/if}
             <button class="btn btn-ghost btn-sm" disabled={actionBusy} onclick={handleCompact} title="Compress transcript">Compact</button>
+            <span class="session-actions-sep"></span>
+            <button class="btn btn-ghost btn-sm" onclick={handleCopyChat} title="Copy conversation to clipboard">Copy All</button>
+            <button class="btn btn-ghost btn-sm" onclick={handleDownloadChat} title="Download as markdown file">Download</button>
             {#if !isMainSession()}
+              <span class="session-actions-sep"></span>
               <button class="btn btn-danger btn-sm" disabled={actionBusy} onclick={handleDelete}>
                 {deleteConfirm ? 'Confirm?' : 'Delete'}
               </button>
@@ -287,6 +311,7 @@
 
       {#key chatKey}
         <ChatPanel
+          bind:this={chatPanelRef}
           sessionId={selectedSessionId || undefined}
           {initialPrompt}
           onSessionChange={handleSessionChange}
@@ -447,6 +472,13 @@
     align-items: center;
     gap: var(--space-1);
     flex-shrink: 0;
+  }
+
+  .session-actions-sep {
+    width: 1px;
+    height: 16px;
+    background: var(--border-subtle);
+    margin: 0 var(--space-1);
   }
 
   @media (max-width: 768px) {

--- a/frontend/console/src/components/ChatPanel.svelte
+++ b/frontend/console/src/components/ChatPanel.svelte
@@ -224,7 +224,7 @@
       await streamChat(
         {
           message,
-          session_id: chatSessionId || undefined,
+          session_id: chatSessionId || 'new',
           project_id: projectId || undefined,
           attachments: chatAttachments,
         },
@@ -325,6 +325,30 @@
       })
     }
     return results
+  }
+
+  function copyMessageText(text: string) {
+    navigator.clipboard.writeText(text).catch(() => {})
+  }
+
+  export function exportAsMarkdown(): string {
+    const lines: string[] = []
+    for (const msg of chatMessages) {
+      if (msg.role === 'system') continue
+      if (msg.role === 'tool') {
+        lines.push(`> **Tool: ${msg.toolName}**`)
+        if (msg.toolArgs) lines.push(`> Args: \`${msg.toolArgs}\``)
+        if (msg.toolResult) lines.push(`> Result: \`${msg.toolResult}\``)
+        lines.push('')
+      } else if (msg.role === 'user') {
+        lines.push(`### User\n\n${msg.text}\n`)
+      } else if (msg.role === 'assistant') {
+        lines.push(`### Assistant\n\n${msg.text}\n`)
+      } else if (msg.role === 'error') {
+        lines.push(`> **Error:** ${msg.text}\n`)
+      }
+    }
+    return lines.join('\n')
   }
 
   function fmtSize(bytes: number): string {
@@ -432,14 +456,6 @@
       <div class="drop-label">Drop files here</div>
     </div>
   {/if}
-  <div class="chat-toolbar-row">
-    <div class="chat-status">
-      {chatBusy ? 'streaming' : chatStatusLine || 'idle'}
-    </div>
-    {#if chatSessionId}
-      <span class="session-id" title={chatSessionId}>{chatSessionId.slice(0, 8)}</span>
-    {/if}
-  </div>
   <div class="chat-log" bind:this={chatLogEl} onscroll={handleScroll}>
     {#each chatMessages as msg}
       {#if msg.role === 'tool'}
@@ -468,7 +484,12 @@
         </div>
       {:else}
         <div class="chat-msg chat-{msg.role}">
-          <span class="chat-role">{msg.role}</span>
+          <div class="chat-msg-header">
+            <span class="chat-role">{msg.role}</span>
+            {#if (msg.role === 'assistant' || msg.role === 'user') && msg.text}
+              <button type="button" class="msg-copy-btn" title="Copy message" onclick={() => copyMessageText(msg.text)}>Copy</button>
+            {/if}
+          </div>
           {#if msg.role === 'assistant'}
             <div class="chat-text"><MarkdownContent text={msg.text} /></div>
           {:else}
@@ -563,27 +584,6 @@
     color: var(--accent);
   }
 
-  .chat-toolbar-row {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: var(--space-2);
-  }
-
-  .chat-status {
-    font-size: var(--text-xs);
-    color: var(--text-tertiary);
-  }
-
-  .session-id {
-    font-family: var(--font-mono);
-    font-size: 10px;
-    color: var(--text-ghost);
-    background: var(--bg-elevated);
-    padding: 1px var(--space-1);
-    border-radius: var(--radius-sm);
-  }
-
   .chat-log {
     display: grid;
     gap: var(--space-2);
@@ -670,14 +670,34 @@
     overflow-y: auto;
   }
 
+  .chat-msg-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: var(--space-1);
+  }
+
   .chat-role {
     font-family: var(--font-display);
     font-size: var(--text-xs);
     font-weight: 500;
     color: var(--text-tertiary);
-    margin-bottom: var(--space-1);
-    display: block;
   }
+
+  .msg-copy-btn {
+    background: none;
+    border: none;
+    color: var(--text-ghost);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    cursor: pointer;
+    padding: 1px 6px;
+    border-radius: var(--radius-sm);
+    opacity: 0;
+    transition: opacity var(--duration-fast), color var(--duration-fast);
+  }
+  .chat-msg:hover .msg-copy-btn { opacity: 1; }
+  .msg-copy-btn:hover { color: var(--accent); }
 
   .chat-text {
     white-space: pre-wrap;

--- a/frontend/console/src/components/MarkdownContent.svelte
+++ b/frontend/console/src/components/MarkdownContent.svelte
@@ -38,27 +38,42 @@
       })
     }
 
-    // Code/Preview toggle buttons
+    // Code/Preview toggle buttons (for code-block and mermaid-block)
     for (const btn of containerEl.querySelectorAll<HTMLButtonElement>('.code-toggle')) {
       on(btn, 'click', () => {
-        const block = btn.closest('.code-block')
+        const block = btn.closest('.code-block, .mermaid-block')
         if (!block) return
         const mode = btn.getAttribute('data-mode')
-        const pre = block.querySelector('pre')
-        const preview = block.querySelector<HTMLElement>('[data-preview]')
-        if (!pre || !preview) return
 
         // Update active state on sibling toggles
         for (const sib of block.querySelectorAll('.code-toggle')) {
           sib.classList.toggle('active', sib === btn)
         }
 
-        if (mode === 'preview') {
-          pre.style.display = 'none'
-          preview.style.display = 'block'
-        } else {
-          pre.style.display = ''
-          preview.style.display = 'none'
+        // For code-block (html/svg preview)
+        const codeBlockPre = block.querySelector<HTMLElement>(':scope > pre')
+        const codeBlockPreview = block.querySelector<HTMLElement>('[data-preview]')
+        if (codeBlockPre && codeBlockPreview) {
+          if (mode === 'preview') {
+            codeBlockPre.style.display = 'none'
+            codeBlockPreview.style.display = 'block'
+          } else {
+            codeBlockPre.style.display = ''
+            codeBlockPreview.style.display = 'none'
+          }
+        }
+
+        // For mermaid-block (code/diagram toggle)
+        const mermaidSrc = block.querySelector<HTMLElement>('.mermaid-src')
+        const mermaidPreview = block.querySelector<HTMLElement>('[data-mermaid-preview]')
+        if (mermaidSrc && mermaidPreview) {
+          if (mode === 'code') {
+            mermaidSrc.style.display = ''
+            mermaidPreview.style.display = 'none'
+          } else {
+            mermaidSrc.style.display = 'none'
+            mermaidPreview.style.display = ''
+          }
         }
       })
     }
@@ -107,12 +122,15 @@
       const block = freshBlocks[i]
       const graph = block.getAttribute('data-graph')
       if (!graph) continue
+      const previewEl = block.querySelector<HTMLElement>('[data-mermaid-preview]')
+      if (!previewEl) continue
       try {
         const id = `mermaid-${Date.now()}-${i}`
         const { svg } = await mermaidModule!.render(id, graph)
-        block.innerHTML = svg
+        previewEl.innerHTML = svg
         block.setAttribute('data-rendered', 'true')
       } catch {
+        previewEl.innerHTML = '<span style="color:var(--error);font-size:var(--text-xs)">Diagram render failed</span>'
         block.classList.add('mermaid-error')
         block.setAttribute('data-rendered', 'true')
       }

--- a/frontend/console/src/lib/markdown.ts
+++ b/frontend/console/src/lib/markdown.ts
@@ -77,9 +77,9 @@ const marked = new Marked({
     code({ text, lang }: { text: string; lang?: string }) {
       const language = lang?.trim().toLowerCase() || ''
 
-      // Mermaid diagrams: render as placeholder for lazy-load
+      // Mermaid diagrams: toolbar + code/preview toggle + lazy-load
       if (language === 'mermaid') {
-        return `<div class="mermaid-block" data-graph="${escapeAttr(text)}"><pre class="mermaid-src"><code>${escapeAttr(text)}</code></pre></div>`
+        return `<div class="mermaid-block" data-graph="${escapeAttr(text)}"><div class="code-toolbar"><span class="code-lang">mermaid</span><div class="code-actions"><button type="button" class="code-toggle" data-mode="code" title="View code">Code</button><button type="button" class="code-toggle active" data-mode="preview" title="Preview diagram">Preview</button><button type="button" class="code-copy" data-code="${escapeAttr(text)}" title="Copy code">Copy</button></div></div><pre class="mermaid-src" style="display:none"><code>${escapeAttr(text)}</code></pre><div class="mermaid-preview" data-mermaid-preview></div></div>`
       }
 
       // Syntax highlighting


### PR DESCRIPTION
## Summary

### Bugs fixed
- **Session kind always "main"**: New chats sent `session_id: undefined` which resolved to the main session. Now sends `session_id: "new"` to create dedicated sessions with `kind: ""`
- **Mermaid no toggle**: Mermaid blocks had no Code/Preview switch. Now has toolbar with Code/Preview toggle (default: Preview shows rendered diagram)
- **idle/session-id clutter**: Removed redundant status toolbar from ChatPanel (session info is in Chat.svelte header)

### Features added
- **Per-message copy**: Hover-visible Copy button on each user/assistant message
- **Chat export**: "Copy All" (clipboard) and "Download" (.md file) buttons in session header
- **Mermaid toolbar**: Language label + Code/Preview toggle + Copy button, matching code block style

## Test plan
- [x] `npm run check` — 0 errors
- [x] `make build` — success
- [ ] Manual: new chat → session created with kind="" (not "main")
- [ ] Manual: mermaid diagram → Code/Preview toggle works
- [ ] Manual: hover message → Copy button appears
- [ ] Manual: Copy All → full conversation in clipboard
- [ ] Manual: Download → .md file downloaded