### PR TITLE
fix: sidebar toggle UX and message copy button position

### DIFF
--- a/frontend/console/src/components/ChatPanel.svelte
+++ b/frontend/console/src/components/ChatPanel.svelte
@@ -484,16 +484,16 @@
         </div>
       {:else}
         <div class="chat-msg chat-{msg.role}">
-          <div class="chat-msg-header">
-            <span class="chat-role">{msg.role}</span>
-            {#if (msg.role === 'assistant' || msg.role === 'user') && msg.text}
-              <button type="button" class="msg-copy-btn" title="Copy message" onclick={() => copyMessageText(msg.text)}>Copy</button>
-            {/if}
-          </div>
+          <span class="chat-role">{msg.role}</span>
           {#if msg.role === 'assistant'}
             <div class="chat-text"><MarkdownContent text={msg.text} /></div>
           {:else}
             <div class="chat-text">{msg.text || '\u2026'}</div>
+          {/if}
+          {#if (msg.role === 'assistant' || msg.role === 'user') && msg.text}
+            <div class="chat-msg-footer">
+              <button type="button" class="msg-copy-btn" title="Copy message" onclick={() => copyMessageText(msg.text)}>Copy</button>
+            </div>
           {/if}
         </div>
       {/if}
@@ -670,34 +670,36 @@
     overflow-y: auto;
   }
 
-  .chat-msg-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: var(--space-1);
-  }
-
   .chat-role {
     font-family: var(--font-display);
     font-size: var(--text-xs);
     font-weight: 500;
     color: var(--text-tertiary);
+    margin-bottom: var(--space-1);
+    display: block;
   }
 
+  .chat-msg-footer {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: var(--space-2);
+    opacity: 0;
+    transition: opacity var(--duration-fast);
+  }
+  .chat-msg:hover .chat-msg-footer { opacity: 1; }
+
   .msg-copy-btn {
-    background: none;
-    border: none;
+    background: var(--bg-base);
+    border: 1px solid var(--border-subtle);
     color: var(--text-ghost);
     font-family: var(--font-mono);
     font-size: 10px;
     cursor: pointer;
-    padding: 1px 6px;
+    padding: 2px 10px;
     border-radius: var(--radius-sm);
-    opacity: 0;
-    transition: opacity var(--duration-fast), color var(--duration-fast);
+    transition: all var(--duration-fast);
   }
-  .chat-msg:hover .msg-copy-btn { opacity: 1; }
-  .msg-copy-btn:hover { color: var(--accent); }
+  .msg-copy-btn:hover { color: var(--accent); border-color: var(--accent); }
 
   .chat-text {
     white-space: pre-wrap;

--- a/frontend/console/src/components/SessionSidebar.svelte
+++ b/frontend/console/src/components/SessionSidebar.svelte
@@ -182,10 +182,9 @@
     <button type="button" class="btn btn-primary btn-sm new-chat-btn" onclick={onNewSession}>
       + New Chat
     </button>
-    <label class="sidebar-toggle" title="Show worker sessions">
-      <input type="checkbox" checked={showHidden} onchange={toggleHidden} />
-      <span class="toggle-icon">{showHidden ? '\u25C9' : '\u25CB'}</span>
-    </label>
+    <button type="button" class="btn btn-ghost btn-sm" onclick={toggleHidden} title={showHidden ? 'Hide worker sessions' : 'Show worker sessions'}>
+      {showHidden ? 'All' : 'Active'}
+    </button>
   </div>
 
   <input type="text" class="sidebar-search" placeholder="Search..." bind:value={searchQuery} />
@@ -280,18 +279,6 @@
 
   .new-chat-btn {
     flex: 1;
-  }
-
-  .sidebar-toggle {
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-    flex-shrink: 0;
-  }
-  .sidebar-toggle input { display: none; }
-  .toggle-icon {
-    font-size: var(--text-md);
-    color: var(--text-tertiary);
   }
 
   .sidebar-search {


### PR DESCRIPTION
## Summary
- **Sidebar toggle**: Replace cryptic checkbox+circle icon with labeled "Active"/"All" ghost button — clearly indicates worker session visibility
- **Copy button position**: Move from message header (top) to footer (bottom) — no more scrolling up on long responses to find the copy button
- Copy button is hover-visible with bordered style for better affordance

## Test plan
- [x] `npm run check` — 0 errors
- [ ] Manual: sidebar shows "Active" button, click toggles to "All" (shows worker sessions)
- [ ] Manual: hover message → Copy button at bottom of card
- [ ] Manual: main session selectable in sidebar for continued chat