### PR TITLE
fix: remove max-width cap and make chat pulse bar sticky

### DIFF
--- a/frontend/console/src/components/Chat.svelte
+++ b/frontend/console/src/components/Chat.svelte
@@ -370,6 +370,9 @@
     background: var(--bg-surface);
     border-bottom: 1px solid var(--border-subtle);
     flex-shrink: 0;
+    position: sticky;
+    top: 0;
+    z-index: 10;
   }
 
   .pulse-item {

--- a/frontend/console/src/components/Shell.svelte
+++ b/frontend/console/src/components/Shell.svelte
@@ -51,7 +51,6 @@
   .shell-content {
     flex: 1;
     padding: var(--space-6);
-    max-width: 1200px;
     width: 100%;
   }
 


### PR DESCRIPTION
## Summary
- Remove `max-width: 1200px` from Shell content — all pages now fill full viewport width
- Add `position: sticky` to chat pulse bar — stays visible when scrolling long conversations

## Test plan
- [x] Wide screen: no right-side gap on any page (Chat, Memory, System Prompt, etc.)
- [x] Chat: pulse bar stays fixed at top when scrolling