### PR TITLE
fix: directory picker starts from user home

### DIFF
--- a/frontend/console/src/components/ArtifactPanel.svelte
+++ b/frontend/console/src/components/ArtifactPanel.svelte
@@ -73,8 +73,8 @@
   async function browsePick(path: string) {
     pickLoading = true
     try {
-      // Browse from workspace root (pass root=workspaceDir equivalent via no root param with special marker)
-      const result = await listWorkspaceFiles(path, '/')
+      // Browse from user home directory
+      const result = await listWorkspaceFiles(path, '~')
       pickFiles = (result.files || []).filter(f => f.is_dir)
       pickPath = result.path || path
     } catch {

--- a/internal/tarsserver/handler_workspace_files.go
+++ b/internal/tarsserver/handler_workspace_files.go
@@ -33,9 +33,14 @@ func newWorkspaceFilesHandler(workspaceDir string, logger zerolog.Logger) http.H
 
 		// Allow overriding the root directory (for session work dirs)
 		// Default to artifacts/ subdirectory to avoid exposing internal workspace files
+		// Special value "~" resolves to user home directory
 		rootDir := strings.TrimSpace(r.URL.Query().Get("root"))
 		if rootDir == "" {
 			rootDir = filepath.Join(workspaceDir, "artifacts")
+		} else if rootDir == "~" {
+			if home, err := os.UserHomeDir(); err == nil {
+				rootDir = home
+			}
 		}
 
 		// Prevent path traversal


### PR DESCRIPTION
Use root=~ instead of root=/ for safer directory browsing scope.