### PR TITLE
feat: add session working directories with file browser integration

### DIFF
--- a/frontend/console/src/components/ArtifactPanel.svelte
+++ b/frontend/console/src/components/ArtifactPanel.svelte
@@ -1,18 +1,23 @@
 <script lang="ts">
-  import { onMount } from 'svelte'
   import type { Artifact } from '../lib/artifacts'
   import { fileIcon } from '../lib/artifacts'
-  import { listWorkspaceFiles, readWorkspaceFile, type WorkspaceFileEntry, type WorkspaceFileContent } from '../lib/api'
+  import { listWorkspaceFiles, readWorkspaceFile, getSessionWorkDirs, updateSessionWorkDirs, type WorkspaceFileEntry, type WorkspaceFileContent } from '../lib/api'
+  import type { SessionWorkDirs } from '../lib/types'
 
   interface Props {
     artifacts: Artifact[]
+    sessionId: string
     onClose: () => void
   }
 
-  let { artifacts, onClose }: Props = $props()
+  let { artifacts, sessionId, onClose }: Props = $props()
 
   type Tab = 'session' | 'workspace'
   let activeTab: Tab = $state(artifacts.length > 0 ? 'session' : 'workspace')
+
+  // WorkDirs state
+  let workDirs: SessionWorkDirs = $state({ work_dirs: [], current_dir: '' })
+  let newDirInput = $state('')
 
   // Workspace browser state
   let currentPath = $state('.')
@@ -26,11 +31,47 @@
   let previewError = $state('')
   let copied = $state(false)
 
+  const effectiveRoot = $derived(workDirs.current_dir || undefined)
+
+  async function loadWorkDirs() {
+    if (!sessionId) return
+    try {
+      workDirs = await getSessionWorkDirs(sessionId)
+    } catch { /* ignore */ }
+  }
+
+  async function switchDir(dir: string) {
+    await updateSessionWorkDirs(sessionId, { ...workDirs, current_dir: dir })
+    workDirs.current_dir = dir
+    currentPath = '.'
+    await browseDir('.')
+  }
+
+  async function addDir() {
+    const dir = newDirInput.trim()
+    if (!dir) return
+    const dirs = [...workDirs.work_dirs, dir]
+    await updateSessionWorkDirs(sessionId, { work_dirs: dirs, current_dir: dir })
+    workDirs = { work_dirs: dirs, current_dir: dir }
+    newDirInput = ''
+    currentPath = '.'
+    await browseDir('.')
+  }
+
+  async function removeDir(dir: string) {
+    const dirs = workDirs.work_dirs.filter(d => d !== dir)
+    const cd = dir === workDirs.current_dir ? (dirs[0] || '') : workDirs.current_dir
+    await updateSessionWorkDirs(sessionId, { work_dirs: dirs, current_dir: cd })
+    workDirs = { work_dirs: dirs, current_dir: cd }
+    currentPath = '.'
+    await browseDir('.')
+  }
+
   async function browseDir(path: string) {
     wsLoading = true
     wsError = ''
     try {
-      const result = await listWorkspaceFiles(path)
+      const result = await listWorkspaceFiles(path, effectiveRoot)
       wsFiles = result.files || []
       currentPath = result.path || path
     } catch (err) {
@@ -45,7 +86,7 @@
     previewError = ''
     previewFile = null
     try {
-      previewFile = await readWorkspaceFile(path)
+      previewFile = await readWorkspaceFile(path, effectiveRoot)
     } catch (err) {
       previewError = err instanceof Error ? err.message : 'Failed to read file'
     } finally {
@@ -84,9 +125,10 @@
   }
 
   function breadcrumbs(path: string): Array<{ label: string; path: string }> {
-    if (path === '.') return [{ label: 'workspace', path: '.' }]
+    const rootLabel = effectiveRoot ? (effectiveRoot.split('/').pop() || 'root') : 'workspace'
+    if (path === '.') return [{ label: rootLabel, path: '.' }]
     const parts = path.split('/').filter(Boolean)
-    const crumbs = [{ label: 'workspace', path: '.' }]
+    const crumbs = [{ label: rootLabel, path: '.' }]
     for (let i = 0; i < parts.length; i++) {
       crumbs.push({ label: parts[i], path: parts.slice(0, i + 1).join('/') })
     }
@@ -134,7 +176,7 @@
 
   $effect(() => {
     if (activeTab === 'workspace') {
-      void browseDir(currentPath)
+      void loadWorkDirs().then(() => browseDir(currentPath))
     }
   })
 </script>
@@ -179,6 +221,26 @@
     </div>
 
   {:else}
+    <!-- WorkDir bar -->
+    <div class="workdir-bar">
+      {#if workDirs.work_dirs.length > 0}
+        <div class="workdir-list">
+          <select class="workdir-select" value={workDirs.current_dir} onchange={(e) => switchDir(e.currentTarget.value)}>
+            {#each workDirs.work_dirs as dir}
+              <option value={dir}>{dir.split('/').pop() || dir}</option>
+            {/each}
+          </select>
+          <button type="button" class="btn btn-ghost btn-sm" title="Remove current directory" onclick={() => removeDir(workDirs.current_dir)}>-</button>
+        </div>
+      {:else}
+        <span class="workdir-default">workspace/</span>
+      {/if}
+      <div class="workdir-add">
+        <input type="text" placeholder="Add directory path..." bind:value={newDirInput} class="workdir-input" onkeydown={(e) => e.key === 'Enter' && addDir()} />
+        <button type="button" class="btn btn-ghost btn-sm" onclick={addDir} disabled={!newDirInput.trim()}>+</button>
+      </div>
+    </div>
+
     <!-- Workspace browser -->
     <div class="ws-breadcrumbs">
       {#each breadcrumbs(currentPath) as crumb, i}
@@ -319,6 +381,56 @@
     line-height: 1;
   }
   .artifact-close:hover { color: var(--text-primary); }
+
+  /* WorkDir bar */
+  .workdir-bar {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    border-bottom: 1px solid var(--border-subtle);
+    flex-shrink: 0;
+  }
+
+  .workdir-list {
+    display: flex;
+    gap: var(--space-1);
+    align-items: center;
+  }
+
+  .workdir-select {
+    flex: 1;
+    background: var(--bg-inset);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    padding: 4px 8px;
+  }
+
+  .workdir-default {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-secondary);
+    padding: 4px 0;
+  }
+
+  .workdir-add {
+    display: flex;
+    gap: var(--space-1);
+  }
+
+  .workdir-input {
+    flex: 1;
+    background: var(--bg-inset);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    padding: 3px 6px;
+  }
 
   .artifact-list {
     flex: 1;

--- a/frontend/console/src/components/Chat.svelte
+++ b/frontend/console/src/components/Chat.svelte
@@ -327,7 +327,7 @@
     {#if rightPanel !== 'none'}
       <aside class="chat-right-panel">
         {#if rightPanel === 'artifacts'}
-          <ArtifactPanel artifacts={chatArtifacts} onClose={() => { rightPanel = 'none' }} />
+          <ArtifactPanel artifacts={chatArtifacts} sessionId={selectedSessionId || ''} onClose={() => { rightPanel = 'none' }} />
         {:else if rightPanel === 'config' && (selectedSessionId || true)}
           <SessionConfigPanel sessionId={selectedSessionId ?? ''} onClose={() => { rightPanel = 'none' }} />
         {:else if rightPanel === 'context'}

--- a/frontend/console/src/lib/api.ts
+++ b/frontend/console/src/lib/api.ts
@@ -38,6 +38,7 @@ import type {
   SessionMessage,
   UpdateCronJobRequest,
   SessionTasks,
+  SessionWorkDirs,
   UpdateProjectRequest,
 } from './types'
 
@@ -220,6 +221,18 @@ export async function compactSession(sessionId: string): Promise<{ compacted: bo
 
 export async function getSessionTasks(sessionId: string): Promise<SessionTasks> {
   return requestJSON<SessionTasks>(`/v1/admin/sessions/${encodeURIComponent(sessionId)}/tasks`)
+}
+
+export async function getSessionWorkDirs(sessionId: string): Promise<SessionWorkDirs> {
+  return requestJSON<SessionWorkDirs>(`/v1/admin/sessions/${encodeURIComponent(sessionId)}/workdirs`)
+}
+
+export async function updateSessionWorkDirs(sessionId: string, data: { work_dirs: string[]; current_dir: string }): Promise<void> {
+  await requestJSON(`/v1/admin/sessions/${encodeURIComponent(sessionId)}/workdirs`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
 }
 
 // --- Knowledge Base ---
@@ -716,15 +729,19 @@ export type WorkspaceFileContent = {
   content: string
 }
 
-export async function listWorkspaceFiles(path = '.'): Promise<{ path: string; files: WorkspaceFileEntry[] }> {
+export async function listWorkspaceFiles(path = '.', root?: string): Promise<{ path: string; files: WorkspaceFileEntry[] }> {
+  const params = new URLSearchParams({ path })
+  if (root) params.set('root', root)
   return requestJSON<{ path: string; files: WorkspaceFileEntry[] }>(
-    `/v1/workspace/files?path=${encodeURIComponent(path)}`
+    `/v1/workspace/files?${params}`
   )
 }
 
-export async function readWorkspaceFile(path: string): Promise<WorkspaceFileContent> {
+export async function readWorkspaceFile(path: string, root?: string): Promise<WorkspaceFileContent> {
+  const params = new URLSearchParams({ path })
+  if (root) params.set('root', root)
   return requestJSON<WorkspaceFileContent>(
-    `/v1/workspace/files?path=${encodeURIComponent(path)}`
+    `/v1/workspace/files?${params}`
   )
 }
 

--- a/frontend/console/src/lib/types.ts
+++ b/frontend/console/src/lib/types.ts
@@ -491,3 +491,8 @@ export type SessionTasks = {
   plan?: SessionPlan
   tasks: SessionTask[]
 }
+
+export type SessionWorkDirs = {
+  work_dirs: string[]
+  current_dir: string
+}

--- a/internal/memory/workspace.go
+++ b/internal/memory/workspace.go
@@ -155,6 +155,9 @@ func EnsureWorkspace(root string) error {
 	if err := os.MkdirAll(filepath.Join(root, "_shared"), 0o755); err != nil {
 		return fmt.Errorf("create shared dir: %w", err)
 	}
+	if err := os.MkdirAll(filepath.Join(root, "artifacts"), 0o755); err != nil {
+		return fmt.Errorf("create artifacts dir: %w", err)
+	}
 	if err := ensureFile(filepath.Join(root, "MEMORY.md"), defaultMemoryTemplate); err != nil {
 		return err
 	}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -28,6 +28,8 @@ type Session struct {
 	ProjectID      string             `json:"project_id,omitempty"`
 	ToolConfig     *SessionToolConfig `json:"tool_config,omitempty"`
 	PromptOverride string             `json:"prompt_override,omitempty"`
+	WorkDirs       []string           `json:"work_dirs,omitempty"`
+	CurrentDir     string             `json:"current_dir,omitempty"`
 	CreatedAt      time.Time          `json:"created_at"`
 	UpdatedAt      time.Time          `json:"updated_at"`
 }
@@ -329,6 +331,86 @@ func (s *Store) SetPromptOverride(id string, override string) error {
 		return fmt.Errorf("session not found")
 	}
 	sess.PromptOverride = override
+	sess.UpdatedAt = time.Now().UTC()
+	index[id] = sess
+	return s.saveIndex(index)
+}
+
+// SetWorkDirs updates the per-session working directories and current directory.
+func (s *Store) SetWorkDirs(id string, dirs []string, currentDir string) error {
+	unlock := lockPath(s.indexPath())
+	defer unlock()
+	index, err := s.loadIndex()
+	if err != nil {
+		return err
+	}
+	sess, ok := index[id]
+	if !ok {
+		return fmt.Errorf("session not found")
+	}
+	// Normalize and deduplicate dirs
+	cleaned := make([]string, 0, len(dirs))
+	seen := map[string]struct{}{}
+	for _, d := range dirs {
+		d = strings.TrimSpace(d)
+		if d == "" {
+			continue
+		}
+		if _, exists := seen[d]; exists {
+			continue
+		}
+		seen[d] = struct{}{}
+		cleaned = append(cleaned, d)
+	}
+	sess.WorkDirs = cleaned
+	// Validate currentDir is in WorkDirs
+	cd := strings.TrimSpace(currentDir)
+	if cd != "" {
+		found := false
+		for _, d := range cleaned {
+			if d == cd {
+				found = true
+				break
+			}
+		}
+		if !found && len(cleaned) > 0 {
+			cd = cleaned[0]
+		}
+	} else if len(cleaned) > 0 {
+		cd = cleaned[0]
+	}
+	sess.CurrentDir = cd
+	sess.UpdatedAt = time.Now().UTC()
+	index[id] = sess
+	return s.saveIndex(index)
+}
+
+// SetCurrentDir updates only the current working directory for a session.
+func (s *Store) SetCurrentDir(id string, dir string) error {
+	unlock := lockPath(s.indexPath())
+	defer unlock()
+	index, err := s.loadIndex()
+	if err != nil {
+		return err
+	}
+	sess, ok := index[id]
+	if !ok {
+		return fmt.Errorf("session not found")
+	}
+	cd := strings.TrimSpace(dir)
+	if cd != "" && len(sess.WorkDirs) > 0 {
+		found := false
+		for _, d := range sess.WorkDirs {
+			if d == cd {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("directory not in work_dirs")
+		}
+	}
+	sess.CurrentDir = cd
 	sess.UpdatedAt = time.Now().UTC()
 	index[id] = sess
 	return s.saveIndex(index)

--- a/internal/tarsserver/handler_session.go
+++ b/internal/tarsserver/handler_session.go
@@ -396,6 +396,39 @@ func newSessionAPIHandler(store *session.Store, logger zerolog.Logger) http.Hand
 				return
 			}
 			writeJSON(w, http.StatusOK, tasks)
+		case len(pathParts) == 2 && pathParts[1] == "workdirs":
+			if !requireMethod(w, r, http.MethodGet, http.MethodPut) {
+				return
+			}
+			sess, err := reqStore.Get(sessionID)
+			if err != nil {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": "session not found"})
+				return
+			}
+			switch r.Method {
+			case http.MethodGet:
+				workDirs := sess.WorkDirs
+				if workDirs == nil {
+					workDirs = []string{}
+				}
+				writeJSON(w, http.StatusOK, map[string]any{
+					"work_dirs":   workDirs,
+					"current_dir": sess.CurrentDir,
+				})
+			case http.MethodPut:
+				var req struct {
+					WorkDirs   []string `json:"work_dirs"`
+					CurrentDir string   `json:"current_dir"`
+				}
+				if !decodeJSONBody(w, r, &req) {
+					return
+				}
+				if err := reqStore.SetWorkDirs(sessionID, req.WorkDirs, req.CurrentDir); err != nil {
+					writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+					return
+				}
+				writeJSON(w, http.StatusOK, map[string]string{"ok": "true"})
+			}
 		default:
 			http.NotFound(w, r)
 		}

--- a/internal/tarsserver/handler_workspace_files.go
+++ b/internal/tarsserver/handler_workspace_files.go
@@ -31,8 +31,14 @@ func newWorkspaceFilesHandler(workspaceDir string, logger zerolog.Logger) http.H
 			relPath = "."
 		}
 
+		// Allow overriding the root directory (for session work dirs)
+		rootDir := strings.TrimSpace(r.URL.Query().Get("root"))
+		if rootDir == "" {
+			rootDir = workspaceDir
+		}
+
 		// Prevent path traversal
-		cleanRoot := strings.TrimRight(filepath.Clean(workspaceDir), "/")
+		cleanRoot := strings.TrimRight(filepath.Clean(rootDir), "/")
 		absPath := filepath.Join(cleanRoot, filepath.Clean(relPath))
 		if !strings.HasPrefix(absPath, cleanRoot) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid path"})


### PR DESCRIPTION
## Summary
- **Session WorkDirs** — sessions can map multiple working directories, with one active as "current dir" (pwd)
- **WorkDirs API** — `GET/PUT /v1/admin/sessions/{id}/workdirs`
- **File browser** — browses active session directory; dropdown to switch between dirs
- **Default fallback** — `workspace/artifacts/` when no dirs mapped
- **Root parameter** — workspace files API accepts `root` query param for arbitrary directory browsing

## Test plan
- [x] `make build` passes
- [x] `make test` — all tests pass
- [ ] `make dev-console` — add directory, switch, browse files