### PR TITLE
feat: chat cancellation, per-session tool config, context monitor, prompt editor

### DIFF
--- a/frontend/console/src/components/Chat.svelte
+++ b/frontend/console/src/components/Chat.svelte
@@ -9,6 +9,9 @@
   import SessionSidebar from './SessionSidebar.svelte'
   import ChatPanel from './ChatPanel.svelte'
   import ArtifactPanel from './ArtifactPanel.svelte'
+  import SessionConfigPanel from './SessionConfigPanel.svelte'
+  import ContextMonitor from './ContextMonitor.svelte'
+  import PromptEditor from './PromptEditor.svelte'
 
   interface Props {
     sessionId?: string
@@ -46,9 +49,10 @@
   let actionBusy = $state(false)
   let deleteConfirm = $state(false)
 
-  // Artifact panel
+  // Right panel state
   let chatArtifacts: Artifact[] = $state([])
-  let showArtifacts = $state(false)
+  type RightPanel = 'none' | 'artifacts' | 'config' | 'context' | 'prompt'
+  let rightPanel = $state<RightPanel>('none')
 
   let sidebarRef: SessionSidebar | undefined = $state()
   let stopStream: (() => void) | null = null
@@ -75,7 +79,7 @@
     selectedSession = session
     chatKey++
     chatArtifacts = []
-    showArtifacts = false
+    rightPanel = 'none'
     renaming = false
     deleteConfirm = false
     onNavigate(`/console/chat/${encodeURIComponent(session.id)}`)
@@ -86,7 +90,7 @@
     selectedSession = null
     chatKey++
     chatArtifacts = []
-    showArtifacts = false
+    rightPanel = 'none'
     renaming = false
     deleteConfirm = false
     onNavigate('/console/chat')
@@ -100,9 +104,13 @@
 
   function handleArtifactsChange(arts: Artifact[]) {
     chatArtifacts = arts
-    if (arts.length > 0 && !showArtifacts) {
-      showArtifacts = true
+    if (arts.length > 0 && rightPanel === 'none') {
+      rightPanel = 'artifacts'
     }
+  }
+
+  function togglePanel(panel: RightPanel) {
+    rightPanel = rightPanel === panel ? 'none' : panel
   }
 
   // Session actions
@@ -249,14 +257,20 @@
     </div>
     {#if chatArtifacts.length > 0}
       <div class="pulse-sep"></div>
-      <button type="button" class="pulse-artifact-btn" onclick={() => { showArtifacts = !showArtifacts }}>
+      <button type="button" class="pulse-artifact-btn" class:active={rightPanel === 'artifacts'} onclick={() => togglePanel('artifacts')}>
         <span class="pulse-val">{chatArtifacts.length}</span>
-        <span class="pulse-lbl">Artifacts {showArtifacts ? '\u25B8' : '\u25C2'}</span>
+        <span class="pulse-lbl">Artifacts</span>
       </button>
     {/if}
+    <div class="pulse-sep"></div>
+    <div class="pulse-panel-toggles">
+      <button type="button" class="pulse-toggle-btn" class:active={rightPanel === 'config'} onclick={() => togglePanel('config')} title="Session tool config">Config</button>
+      <button type="button" class="pulse-toggle-btn" class:active={rightPanel === 'context'} onclick={() => togglePanel('context')} title="Context monitor">Context</button>
+      <button type="button" class="pulse-toggle-btn" class:active={rightPanel === 'prompt'} onclick={() => togglePanel('prompt')} title="Prompt editor">Prompt</button>
+    </div>
   </div>
 
-  <div class="chat-layout" class:has-artifacts={showArtifacts}>
+  <div class="chat-layout" class:has-right-panel={rightPanel !== 'none'}>
     <!-- Session sidebar -->
     <aside class="chat-sidebar">
       <SessionSidebar
@@ -320,10 +334,18 @@
       {/key}
     </main>
 
-    <!-- Artifact panel -->
-    {#if showArtifacts}
-      <aside class="chat-artifacts">
-        <ArtifactPanel artifacts={chatArtifacts} onClose={() => { showArtifacts = false }} />
+    <!-- Right panel -->
+    {#if rightPanel !== 'none'}
+      <aside class="chat-right-panel">
+        {#if rightPanel === 'artifacts'}
+          <ArtifactPanel artifacts={chatArtifacts} onClose={() => { rightPanel = 'none' }} />
+        {:else if rightPanel === 'config' && (selectedSessionId || true)}
+          <SessionConfigPanel sessionId={selectedSessionId ?? ''} onClose={() => { rightPanel = 'none' }} />
+        {:else if rightPanel === 'context'}
+          <ContextMonitor sessionId={selectedSessionId ?? ''} onClose={() => { rightPanel = 'none' }} />
+        {:else if rightPanel === 'prompt'}
+          <PromptEditor sessionId={selectedSessionId ?? ''} onClose={() => { rightPanel = 'none' }} />
+        {/if}
       </aside>
     {/if}
   </div>
@@ -390,6 +412,35 @@
   .pulse-artifact-btn:hover {
     background: var(--bg-elevated);
   }
+  .pulse-artifact-btn.active {
+    background: rgba(224, 145, 69, 0.12);
+  }
+
+  .pulse-panel-toggles {
+    display: flex;
+    gap: 2px;
+  }
+
+  .pulse-toggle-btn {
+    background: none;
+    border: 1px solid var(--border-subtle);
+    color: var(--text-ghost);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    cursor: pointer;
+    padding: 2px 8px;
+    border-radius: var(--radius-sm);
+    transition: all var(--duration-fast);
+  }
+  .pulse-toggle-btn:hover {
+    color: var(--text-primary);
+    border-color: var(--border-default);
+  }
+  .pulse-toggle-btn.active {
+    color: var(--accent);
+    border-color: var(--accent);
+    background: rgba(224, 145, 69, 0.08);
+  }
 
   /* Layout */
   .chat-layout {
@@ -398,8 +449,8 @@
     grid-template-columns: 280px 1fr;
     min-height: 0;
   }
-  .chat-layout.has-artifacts {
-    grid-template-columns: 280px 1fr 280px;
+  .chat-layout.has-right-panel {
+    grid-template-columns: 280px 1fr 300px;
   }
 
   .chat-sidebar {
@@ -418,10 +469,9 @@
     overflow: hidden;
   }
 
-  .chat-artifacts {
-    border-left: 1px solid var(--border-subtle);
-    background: var(--bg-surface);
+  .chat-right-panel {
     overflow: hidden;
+    min-height: 0;
   }
 
   /* Session header */
@@ -482,10 +532,10 @@
   }
 
   @media (max-width: 768px) {
-    .chat-layout, .chat-layout.has-artifacts {
+    .chat-layout, .chat-layout.has-right-panel {
       grid-template-columns: 1fr;
     }
-    .chat-sidebar, .chat-artifacts {
+    .chat-sidebar, .chat-right-panel {
       display: none;
     }
     .chat-pulse {

--- a/frontend/console/src/components/ChatPanel.svelte
+++ b/frontend/console/src/components/ChatPanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount, tick } from 'svelte'
-  import { streamChat, listSessions, getSessionHistory, renameSession } from '../lib/api'
+  import { streamChat, cancelChat, listSessions, getSessionHistory, renameSession } from '../lib/api'
   import type { ChatAttachment, ChatEvent, SessionMessage } from '../lib/types'
   import { extractArtifact, extractArtifactsFromHistory, type Artifact } from '../lib/artifacts'
   import MarkdownContent from './MarkdownContent.svelte'
@@ -14,6 +14,7 @@
     toolArgs?: string
     toolResult?: string
     toolDone?: boolean
+    usage?: { input_tokens: number; output_tokens: number; cached_tokens: number; cache_read_tokens: number; cache_write_tokens: number }
   }
 
   interface Props {
@@ -37,6 +38,8 @@
   let chatMessages: ChatMessage[] = $state([])
   let autoTitled = $state(false)
   let autoSendDone = false
+  let abortController: AbortController | null = $state(null)
+  let contextInfo: { system_prompt_tokens?: number; history_tokens?: number; history_messages?: number; tool_count?: number; memory_count?: number; memory_tokens?: number; tool_names?: string[] } = $state({})
 
   // One-shot auto-send: fires once when autoSend becomes true with a prompt
   $effect(() => {
@@ -176,9 +179,28 @@
         }
         break
       }
-      case 'done':
+      case 'context_info':
+        contextInfo = {
+          system_prompt_tokens: event.system_prompt_tokens,
+          history_tokens: event.history_tokens,
+          history_messages: event.history_messages,
+          tool_count: event.tool_count,
+          memory_count: event.memory_count,
+          memory_tokens: event.memory_tokens,
+          tool_names: event.tool_names,
+        }
+        break
+      case 'done': {
         chatSessionId = event.session_id?.trim() || chatSessionId
         chatStatusLine = 'done'
+        // Attach usage to assistant message
+        if (event.usage) {
+          const aIdx = chatMessages.findIndex((m) => m.id === assistantId)
+          if (aIdx >= 0) {
+            chatMessages[aIdx] = { ...chatMessages[aIdx], usage: event.usage }
+            chatMessages = [...chatMessages]
+          }
+        }
         // Auto-title: use first user message as session title for new sessions
         if (chatSessionId && !autoTitled) {
           autoTitled = true
@@ -188,6 +210,11 @@
             renameSession(chatSessionId, title).catch(() => {})
           }
         }
+        onSessionChange?.()
+        break
+      }
+      case 'cancelled':
+        chatStatusLine = 'cancelled'
         onSessionChange?.()
         break
       case 'error':
@@ -219,6 +246,8 @@
       { id: assistantId, role: 'assistant', text: '' },
     ]
     void scrollToBottom()
+    const ac = new AbortController()
+    abortController = ac
     try {
       const chatAttachments = currentFiles.length > 0 ? await filesToAttachments(currentFiles) : undefined
       await streamChat(
@@ -229,14 +258,27 @@
           attachments: chatAttachments,
         },
         (event) => handleChatEvent(event, assistantId),
+        ac.signal,
       )
     } catch (err) {
-      chatError = err instanceof Error ? err.message : 'Failed to send'
-      chatMessages = [...chatMessages, { id: `error-${Date.now()}`, role: 'error', text: chatError }]
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        // User cancelled — no error to show
+      } else {
+        chatError = err instanceof Error ? err.message : 'Failed to send'
+        chatMessages = [...chatMessages, { id: `error-${Date.now()}`, role: 'error', text: chatError }]
+      }
     } finally {
+      abortController = null
       chatBusy = false
       void scrollToBottom()
     }
+  }
+
+  async function handleCancel() {
+    if (chatSessionId) {
+      await cancelChat(chatSessionId)
+    }
+    abortController?.abort()
   }
 
   // -- File attachments --
@@ -492,6 +534,9 @@
           {/if}
           {#if (msg.role === 'assistant' || msg.role === 'user') && msg.text}
             <div class="chat-msg-footer">
+              {#if msg.usage}
+                <span class="usage-badge" title="Token usage">In: {msg.usage.input_tokens.toLocaleString()} &middot; Out: {msg.usage.output_tokens.toLocaleString()}{msg.usage.cache_read_tokens ? ` \u00b7 Cached: ${msg.usage.cache_read_tokens.toLocaleString()}` : ''}</span>
+              {/if}
               <button type="button" class="msg-copy-btn" title="Copy message" onclick={() => copyMessageText(msg.text)}>Copy</button>
             </div>
           {/if}
@@ -550,9 +595,16 @@
         onpaste={handlePaste}
       ></textarea>
     </div>
-    <button type="submit" class="btn btn-primary" disabled={chatBusy || !chatInput.trim()}>
-      {chatBusy ? 'Streaming...' : 'Send'}
-    </button>
+    <div class="chat-form-actions">
+      {#if chatBusy}
+        <button type="button" class="btn btn-danger btn-sm" onclick={handleCancel}>Stop</button>
+      {:else}
+        <button type="submit" class="btn btn-primary" disabled={!chatInput.trim()}>Send</button>
+      {/if}
+      {#if chatStatusLine && chatBusy}
+        <span class="chat-status-line">{chatStatusLine}</span>
+      {/if}
+    </div>
   </form>
 </div>
 
@@ -844,6 +896,31 @@
   }
 
   .toolbar-icon { font-size: 14px; }
+
+  .chat-form-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .chat-status-line {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--text-ghost);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .usage-badge {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-ghost);
+    background: rgba(255, 255, 255, 0.04);
+    padding: 1px 6px;
+    border-radius: var(--radius-sm);
+    margin-right: auto;
+  }
 
   .file-input-hidden {
     position: absolute;

--- a/frontend/console/src/components/ContextMonitor.svelte
+++ b/frontend/console/src/components/ContextMonitor.svelte
@@ -1,0 +1,269 @@
+<script lang="ts">
+  import { getChatContext, type ChatContextInfo } from '../lib/api'
+
+  interface Props {
+    sessionId: string
+    contextInfo?: {
+      system_prompt_tokens?: number
+      history_tokens?: number
+      history_messages?: number
+      tool_count?: number
+      memory_count?: number
+      memory_tokens?: number
+      tool_names?: string[]
+    }
+    onClose?: () => void
+  }
+
+  let { sessionId, contextInfo, onClose }: Props = $props()
+
+  let fullContext = $state<ChatContextInfo | null>(null)
+  let loading = $state(false)
+  let showPrompt = $state(false)
+
+  async function loadFullContext() {
+    if (!sessionId) return
+    loading = true
+    try {
+      fullContext = await getChatContext(sessionId)
+    } catch {
+      // ignore
+    }
+    loading = false
+  }
+
+  function valOr(a: number | undefined, b: number | undefined): number {
+    return a ?? b ?? 0
+  }
+
+  let totalTokens = $derived(
+    valOr(contextInfo?.system_prompt_tokens, fullContext?.system_prompt_tokens) +
+    valOr(contextInfo?.history_tokens, fullContext?.history_tokens) +
+    valOr(contextInfo?.memory_tokens, fullContext?.memory_tokens)
+  )
+
+  let contextLimit = 200000
+  let usagePercent = $derived(Math.min(100, (totalTokens / contextLimit) * 100))
+  let usageColor = $derived(
+    usagePercent > 80 ? 'var(--error)' : usagePercent > 50 ? 'var(--warning, #f59e0b)' : 'var(--success, #22c55e)'
+  )
+
+  $effect(() => {
+    if (sessionId) void loadFullContext()
+  })
+</script>
+
+<div class="monitor-panel">
+  <div class="monitor-header">
+    <span class="monitor-title">Context Monitor</span>
+    {#if onClose}
+      <button class="monitor-close" onclick={onClose}>&times;</button>
+    {/if}
+  </div>
+
+  <div class="monitor-bar-container">
+    <div class="monitor-bar" style="width: {usagePercent}%; background: {usageColor};"></div>
+  </div>
+  <div class="monitor-bar-label">
+    {totalTokens.toLocaleString()} / {contextLimit.toLocaleString()} tokens ({usagePercent.toFixed(1)}%)
+  </div>
+
+  <div class="monitor-grid">
+    <div class="monitor-stat">
+      <span class="stat-label">System Prompt</span>
+      <span class="stat-value">{(contextInfo?.system_prompt_tokens ?? fullContext?.system_prompt_tokens ?? 0).toLocaleString()}</span>
+    </div>
+    <div class="monitor-stat">
+      <span class="stat-label">History</span>
+      <span class="stat-value">{(contextInfo?.history_tokens ?? fullContext?.history_tokens ?? 0).toLocaleString()} ({contextInfo?.history_messages ?? fullContext?.history_messages ?? 0} msgs)</span>
+    </div>
+    <div class="monitor-stat">
+      <span class="stat-label">Tools</span>
+      <span class="stat-value">{contextInfo?.tool_count ?? fullContext?.tool_count ?? 0}</span>
+    </div>
+    <div class="monitor-stat">
+      <span class="stat-label">Memory</span>
+      <span class="stat-value">{(contextInfo?.memory_count ?? fullContext?.memory_count ?? 0)} ({(contextInfo?.memory_tokens ?? fullContext?.memory_tokens ?? 0).toLocaleString()} tokens)</span>
+    </div>
+  </div>
+
+  {#if fullContext?.tool_names && fullContext.tool_names.length > 0}
+    <div class="monitor-section">
+      <span class="section-title">Injected Tools</span>
+      <div class="tool-chips">
+        {#each fullContext.tool_names as name}
+          <span class="tool-chip">{name}</span>
+        {/each}
+      </div>
+    </div>
+  {/if}
+
+  {#if fullContext?.system_prompt}
+    <div class="monitor-section">
+      <button class="section-toggle" onclick={() => showPrompt = !showPrompt}>
+        {showPrompt ? '\u25BC' : '\u25B6'} System Prompt
+      </button>
+      {#if showPrompt}
+        <pre class="prompt-preview">{fullContext.system_prompt}</pre>
+      {/if}
+    </div>
+  {/if}
+
+  <div class="monitor-actions">
+    <button class="btn btn-ghost btn-sm" onclick={loadFullContext} disabled={loading}>
+      {loading ? 'Loading...' : 'Refresh'}
+    </button>
+  </div>
+</div>
+
+<style>
+  .monitor-panel {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+    background: var(--bg-surface);
+    border-left: 1px solid var(--border-subtle);
+  }
+
+  .monitor-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-2) var(--space-3);
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .monitor-title {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: var(--text-sm);
+    color: var(--text-primary);
+  }
+
+  .monitor-close {
+    background: none;
+    border: none;
+    color: var(--text-ghost);
+    cursor: pointer;
+    font-size: 18px;
+    padding: 0;
+    line-height: 1;
+  }
+  .monitor-close:hover { color: var(--text-primary); }
+
+  .monitor-bar-container {
+    height: 4px;
+    background: var(--bg-base);
+    margin: var(--space-2) var(--space-3) 0;
+    border-radius: 2px;
+    overflow: hidden;
+  }
+
+  .monitor-bar {
+    height: 100%;
+    border-radius: 2px;
+    transition: width 0.3s ease, background 0.3s ease;
+  }
+
+  .monitor-bar-label {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-ghost);
+    text-align: center;
+    padding: 2px var(--space-3) var(--space-2);
+  }
+
+  .monitor-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1px;
+    padding: 0 var(--space-3);
+    margin-bottom: var(--space-2);
+  }
+
+  .monitor-stat {
+    display: flex;
+    flex-direction: column;
+    padding: var(--space-2);
+    background: var(--bg-base);
+    border-radius: var(--radius-sm);
+  }
+
+  .stat-label {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-ghost);
+    margin-bottom: 2px;
+  }
+
+  .stat-value {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--text-primary);
+    font-weight: 500;
+  }
+
+  .monitor-section {
+    padding: var(--space-2) var(--space-3);
+    border-top: 1px solid var(--border-subtle);
+  }
+
+  .section-title {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-ghost);
+    display: block;
+    margin-bottom: var(--space-1);
+  }
+
+  .section-toggle {
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    cursor: pointer;
+    padding: 0;
+    display: block;
+    width: 100%;
+    text-align: left;
+  }
+  .section-toggle:hover { color: var(--accent); }
+
+  .tool-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 3px;
+  }
+
+  .tool-chip {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    color: var(--text-ghost);
+    background: var(--bg-base);
+    padding: 1px 5px;
+    border-radius: 3px;
+    border: 1px solid var(--border-subtle);
+  }
+
+  .prompt-preview {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-ghost);
+    background: var(--bg-base);
+    border-radius: var(--radius-sm);
+    padding: var(--space-2);
+    margin-top: var(--space-1);
+    max-height: 300px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  .monitor-actions {
+    padding: var(--space-2) var(--space-3);
+    border-top: 1px solid var(--border-subtle);
+    margin-top: auto;
+  }
+</style>

--- a/frontend/console/src/components/PromptEditor.svelte
+++ b/frontend/console/src/components/PromptEditor.svelte
@@ -1,0 +1,223 @@
+<script lang="ts">
+  import { getChatContext, updateSessionPrompt } from '../lib/api'
+
+  interface Props {
+    sessionId: string
+    onClose?: () => void
+  }
+
+  let { sessionId, onClose }: Props = $props()
+
+  let systemPrompt = $state('')
+  let promptOverride = $state('')
+  let originalOverride = $state('')
+  let systemPromptTokens = $state(0)
+  let loading = $state(true)
+  let saving = $state(false)
+  let showBase = $state(false)
+
+  async function load() {
+    if (!sessionId) return
+    loading = true
+    try {
+      const ctx = await getChatContext(sessionId)
+      systemPrompt = ctx.system_prompt
+      systemPromptTokens = ctx.system_prompt_tokens
+      promptOverride = ctx.prompt_override ?? ''
+      originalOverride = promptOverride
+    } catch {
+      // ignore
+    }
+    loading = false
+  }
+
+  async function save() {
+    if (!sessionId) return
+    saving = true
+    try {
+      await updateSessionPrompt(sessionId, promptOverride)
+      originalOverride = promptOverride
+    } catch {
+      // ignore
+    }
+    saving = false
+  }
+
+  async function clearOverride() {
+    promptOverride = ''
+    await save()
+  }
+
+  let isDirty = $derived(promptOverride !== originalOverride)
+  let overrideTokens = $derived(Math.max(1, Math.floor(promptOverride.length / 4)))
+
+  $effect(() => {
+    if (sessionId) void load()
+  })
+</script>
+
+<div class="editor-panel">
+  <div class="editor-header">
+    <span class="editor-title">Prompt Editor</span>
+    {#if onClose}
+      <button class="editor-close" onclick={onClose}>&times;</button>
+    {/if}
+  </div>
+
+  {#if loading}
+    <div class="editor-loading">Loading...</div>
+  {:else}
+    <div class="editor-section">
+      <button class="section-toggle" onclick={() => showBase = !showBase}>
+        {showBase ? '\u25BC' : '\u25B6'} Base System Prompt ({systemPromptTokens.toLocaleString()} tokens)
+      </button>
+      {#if showBase}
+        <pre class="prompt-readonly">{systemPrompt}</pre>
+      {/if}
+    </div>
+
+    <div class="editor-section">
+      <div class="override-header">
+        <span class="override-label">Session Override</span>
+        {#if promptOverride}
+          <span class="override-tokens">~{overrideTokens} tokens</span>
+        {/if}
+      </div>
+      <textarea
+        class="override-textarea"
+        bind:value={promptOverride}
+        rows="8"
+        placeholder="Add custom instructions for this session..."
+      ></textarea>
+      <div class="editor-actions">
+        <button class="btn btn-primary btn-sm" onclick={save} disabled={saving || !isDirty}>
+          {saving ? 'Saving...' : 'Apply'}
+        </button>
+        {#if promptOverride}
+          <button class="btn btn-ghost btn-sm" onclick={clearOverride}>Clear</button>
+        {/if}
+        <button class="btn btn-ghost btn-sm" onclick={load}>Refresh</button>
+      </div>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .editor-panel {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+    background: var(--bg-surface);
+    border-left: 1px solid var(--border-subtle);
+  }
+
+  .editor-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-2) var(--space-3);
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .editor-title {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: var(--text-sm);
+    color: var(--text-primary);
+  }
+
+  .editor-close {
+    background: none;
+    border: none;
+    color: var(--text-ghost);
+    cursor: pointer;
+    font-size: 18px;
+    padding: 0;
+    line-height: 1;
+  }
+  .editor-close:hover { color: var(--text-primary); }
+
+  .editor-loading {
+    padding: var(--space-4);
+    text-align: center;
+    color: var(--text-ghost);
+    font-size: var(--text-sm);
+  }
+
+  .editor-section {
+    padding: var(--space-2) var(--space-3);
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .section-toggle {
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    cursor: pointer;
+    padding: 0;
+    display: block;
+    width: 100%;
+    text-align: left;
+  }
+  .section-toggle:hover { color: var(--accent); }
+
+  .prompt-readonly {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-ghost);
+    background: var(--bg-base);
+    border-radius: var(--radius-sm);
+    padding: var(--space-2);
+    margin-top: var(--space-1);
+    max-height: 300px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  .override-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: var(--space-1);
+  }
+
+  .override-label {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--text-secondary);
+    font-weight: 500;
+  }
+
+  .override-tokens {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-ghost);
+  }
+
+  .override-textarea {
+    width: 100%;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--text-primary);
+    background: var(--bg-base);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    padding: var(--space-2);
+    resize: vertical;
+    min-height: 120px;
+  }
+  .override-textarea:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+
+  .editor-actions {
+    display: flex;
+    gap: var(--space-2);
+    margin-top: var(--space-2);
+  }
+</style>

--- a/frontend/console/src/components/SessionConfigPanel.svelte
+++ b/frontend/console/src/components/SessionConfigPanel.svelte
@@ -1,0 +1,348 @@
+<script lang="ts">
+  import { listChatTools, getSessionConfig, updateSessionConfig, type ChatToolInfo, type SessionToolConfig } from '../lib/api'
+
+  interface Props {
+    sessionId: string
+    onClose?: () => void
+  }
+
+  let { sessionId, onClose }: Props = $props()
+
+  let tools: ChatToolInfo[] = $state([])
+  let skills: string[] = $state([])
+  let config: SessionToolConfig = $state({})
+  let loading = $state(true)
+  let filterText = $state('')
+  let activeTab: 'tools' | 'skills' | 'mcp' = $state('tools')
+
+  let enabledSet: Set<string> = $state(new Set())
+  let disabledSet: Set<string> = $state(new Set())
+  let skillsEnabledSet: Set<string> = $state(new Set())
+  let useCustomConfig = $state(false)
+  let useCustomSkills = $state(false)
+
+  async function load() {
+    loading = true
+    try {
+      const [toolsResp, configResp] = await Promise.all([
+        listChatTools(),
+        sessionId ? getSessionConfig(sessionId) : Promise.resolve({} as SessionToolConfig),
+      ])
+      tools = toolsResp.tools
+      skills = toolsResp.skills ?? []
+      config = configResp
+
+      // Initialize sets from config
+      if (config.tools_enabled && config.tools_enabled.length > 0) {
+        useCustomConfig = true
+        enabledSet = new Set(config.tools_enabled)
+      } else {
+        useCustomConfig = false
+        enabledSet = new Set(tools.map((t) => t.name))
+      }
+      disabledSet = new Set(config.tools_disabled ?? [])
+
+      if (config.skills_enabled && config.skills_enabled.length > 0) {
+        useCustomSkills = true
+        skillsEnabledSet = new Set(config.skills_enabled)
+      } else {
+        useCustomSkills = false
+        skillsEnabledSet = new Set(skills)
+      }
+    } catch {
+      // ignore
+    }
+    loading = false
+  }
+
+  function isToolEnabled(name: string): boolean {
+    if (!useCustomConfig) return !disabledSet.has(name)
+    return enabledSet.has(name) && !disabledSet.has(name)
+  }
+
+  function toggleTool(name: string) {
+    if (isToolEnabled(name)) {
+      if (useCustomConfig) {
+        enabledSet.delete(name)
+        enabledSet = new Set(enabledSet)
+      } else {
+        disabledSet.add(name)
+        disabledSet = new Set(disabledSet)
+      }
+    } else {
+      if (useCustomConfig) {
+        enabledSet.add(name)
+        enabledSet = new Set(enabledSet)
+      }
+      disabledSet.delete(name)
+      disabledSet = new Set(disabledSet)
+    }
+    void saveConfig()
+  }
+
+  function isSkillEnabled(name: string): boolean {
+    if (!useCustomSkills) return true
+    return skillsEnabledSet.has(name)
+  }
+
+  function toggleSkill(name: string) {
+    if (isSkillEnabled(name)) {
+      if (!useCustomSkills) {
+        useCustomSkills = true
+        skillsEnabledSet = new Set(skills.filter((s) => s !== name))
+      } else {
+        skillsEnabledSet.delete(name)
+        skillsEnabledSet = new Set(skillsEnabledSet)
+      }
+    } else {
+      skillsEnabledSet.add(name)
+      skillsEnabledSet = new Set(skillsEnabledSet)
+    }
+    void saveConfig()
+  }
+
+  function toggleAllTools() {
+    if (useCustomConfig) {
+      useCustomConfig = false
+      enabledSet = new Set(tools.map((t) => t.name))
+      disabledSet = new Set()
+    } else {
+      useCustomConfig = true
+      enabledSet = new Set()
+      disabledSet = new Set()
+    }
+    void saveConfig()
+  }
+
+  function toggleAllSkills() {
+    if (useCustomSkills) {
+      useCustomSkills = false
+      skillsEnabledSet = new Set(skills)
+    } else {
+      useCustomSkills = true
+      skillsEnabledSet = new Set()
+    }
+    void saveConfig()
+  }
+
+  async function saveConfig() {
+    if (!sessionId) return
+    const newConfig: SessionToolConfig = {}
+    if (useCustomConfig) {
+      newConfig.tools_enabled = [...enabledSet]
+    }
+    if (disabledSet.size > 0) {
+      newConfig.tools_disabled = [...disabledSet]
+    }
+    if (useCustomSkills) {
+      newConfig.skills_enabled = [...skillsEnabledSet]
+    }
+    await updateSessionConfig(sessionId, newConfig).catch(() => {})
+  }
+
+  let filteredTools = $derived(
+    tools.filter((t) => !filterText || t.name.toLowerCase().includes(filterText.toLowerCase()))
+  )
+  let filteredSkills = $derived(
+    skills.filter((s) => !filterText || s.toLowerCase().includes(filterText.toLowerCase()))
+  )
+
+  $effect(() => {
+    if (sessionId) void load()
+  })
+</script>
+
+<div class="config-panel">
+  <div class="config-header">
+    <span class="config-title">Session Config</span>
+    {#if onClose}
+      <button class="config-close" onclick={onClose}>&times;</button>
+    {/if}
+  </div>
+
+  {#if loading}
+    <div class="config-loading">Loading...</div>
+  {:else}
+    <div class="config-tabs">
+      <button class="config-tab" class:active={activeTab === 'tools'} onclick={() => activeTab = 'tools'}>
+        Tools ({tools.length})
+      </button>
+      <button class="config-tab" class:active={activeTab === 'skills'} onclick={() => activeTab = 'skills'}>
+        Skills ({skills.length})
+      </button>
+    </div>
+
+    <div class="config-filter">
+      <input type="text" bind:value={filterText} placeholder="Filter..." class="config-filter-input" />
+    </div>
+
+    {#if activeTab === 'tools'}
+      <div class="config-actions">
+        <label class="config-toggle">
+          <input type="checkbox" checked={!useCustomConfig} onchange={toggleAllTools} />
+          <span>All tools</span>
+        </label>
+        <span class="config-count">{useCustomConfig ? enabledSet.size : tools.length - disabledSet.size} active</span>
+      </div>
+      <div class="config-list">
+        {#each filteredTools as t}
+          <label class="config-item" class:high-risk={t.high_risk}>
+            <input type="checkbox" checked={isToolEnabled(t.name)} onchange={() => toggleTool(t.name)} />
+            <span class="item-name">{t.name}</span>
+            {#if t.high_risk}
+              <span class="badge badge-warning" style="font-size:9px;padding:0 4px;">risk</span>
+            {/if}
+          </label>
+        {/each}
+      </div>
+    {:else if activeTab === 'skills'}
+      <div class="config-actions">
+        <label class="config-toggle">
+          <input type="checkbox" checked={!useCustomSkills} onchange={toggleAllSkills} />
+          <span>All skills</span>
+        </label>
+        <span class="config-count">{useCustomSkills ? skillsEnabledSet.size : skills.length} active</span>
+      </div>
+      <div class="config-list">
+        {#each filteredSkills as s}
+          <label class="config-item">
+            <input type="checkbox" checked={isSkillEnabled(s)} onchange={() => toggleSkill(s)} />
+            <span class="item-name">{s}</span>
+          </label>
+        {/each}
+      </div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .config-panel {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+    background: var(--bg-surface);
+    border-left: 1px solid var(--border-subtle);
+  }
+
+  .config-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-2) var(--space-3);
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .config-title {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: var(--text-sm);
+    color: var(--text-primary);
+  }
+
+  .config-close {
+    background: none;
+    border: none;
+    color: var(--text-ghost);
+    cursor: pointer;
+    font-size: 18px;
+    padding: 0;
+    line-height: 1;
+  }
+  .config-close:hover { color: var(--text-primary); }
+
+  .config-loading {
+    padding: var(--space-4);
+    text-align: center;
+    color: var(--text-ghost);
+    font-size: var(--text-sm);
+  }
+
+  .config-tabs {
+    display: flex;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .config-tab {
+    flex: 1;
+    padding: var(--space-2);
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    color: var(--text-ghost);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    cursor: pointer;
+    transition: all var(--duration-fast);
+  }
+  .config-tab.active {
+    color: var(--accent);
+    border-bottom-color: var(--accent);
+  }
+  .config-tab:hover { color: var(--text-primary); }
+
+  .config-filter {
+    padding: var(--space-2) var(--space-3);
+  }
+
+  .config-filter-input {
+    width: 100%;
+    padding: var(--space-1) var(--space-2);
+    background: var(--bg-base);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+  }
+
+  .config-actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-1) var(--space-3);
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .config-toggle {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    font-size: var(--text-xs);
+    color: var(--text-secondary);
+    cursor: pointer;
+  }
+
+  .config-count {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-ghost);
+  }
+
+  .config-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--space-1) 0;
+  }
+
+  .config-item {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: 3px var(--space-3);
+    cursor: pointer;
+    transition: background var(--duration-fast);
+  }
+  .config-item:hover { background: rgba(255, 255, 255, 0.03); }
+
+  .config-item.high-risk { border-left: 2px solid rgba(248, 113, 113, 0.3); }
+
+  .item-name {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+</style>

--- a/frontend/console/src/lib/api.ts
+++ b/frontend/console/src/lib/api.ts
@@ -211,6 +211,74 @@ export async function compactSession(sessionId: string): Promise<{ compacted: bo
   )
 }
 
+// --- Session Config ---
+
+export type SessionToolConfig = {
+  tools_enabled?: string[]
+  tools_disabled?: string[]
+  skills_enabled?: string[]
+  mcp_enabled?: string[]
+}
+
+export async function getSessionConfig(sessionId: string): Promise<SessionToolConfig> {
+  return requestJSON<SessionToolConfig>(`/v1/admin/sessions/${encodeURIComponent(sessionId)}/config`)
+}
+
+export async function updateSessionConfig(sessionId: string, config: SessionToolConfig): Promise<void> {
+  await requestJSON(`/v1/admin/sessions/${encodeURIComponent(sessionId)}/config`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(config),
+  })
+}
+
+export type ChatToolInfo = {
+  name: string
+  description: string
+  high_risk: boolean
+}
+
+export type ChatToolsResponse = {
+  tools: ChatToolInfo[]
+  skills?: string[]
+  mcp_servers?: string[]
+}
+
+export async function listChatTools(): Promise<ChatToolsResponse> {
+  return requestJSON<ChatToolsResponse>('/v1/chat/tools')
+}
+
+// --- Chat Context ---
+
+export type ChatContextInfo = {
+  session_id: string
+  system_prompt: string
+  system_prompt_tokens: number
+  history_tokens: number
+  history_messages: number
+  tool_count: number
+  tool_names: string[]
+  memory_count: number
+  memory_tokens: number
+  prompt_override: string
+}
+
+export async function getChatContext(sessionId: string): Promise<ChatContextInfo> {
+  return requestJSON<ChatContextInfo>(`/v1/chat/context?session_id=${encodeURIComponent(sessionId)}`)
+}
+
+export async function getSessionPrompt(sessionId: string): Promise<{ prompt_override: string }> {
+  return requestJSON<{ prompt_override: string }>(`/v1/admin/sessions/${encodeURIComponent(sessionId)}/prompt`)
+}
+
+export async function updateSessionPrompt(sessionId: string, promptOverride: string): Promise<void> {
+  await requestJSON(`/v1/admin/sessions/${encodeURIComponent(sessionId)}/prompt`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ prompt_override: promptOverride }),
+  })
+}
+
 export async function getEventsHistory(limit = 30): Promise<EventsHistoryInfo> {
   return requestJSON<EventsHistoryInfo>(`/v1/events/history?limit=${limit}`)
 }
@@ -453,6 +521,7 @@ export function streamEvents(
 export async function streamChat(
   request: ChatRequest,
   onEvent: (event: ChatEvent) => void,
+  signal?: AbortSignal,
 ): Promise<void> {
   const response = await fetch('/v1/chat', {
     method: 'POST',
@@ -462,6 +531,7 @@ export async function streamChat(
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(request),
+    signal,
   })
 
   if (!response.ok) {
@@ -505,6 +575,18 @@ export async function streamChat(
     if (done) {
       break
     }
+  }
+}
+
+export async function cancelChat(sessionId: string): Promise<boolean> {
+  try {
+    const result = await requestJSON<{ cancelled: boolean }>(
+      `/v1/chat/cancel?session_id=${encodeURIComponent(sessionId)}`,
+      { method: 'POST' },
+    )
+    return result.cancelled
+  } catch {
+    return false
   }
 }
 

--- a/frontend/console/src/lib/types.ts
+++ b/frontend/console/src/lib/types.ts
@@ -191,6 +191,22 @@ export type ChatEvent = {
   tool_result_preview?: string
   skill_name?: string
   skill_reason?: string
+  // context_info fields
+  system_prompt_tokens?: number
+  history_tokens?: number
+  history_messages?: number
+  tool_count?: number
+  tool_names?: string[]
+  memory_count?: number
+  memory_tokens?: number
+  // done event usage
+  usage?: {
+    input_tokens: number
+    output_tokens: number
+    cached_tokens: number
+    cache_read_tokens: number
+    cache_write_tokens: number
+  }
 }
 
 export type ChatAttachment = {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -11,14 +11,25 @@ import (
 	"time"
 )
 
+// SessionToolConfig holds per-session tool/skill/MCP configuration.
+// nil slices mean "inherit all from system defaults".
+type SessionToolConfig struct {
+	ToolsEnabled  []string `json:"tools_enabled,omitempty"`
+	ToolsDisabled []string `json:"tools_disabled,omitempty"`
+	SkillsEnabled []string `json:"skills_enabled,omitempty"`
+	MCPEnabled    []string `json:"mcp_enabled,omitempty"`
+}
+
 type Session struct {
-	ID        string    `json:"id"`
-	Title     string    `json:"title"`
-	Kind      string    `json:"kind,omitempty"`
-	Hidden    bool      `json:"hidden,omitempty"`
-	ProjectID string    `json:"project_id,omitempty"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	ID             string             `json:"id"`
+	Title          string             `json:"title"`
+	Kind           string             `json:"kind,omitempty"`
+	Hidden         bool               `json:"hidden,omitempty"`
+	ProjectID      string             `json:"project_id,omitempty"`
+	ToolConfig     *SessionToolConfig `json:"tool_config,omitempty"`
+	PromptOverride string             `json:"prompt_override,omitempty"`
+	CreatedAt      time.Time          `json:"created_at"`
+	UpdatedAt      time.Time          `json:"updated_at"`
 }
 
 type Store struct {
@@ -282,6 +293,42 @@ func (s *Store) SetProjectID(id string, projectID string) error {
 		return fmt.Errorf("session not found")
 	}
 	sess.ProjectID = strings.TrimSpace(projectID)
+	sess.UpdatedAt = time.Now().UTC()
+	index[id] = sess
+	return s.saveIndex(index)
+}
+
+// SetToolConfig updates the per-session tool configuration.
+func (s *Store) SetToolConfig(id string, config *SessionToolConfig) error {
+	unlock := lockPath(s.indexPath())
+	defer unlock()
+	index, err := s.loadIndex()
+	if err != nil {
+		return err
+	}
+	sess, ok := index[id]
+	if !ok {
+		return fmt.Errorf("session not found")
+	}
+	sess.ToolConfig = config
+	sess.UpdatedAt = time.Now().UTC()
+	index[id] = sess
+	return s.saveIndex(index)
+}
+
+// SetPromptOverride updates the per-session prompt override.
+func (s *Store) SetPromptOverride(id string, override string) error {
+	unlock := lockPath(s.indexPath())
+	defer unlock()
+	index, err := s.loadIndex()
+	if err != nil {
+		return err
+	}
+	sess, ok := index[id]
+	if !ok {
+		return fmt.Errorf("session not found")
+	}
+	sess.PromptOverride = override
 	sess.UpdatedAt = time.Now().UTC()
 	index[id] = sess
 	return s.saveIndex(index)

--- a/internal/tarsserver/chat_cancel_registry.go
+++ b/internal/tarsserver/chat_cancel_registry.go
@@ -1,0 +1,47 @@
+package tarsserver
+
+import (
+	"context"
+	"sync"
+)
+
+// chatCancelRegistry tracks active chat sessions and allows cancellation.
+type chatCancelRegistry struct {
+	mu      sync.Mutex
+	cancels map[string]context.CancelFunc
+}
+
+func newChatCancelRegistry() *chatCancelRegistry {
+	return &chatCancelRegistry{
+		cancels: make(map[string]context.CancelFunc),
+	}
+}
+
+// Register stores the cancel function for a session.
+func (r *chatCancelRegistry) Register(sessionID string, cancel context.CancelFunc) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cancels[sessionID] = cancel
+}
+
+// Cancel invokes the cancel function for a session and removes it.
+// Returns true if a cancel was found and invoked.
+func (r *chatCancelRegistry) Cancel(sessionID string) bool {
+	r.mu.Lock()
+	cancel, ok := r.cancels[sessionID]
+	if ok {
+		delete(r.cancels, sessionID)
+	}
+	r.mu.Unlock()
+	if ok {
+		cancel()
+	}
+	return ok
+}
+
+// Unregister removes the cancel function without invoking it.
+func (r *chatCancelRegistry) Unregister(sessionID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.cancels, sessionID)
+}

--- a/internal/tarsserver/handler_chat.go
+++ b/internal/tarsserver/handler_chat.go
@@ -498,6 +498,14 @@ func promptTokenEstimate(content string) int {
 	return tokens
 }
 
+func sumHistoryTokens(messages []session.Message) int {
+	total := 0
+	for _, m := range messages {
+		total += promptTokenEstimate(m.Content)
+	}
+	return total
+}
+
 type chatToolingOptions struct {
 	ProcessManager              *tool.ProcessManager
 	Extensions                  *extensions.Manager
@@ -599,19 +607,154 @@ func newChatAPIHandlerWithRuntimeConfig(
 ) http.Handler {
 	maxIters := resolveAgentMaxIterations(maxIterations)
 	chatLimiter := newInflightLimiter(tooling.APIMaxInflightChat, 2)
+	cancelRegistry := newChatCancelRegistry()
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/chat", func(w http.ResponseWriter, r *http.Request) {
 		handleChatRequest(w, r, chatHandlerDeps{
-			workspaceDir:  workspaceDir,
-			store:         store,
-			client:        client,
-			logger:        logger,
-			maxIters:      maxIters,
-			chatLimiter:   chatLimiter,
-			activity:      activity,
-			mainSessionID: strings.TrimSpace(mainSessionID),
-			tooling:       tooling,
-			extraTools:    extraTools,
+			workspaceDir:   workspaceDir,
+			store:          store,
+			client:         client,
+			logger:         logger,
+			maxIters:       maxIters,
+			chatLimiter:    chatLimiter,
+			activity:       activity,
+			mainSessionID:  strings.TrimSpace(mainSessionID),
+			tooling:        tooling,
+			extraTools:     extraTools,
+			cancelRegistry: cancelRegistry,
+		})
+	})
+	mux.HandleFunc("/v1/chat/cancel", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeMethodNotAllowed(w)
+			return
+		}
+		sessionID := strings.TrimSpace(r.URL.Query().Get("session_id"))
+		if sessionID == "" {
+			writeError(w, http.StatusBadRequest, "", "session_id is required")
+			return
+		}
+		if cancelRegistry.Cancel(sessionID) {
+			writeJSON(w, http.StatusOK, map[string]bool{"cancelled": true})
+		} else {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "no active chat for session"})
+		}
+	})
+	mux.HandleFunc("/v1/chat/tools", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writeMethodNotAllowed(w)
+			return
+		}
+		reqStore, requestWorkspaceDir, _, err := resolveSessionStoreForRequest(workspaceDir, store, r)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "", "resolve workspace failed")
+			return
+		}
+		registry := buildChatToolRegistry(
+			reqStore, "", "", requestWorkspaceDir, nil, chatHandlerDeps{
+				workspaceDir:  workspaceDir,
+				store:         store,
+				client:        client,
+				logger:        logger,
+				tooling:       tooling,
+				extraTools:    extraTools,
+				mainSessionID: strings.TrimSpace(mainSessionID),
+			},
+		)
+		type toolInfo struct {
+			Name        string `json:"name"`
+			Description string `json:"description"`
+			HighRisk    bool   `json:"high_risk"`
+		}
+		schemas := registry.Schemas()
+		tools := make([]toolInfo, 0, len(schemas))
+		for _, s := range schemas {
+			tools = append(tools, toolInfo{
+				Name:        s.Function.Name,
+				Description: s.Function.Description,
+				HighRisk:    isHighRiskToolName(s.Function.Name),
+			})
+		}
+		// Include skills and MCP info if available
+		type chatToolsResponse struct {
+			Tools  []toolInfo `json:"tools"`
+			Skills []string   `json:"skills,omitempty"`
+			MCP    []string   `json:"mcp_servers,omitempty"`
+		}
+		resp := chatToolsResponse{Tools: tools}
+		if tooling.Extensions != nil {
+			snap := tooling.Extensions.Snapshot()
+			for _, sk := range snap.Skills {
+				resp.Skills = append(resp.Skills, sk.Name)
+			}
+		}
+		writeJSON(w, http.StatusOK, resp)
+	})
+	mux.HandleFunc("/v1/chat/context", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writeMethodNotAllowed(w)
+			return
+		}
+		sessionID := strings.TrimSpace(r.URL.Query().Get("session_id"))
+		if sessionID == "" {
+			writeError(w, http.StatusBadRequest, "", "session_id is required")
+			return
+		}
+		reqStore, requestWorkspaceDir, _, err := resolveSessionStoreForRequest(workspaceDir, store, r)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "", "resolve workspace failed")
+			return
+		}
+		sess, err := reqStore.Get(sessionID)
+		if err != nil {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "session not found"})
+			return
+		}
+		transcriptPath := reqStore.TranscriptPath(sessionID)
+		historySnapshot, err := loadSessionHistorySnapshot(transcriptPath, chatHistoryMaxTokens)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "", "load history failed")
+			return
+		}
+		extSnapshot := extensions.Snapshot{}
+		if tooling.Extensions != nil {
+			extSnapshot = tooling.Extensions.Snapshot()
+		}
+		contextDetails, err := prepareChatContextDetailsWithCache(
+			requestWorkspaceDir, sess.ProjectID, sessionID, "(context preview)",
+			extSnapshot, nil, tooling.MemoryCache, tooling.MemorySemanticConfig,
+		)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "", "prepare context failed")
+			return
+		}
+		systemPrompt := contextDetails.SystemPrompt
+		if strings.TrimSpace(sess.PromptOverride) != "" {
+			systemPrompt += "\n\n## Session Prompt Override\n" + strings.TrimSpace(sess.PromptOverride) + "\n"
+		}
+		registry := buildChatToolRegistry(
+			reqStore, "", sessionID, requestWorkspaceDir, historySnapshot.Messages, chatHandlerDeps{
+				workspaceDir:  workspaceDir,
+				store:         store,
+				client:        client,
+				logger:        logger,
+				tooling:       tooling,
+				extraTools:    extraTools,
+				mainSessionID: strings.TrimSpace(mainSessionID),
+			},
+		)
+		injectedSchemas := resolveInjectedToolSchemas(registry, tooling.ToolsDefaultSet, nil, "admin", tooling.ToolsAllowHighRiskUser)
+		writeJSON(w, http.StatusOK, map[string]any{
+			"session_id":           sessionID,
+			"system_prompt":        systemPrompt,
+			"system_prompt_tokens": promptTokenEstimate(systemPrompt),
+			"history_tokens":       sumHistoryTokens(historySnapshot.Messages),
+			"history_messages":     len(historySnapshot.Messages),
+			"tool_count":           len(injectedSchemas),
+			"tool_names":           toolNamesFromSchemas(injectedSchemas),
+			"memory_count":         contextDetails.RelevantMemoryCount,
+			"memory_tokens":        contextDetails.RelevantMemoryTokens,
+			"prompt_override":      sess.PromptOverride,
 		})
 	})
 	return mux

--- a/internal/tarsserver/handler_chat_context.go
+++ b/internal/tarsserver/handler_chat_context.go
@@ -118,15 +118,28 @@ func prepareChatRunState(r *http.Request, req chatRequestPayload, deps chatHandl
 		return chatRunState{}, http.StatusInternalServerError, "save message failed", err
 	}
 
+	// Apply session-level prompt override
+	sess, sessErr := reqStore.Get(sessionID)
+	if sessErr == nil && strings.TrimSpace(sess.PromptOverride) != "" {
+		systemPrompt += "\n\n## Session Prompt Override\n" + strings.TrimSpace(sess.PromptOverride) + "\n"
+	}
+
 	contentBlocks := attachmentsToContentBlocks(req.Attachments)
 	llmMessages := buildLLMMessagesWithBlocks(systemPrompt, history, req.Message, contentBlocks)
 	authRole := strings.TrimSpace(serverauth.RoleFromRequest(r))
+
+	// Apply session-level tool config if present
+	var sessionToolConfigs []session.SessionToolConfig
+	if sessErr == nil && sess.ToolConfig != nil {
+		sessionToolConfigs = append(sessionToolConfigs, *sess.ToolConfig)
+	}
 	injectedSchemas := resolveInjectedToolSchemas(
 		registry,
 		deps.tooling.ToolsDefaultSet,
 		activeProject,
 		authRole,
 		deps.tooling.ToolsAllowHighRiskUser,
+		sessionToolConfigs...,
 	)
 	deps.logger.Debug().
 		Str("session_id", sessionID).

--- a/internal/tarsserver/handler_chat_execution.go
+++ b/internal/tarsserver/handler_chat_execution.go
@@ -2,6 +2,7 @@ package tarsserver
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/devlikebear/tars/internal/agent"
@@ -18,6 +19,7 @@ func executeChatLoop(
 ) (llm.ChatResponse, bool, []ToolCallRecord, error) {
 	streamingAnnounced := false
 	deltaSent := false
+	var accumulated strings.Builder
 	loop, toolCallRecords := setupAgentLoop(deps.client, state.registry, state.sessionID, len(state.history), deps.logger, stream.status)
 
 	deps.logger.Debug().Str("session_id", state.sessionID).Int("messages", len(state.llmMessages)).Msg("llm chat call start")
@@ -29,6 +31,7 @@ func executeChatLoop(
 			if text == "" {
 				return
 			}
+			accumulated.WriteString(text)
 			if !streamingAnnounced {
 				streamingAnnounced = true
 				stream.status("llm_stream", "streaming response", "", "", "", "")
@@ -39,6 +42,12 @@ func executeChatLoop(
 		},
 	})
 	if err != nil {
+		if ctx.Err() == context.Canceled {
+			// Return partial content on cancellation
+			partial := accumulated.String()
+			deps.logger.Debug().Str("session_id", state.sessionID).Int("partial_len", len(partial)).Msg("chat cancelled, returning partial")
+			return llm.ChatResponse{Message: llm.ChatMessage{Content: partial}}, deltaSent, *toolCallRecords, err
+		}
 		deps.logger.Debug().Str("session_id", state.sessionID).Err(err).Msg("llm chat call failed")
 		return llm.ChatResponse{}, false, nil, err
 	}

--- a/internal/tarsserver/handler_chat_pipeline.go
+++ b/internal/tarsserver/handler_chat_pipeline.go
@@ -1,6 +1,7 @@
 package tarsserver
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -12,16 +13,17 @@ import (
 )
 
 type chatHandlerDeps struct {
-	workspaceDir  string
-	store         *session.Store
-	client        llm.Client
-	logger        zerolog.Logger
-	maxIters      int
-	chatLimiter   *inflightLimiter
-	activity      *runtimeActivity
-	mainSessionID string
-	tooling       chatToolingOptions
-	extraTools    []tool.Tool
+	workspaceDir   string
+	store          *session.Store
+	client         llm.Client
+	logger         zerolog.Logger
+	maxIters       int
+	chatLimiter    *inflightLimiter
+	activity       *runtimeActivity
+	mainSessionID  string
+	tooling        chatToolingOptions
+	extraTools     []tool.Tool
+	cancelRegistry *chatCancelRegistry
 }
 
 type chatAttachment struct {
@@ -76,13 +78,37 @@ func handleChatRequest(w http.ResponseWriter, r *http.Request, deps chatHandlerD
 		stream.skillSelected(state.invokedSkill.Name, state.invokedSkillReason)
 	}
 
-	chatCtx := usage.WithCallMeta(r.Context(), usage.CallMeta{
+	// Emit context info for frontend monitoring
+	stream.contextInfo(map[string]any{
+		"system_prompt_tokens": promptTokenEstimate(state.llmMessages[0].Content),
+		"history_tokens":       sumHistoryTokens(state.history),
+		"history_messages":     len(state.history),
+		"tool_count":           len(state.injectedSchemas),
+		"tool_names":           toolNamesFromSchemas(state.injectedSchemas),
+	})
+
+	baseCtx := usage.WithCallMeta(r.Context(), usage.CallMeta{
 		Source:    "chat",
 		SessionID: state.sessionID,
 		ProjectID: state.projectID,
 	})
+	chatCtx, cancelChat := context.WithCancel(baseCtx)
+	defer cancelChat()
+	if deps.cancelRegistry != nil {
+		deps.cancelRegistry.Register(state.sessionID, cancelChat)
+		defer deps.cancelRegistry.Unregister(state.sessionID)
+	}
+
 	chatResp, deltaSent, toolCalls, err := executeChatLoop(chatCtx, deps, state, stream)
 	if err != nil {
+		if chatCtx.Err() == context.Canceled {
+			stream.cancelled()
+			if chatResp.Message.Content != "" {
+				persistChatResult(state, req.Message, chatResp, toolCalls, deps.logger)
+			}
+			deps.logger.Debug().Str("session_id", state.sessionID).Msg("chat request cancelled")
+			return
+		}
 		stream.error(err)
 		return
 	}

--- a/internal/tarsserver/handler_chat_policy.go
+++ b/internal/tarsserver/handler_chat_policy.go
@@ -85,40 +85,84 @@ func resolveInjectedToolSchemas(
 	activeProject *project.Project,
 	authRole string,
 	allowHighRiskUser bool,
+	sessionConfig ...session.SessionToolConfig,
 ) []llm.ToolSchema {
 	if registry == nil {
 		return nil
 	}
 
+	var names []string
 	if activeProject == nil {
-		// No project context: use all registered tools, filtered by high-risk policy
-		if shouldFilterHighRiskTools(authRole, allowHighRiskUser) {
-			names := filterHighRiskToolNamesForRole(toolNamesFromSchemas(registry.Schemas()), authRole, allowHighRiskUser)
-			return registry.SchemasForNames(names)
-		}
-		return registry.Schemas()
+		names = toolNamesFromSchemas(registry.Schemas())
+	} else {
+		// Project context: start with all registered tools, apply project policy
+		names = toolNamesFromSchemas(registry.Schemas())
+		policy := project.NormalizeToolPolicy(project.ToolPolicySpec{
+			ToolsAllow:               activeProject.ToolsAllow,
+			ToolsAllowExists:         len(activeProject.ToolsAllow) > 0,
+			ToolsAllowGroups:         activeProject.ToolsAllowGroups,
+			ToolsAllowGroupsExists:   len(activeProject.ToolsAllowGroups) > 0,
+			ToolsAllowPatterns:       activeProject.ToolsAllowPatterns,
+			ToolsAllowPatternsExists: len(activeProject.ToolsAllowPatterns) > 0,
+			ToolsDeny:                activeProject.ToolsDeny,
+			ToolsDenyExists:          len(activeProject.ToolsDeny) > 0,
+			ToolsRiskMax:             activeProject.ToolsRiskMax,
+			ToolsRiskMaxExists:       strings.TrimSpace(activeProject.ToolsRiskMax) != "",
+		}, knownToolsFromRegistry(registry), project.ToolPolicyOptions{})
+		names = project.ApplyToolConstraints(names, policy)
 	}
 
-	// Project context: start with all registered tools, apply project policy
-	names := toolNamesFromSchemas(registry.Schemas())
-	policy := project.NormalizeToolPolicy(project.ToolPolicySpec{
-		ToolsAllow:               activeProject.ToolsAllow,
-		ToolsAllowExists:         len(activeProject.ToolsAllow) > 0,
-		ToolsAllowGroups:         activeProject.ToolsAllowGroups,
-		ToolsAllowGroupsExists:   len(activeProject.ToolsAllowGroups) > 0,
-		ToolsAllowPatterns:       activeProject.ToolsAllowPatterns,
-		ToolsAllowPatternsExists: len(activeProject.ToolsAllowPatterns) > 0,
-		ToolsDeny:                activeProject.ToolsDeny,
-		ToolsDenyExists:          len(activeProject.ToolsDeny) > 0,
-		ToolsRiskMax:             activeProject.ToolsRiskMax,
-		ToolsRiskMaxExists:       strings.TrimSpace(activeProject.ToolsRiskMax) != "",
-	}, knownToolsFromRegistry(registry), project.ToolPolicyOptions{})
-	names = project.ApplyToolConstraints(names, policy)
+	// Apply session-level tool config (if provided)
+	if len(sessionConfig) > 0 {
+		names = applySessionToolConfig(names, sessionConfig[0])
+	}
+
 	names = filterHighRiskToolNamesForRole(names, authRole, allowHighRiskUser)
 	if len(names) == 0 {
 		return nil
 	}
 	return registry.SchemasForNames(names)
+}
+
+// applySessionToolConfig filters tool names based on per-session configuration.
+func applySessionToolConfig(names []string, config session.SessionToolConfig) []string {
+	// If ToolsEnabled is set, use it as an allowlist
+	if len(config.ToolsEnabled) > 0 {
+		allowed := map[string]struct{}{}
+		for _, name := range config.ToolsEnabled {
+			canonical := tool.CanonicalToolName(name)
+			if canonical != "" {
+				allowed[canonical] = struct{}{}
+			}
+		}
+		filtered := make([]string, 0, len(names))
+		for _, name := range names {
+			canonical := tool.CanonicalToolName(name)
+			if _, ok := allowed[canonical]; ok {
+				filtered = append(filtered, name)
+			}
+		}
+		names = filtered
+	}
+	// Apply deny list
+	if len(config.ToolsDisabled) > 0 {
+		denied := map[string]struct{}{}
+		for _, name := range config.ToolsDisabled {
+			canonical := tool.CanonicalToolName(name)
+			if canonical != "" {
+				denied[canonical] = struct{}{}
+			}
+		}
+		filtered := make([]string, 0, len(names))
+		for _, name := range names {
+			canonical := tool.CanonicalToolName(name)
+			if _, ok := denied[canonical]; !ok {
+				filtered = append(filtered, name)
+			}
+		}
+		names = filtered
+	}
+	return names
 }
 
 func shouldFilterHighRiskTools(authRole string, allowHighRiskUser bool) bool {

--- a/internal/tarsserver/handler_chat_stream.go
+++ b/internal/tarsserver/handler_chat_stream.go
@@ -101,6 +101,19 @@ func (s *chatStreamWriter) memoryRecall(count int) {
 	})
 }
 
+func (s *chatStreamWriter) cancelled() {
+	s.send(map[string]string{
+		"type":       "cancelled",
+		"session_id": s.sessionID,
+	})
+}
+
+func (s *chatStreamWriter) contextInfo(info map[string]any) {
+	info["type"] = "context_info"
+	info["session_id"] = s.sessionID
+	s.send(info)
+}
+
 func (s *chatStreamWriter) done(usage llm.Usage) {
 	s.send(map[string]any{
 		"type":       "done",

--- a/internal/tarsserver/handler_session.go
+++ b/internal/tarsserver/handler_session.go
@@ -332,6 +332,60 @@ func newSessionAPIHandler(store *session.Store, logger zerolog.Logger) http.Hand
 				return
 			}
 			writeJSON(w, http.StatusOK, messages)
+		case len(pathParts) == 2 && pathParts[1] == "config":
+			if !requireMethod(w, r, http.MethodGet, http.MethodPatch) {
+				return
+			}
+			sess, err := reqStore.Get(sessionID)
+			if err != nil {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": "session not found"})
+				return
+			}
+			switch r.Method {
+			case http.MethodGet:
+				config := sess.ToolConfig
+				if config == nil {
+					config = &session.SessionToolConfig{}
+				}
+				writeJSON(w, http.StatusOK, config)
+			case http.MethodPatch:
+				var config session.SessionToolConfig
+				if !decodeJSONBody(w, r, &config) {
+					return
+				}
+				if err := reqStore.SetToolConfig(sessionID, &config); err != nil {
+					writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+					return
+				}
+				writeJSON(w, http.StatusOK, map[string]string{"ok": "true"})
+			}
+		case len(pathParts) == 2 && pathParts[1] == "prompt":
+			if !requireMethod(w, r, http.MethodGet, http.MethodPut) {
+				return
+			}
+			sess, err := reqStore.Get(sessionID)
+			if err != nil {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": "session not found"})
+				return
+			}
+			switch r.Method {
+			case http.MethodGet:
+				writeJSON(w, http.StatusOK, map[string]string{
+					"prompt_override": sess.PromptOverride,
+				})
+			case http.MethodPut:
+				var req struct {
+					PromptOverride string `json:"prompt_override"`
+				}
+				if !decodeJSONBody(w, r, &req) {
+					return
+				}
+				if err := reqStore.SetPromptOverride(sessionID, req.PromptOverride); err != nil {
+					writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+					return
+				}
+				writeJSON(w, http.StatusOK, map[string]string{"ok": "true"})
+			}
 		default:
 			http.NotFound(w, r)
 		}

--- a/internal/tarsserver/main_serve_api.go
+++ b/internal/tarsserver/main_serve_api.go
@@ -32,17 +32,17 @@ import (
 )
 
 type serveAPIRuntime struct {
-	cfg                     config.Config
-	configPath              string
-	mainSessionID           string
-	server                  *http.Server
-	extensionsManager       *extensions.Manager
-	gatewayRuntime          *gateway.Runtime
-	gatewayAgentsWatch      *gatewayAgentsWatcher
-	cronManager             *workspaceCronManager
-	watchdogManager         *workspaceWatchdogManager
-	heartbeatTicker         *heartbeatTickerManager
-	telegramPoller          *telegramUpdatePoller
+	cfg                config.Config
+	configPath         string
+	mainSessionID      string
+	server             *http.Server
+	extensionsManager  *extensions.Manager
+	gatewayRuntime     *gateway.Runtime
+	gatewayAgentsWatch *gatewayAgentsWatcher
+	cronManager        *workspaceCronManager
+	watchdogManager    *workspaceWatchdogManager
+	heartbeatTicker    *heartbeatTickerManager
+	telegramPoller     *telegramUpdatePoller
 }
 
 type apiRouteHandlers struct {
@@ -550,17 +550,17 @@ func buildAPIMux(
 	heartbeatTicker := newHeartbeatTickerManager(heartbeatRunner, heartbeatTickerInterval, logger)
 
 	return &serveAPIRuntime{
-		cfg:                     cfg,
-		configPath:              resolvedConfigPath,
-		mainSessionID:           mainSessionID,
-		server:                  server,
-		extensionsManager:       extensionsManager,
-		gatewayRuntime:          gatewayRuntime,
-		gatewayAgentsWatch:      gatewayAgentsWatch,
-		cronManager:             cronManager,
-		watchdogManager:         watchdogManager,
-		heartbeatTicker:         heartbeatTicker,
-		telegramPoller:          telegramPoller,
+		cfg:                cfg,
+		configPath:         resolvedConfigPath,
+		mainSessionID:      mainSessionID,
+		server:             server,
+		extensionsManager:  extensionsManager,
+		gatewayRuntime:     gatewayRuntime,
+		gatewayAgentsWatch: gatewayAgentsWatch,
+		cronManager:        cronManager,
+		watchdogManager:    watchdogManager,
+		heartbeatTicker:    heartbeatTicker,
+		telegramPoller:     telegramPoller,
 	}, nil
 }
 
@@ -571,6 +571,7 @@ func registerAPIRoutes(mux *http.ServeMux, handlers apiRouteHandlers) {
 	legacyDashboard := newLegacyDashboardRedirectHandler()
 	mux.Handle("/v1/heartbeat/", handlers.heartbeat)
 	mux.Handle("/v1/chat", handlers.chat)
+	mux.Handle("/v1/chat/", handlers.chat)
 	mux.Handle("/v1/sessions", handlers.sessions)
 	mux.Handle("/v1/sessions/", handlers.sessions)
 	mux.Handle("/v1/admin/sessions", handlers.sessions)


### PR DESCRIPTION
## Summary
- **Chat Cancellation**: Stop button during LLM streaming. Backend cancel registry + `POST /v1/chat/cancel` endpoint. Frontend AbortController + server-side context cancellation with partial response persistence.
- **Per-Session Tool/Skill Config**: `SessionToolConfig` on session model with `tools_enabled`/`tools_disabled`/`skills_enabled`/`mcp_enabled`. Config/Context/Prompt API endpoints. `SessionConfigPanel` with tool/skill checkboxes that filter injected schemas per chat request.
- **Context Monitor**: `context_info` SSE event emits token counts before LLM call. `GET /v1/chat/context` returns full context details. `ContextMonitor` panel with usage progress bar, token stats, tool list, and system prompt viewer.
- **Prompt Editor**: Per-session `prompt_override` field. `PromptEditor` panel with read-only base prompt view and editable override textarea.
- **Token Usage**: `done` event usage displayed as badge on assistant messages (input/output/cached tokens).
- **Right Panel System**: Chat layout supports toggling between Artifacts, Config, Context, and Prompt panels via pulse bar buttons.

## Test plan
- [x] `make build` passes
- [x] `make vet && make fmt` clean
- [x] `make test` — same 3 pre-existing failures only
- [x] `npm run check` — 0 errors, 3 pre-existing warnings
- [ ] Manual: Chat cancellation stops streaming immediately
- [ ] Manual: Session config panel toggles tool availability
- [ ] Manual: Context monitor shows token usage
- [ ] Manual: Prompt editor override applies to next message