### PR TITLE
fix: strengthen memory_search prompt to always include session transcripts

### DIFF
--- a/internal/tarsserver/main_options.go
+++ b/internal/tarsserver/main_options.go
@@ -54,7 +54,8 @@ const memoryToolSystemRule = `
 ## Memory Tool Policy
 - Before answering questions that may relate to prior conversations, decisions, dates, people, preferences, habits, or any topic discussed in past sessions, you MUST call memory_search first.
 - Do not guess memory-backed facts without first checking tools.
-- When the user references something from a previous conversation (e.g., "that thing we discussed", "last time", "continue", "그거", "아까 그", "전에 말한", "지난번"), call memory_search with include_sessions=true to find the relevant conversation context.
+- When calling memory_search, ALWAYS pass include_sessions=true. This searches past chat session transcripts across all sessions, enabling cross-session context recall.
+- When the user references something from a previous conversation (e.g., "that thing we discussed", "last time", "continue", "그거", "아까 그", "전에 말한", "지난번"), memory_search is mandatory — do not skip it.
 - If memory_search returns relevant prior context, weave it naturally into your response — do not dump raw search results.
 - When you discover useful context from memory, briefly acknowledge it (e.g., "Based on our previous conversation...") before continuing.
 - Tool-call arguments must be valid JSON.

--- a/internal/tool/memory_search.go
+++ b/internal/tool/memory_search.go
@@ -45,7 +45,7 @@ func NewMemorySearchTool(workspaceDir string, semantic *memory.Service) Tool {
     "limit":{"type":"integer","minimum":1,"maximum":30,"default":8},
     "include_memory":{"type":"boolean","default":true},
     "include_daily":{"type":"boolean","default":true},
-    "include_sessions":{"type":"boolean","default":false,"description":"Search past session transcripts for conversational continuity."}
+    "include_sessions":{"type":"boolean","default":false,"description":"Search past session transcripts for conversational continuity. Always set to true when called."}
   },
   "required":["query"],
   "additionalProperties":false


### PR DESCRIPTION
## Summary
LLM was calling `memory_search` without `include_sessions=true`, so cross-session recall always returned "no matches found" even when relevant content existed in other chat sessions.

**Root cause**: The system prompt only said to use `include_sessions=true` "when the user references previous conversations" — but LLM often didn't detect this intent.

**Fix**: Strengthen the Memory Tool Policy in system prompt:
- "ALWAYS pass `include_sessions=true`" — unconditional instruction
- Make session search mandatory for any prior conversation reference
- Update tool parameter description to hint "Always set to true when called"

Code default remains `false` (backward compatible for API callers), but the system prompt ensures LLM always enables it.

## Test plan
- [x] `make test` — memory_search tests pass
- [ ] Manual: ask about weather in one session, ask "what did I ask about?" in another → should find it