### PR TITLE
fix: enforce main session uniqueness and remove redundant sidebar toggle

### DIFF
--- a/frontend/console/src/components/SessionSidebar.svelte
+++ b/frontend/console/src/components/SessionSidebar.svelte
@@ -14,7 +14,6 @@
   let sessions: Session[] = $state([])
   let loading = $state(true)
   let error = $state('')
-  let showHidden = $state(false)
 
   let searchQuery = $state('')
   let sortBy: 'updated' | 'name' = $state('updated')
@@ -82,17 +81,12 @@
     loading = true
     error = ''
     try {
-      sessions = await listSessions(showHidden)
+      sessions = await listSessions(true)
     } catch (err) {
       error = err instanceof Error ? err.message : 'Failed to load sessions'
     } finally {
       loading = false
     }
-  }
-
-  function toggleHidden() {
-    showHidden = !showHidden
-    void load()
   }
 
   function startRename(s: Session) {
@@ -181,9 +175,6 @@
   <div class="sidebar-header">
     <button type="button" class="btn btn-primary btn-sm new-chat-btn" onclick={onNewSession}>
       + New Chat
-    </button>
-    <button type="button" class="btn btn-ghost btn-sm" onclick={toggleHidden} title={showHidden ? 'Hide worker sessions' : 'Show worker sessions'}>
-      {showHidden ? 'All' : 'Active'}
     </button>
   </div>
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -36,10 +36,17 @@ func (s *Store) Create(title string) (Session, error) {
 }
 
 func (s *Store) CreateWithOptions(title string, kind string, hidden bool) (Session, error) {
+	trimmedKind := strings.TrimSpace(kind)
+
+	// Enforce main session uniqueness: use EnsureMain() instead.
+	if trimmedKind == "main" {
+		return Session{}, fmt.Errorf("cannot create main session directly; use EnsureMain()")
+	}
+
 	now := time.Now().UTC()
 	session := Session{
 		Title:     title,
-		Kind:      strings.TrimSpace(kind),
+		Kind:      trimmedKind,
 		Hidden:    hidden,
 		CreatedAt: now,
 		UpdatedAt: now,
@@ -78,7 +85,45 @@ func (s *Store) CreateWithOptions(title string, kind string, hidden bool) (Sessi
 }
 
 func (s *Store) EnsureMain() (Session, error) {
+	// Deduplicate any stale main sessions before ensuring
+	s.deduplicateMain()
 	return s.ensureNamedSession("main", "main", false)
+}
+
+// deduplicateMain removes duplicate main sessions, keeping only the oldest.
+func (s *Store) deduplicateMain() {
+	unlock := lockPath(s.indexPath())
+	defer unlock()
+	index, err := s.loadIndex()
+	if err != nil {
+		return
+	}
+	var mains []Session
+	for _, sess := range index {
+		if strings.TrimSpace(sess.Kind) == "main" {
+			mains = append(mains, sess)
+		}
+	}
+	if len(mains) <= 1 {
+		return
+	}
+	// Keep the oldest main session, remove the rest
+	oldest := mains[0]
+	for _, m := range mains[1:] {
+		if m.CreatedAt.Before(oldest.CreatedAt) {
+			oldest = m
+		}
+	}
+	changed := false
+	for _, m := range mains {
+		if m.ID != oldest.ID {
+			delete(index, m.ID)
+			changed = true
+		}
+	}
+	if changed {
+		_ = s.saveIndex(index)
+	}
 }
 
 func (s *Store) EnsureWorker(projectID string) (Session, error) {


### PR DESCRIPTION
## Summary

### Main session uniqueness
- `CreateWithOptions()` now rejects `kind="main"` — forces callers to use `EnsureMain()` which guarantees a single main session
- `EnsureMain()` now calls `deduplicateMain()` on every invocation: finds all sessions with `kind="main"`, keeps the oldest, deletes the rest
- Prevents future duplication and cleans up existing duplicate main sessions on next server start

### Sidebar cleanup
- Remove "Active"/"All" toggle button — redundant with the `all/session/main/worker/project` kind filter buttons already present
- Always load all sessions (including hidden) so kind filters work correctly

## Test plan
- [x] Session tests pass
- [x] `npm run check` — 0 errors
- [ ] Manual: restart server → duplicate main sessions cleaned up
- [ ] Manual: only one "main" badge session in sidebar
- [ ] Manual: kind filter buttons still work for all/worker/project