### PR TITLE
chore: remove PROJECT.md from workspace bootstrap and system prompt

### DIFF
--- a/internal/memory/workspace.go
+++ b/internal/memory/workspace.go
@@ -22,13 +22,6 @@ const defaultMemoryTemplate = `# MEMORY.md
 - Keep only durable facts and preferences here.
 `
 
-const defaultProjectTemplate = `# PROJECT.md
-
-## Project Guidance
-- Define global project execution policy and reporting format.
-- Define global execution policy and reporting format.
-`
-
 const defaultAgentsTemplate = `# AGENTS.md
 
 ## Operating Guidelines
@@ -75,13 +68,6 @@ type WorkspaceBootstrapFileSpec struct {
 }
 
 var workspaceBootstrapFileSpecs = []WorkspaceBootstrapFileSpec{
-	{
-		Path:            "PROJECT.md",
-		Title:           "Project Guidance",
-		Description:     "Global project execution policy and reporting format.",
-		DefaultContent:  defaultProjectTemplate,
-		EnsureByDefault: true,
-	},
 	{
 		Path:            "USER.md",
 		Title:           "User Identity",
@@ -148,9 +134,6 @@ func EnsureWorkspace(root string) error {
 	}
 	if err := os.MkdirAll(filepath.Join(root, "memory", "wiki", "notes"), 0o755); err != nil {
 		return fmt.Errorf("create memory wiki notes dir: %w", err)
-	}
-	if err := os.MkdirAll(filepath.Join(root, "projects"), 0o755); err != nil {
-		return fmt.Errorf("create projects dir: %w", err)
 	}
 	if err := os.MkdirAll(filepath.Join(root, "_shared"), 0o755); err != nil {
 		return fmt.Errorf("create shared dir: %w", err)

--- a/internal/memory/workspace_test.go
+++ b/internal/memory/workspace_test.go
@@ -23,11 +23,9 @@ func TestEnsureWorkspace(t *testing.T) {
 		filepath.Join(root, "memory", "wiki", "notes"),
 		filepath.Join(root, "memory", "wiki", "index.md"),
 		filepath.Join(root, "memory", "wiki", "graph.json"),
-		filepath.Join(root, "projects"),
 		filepath.Join(root, "_shared"),
 		filepath.Join(root, "HEARTBEAT.md"),
 		filepath.Join(root, "MEMORY.md"),
-		filepath.Join(root, "PROJECT.md"),
 		filepath.Join(root, "AGENTS.md"),
 		filepath.Join(root, "USER.md"),
 		filepath.Join(root, "IDENTITY.md"),
@@ -53,14 +51,6 @@ func TestEnsureWorkspace(t *testing.T) {
 	}
 	if !strings.Contains(string(memoryFile), "Long-Term Memory") {
 		t.Fatalf("expected default MEMORY template, got %q", string(memoryFile))
-	}
-
-	projectFile, err := os.ReadFile(filepath.Join(root, "PROJECT.md"))
-	if err != nil {
-		t.Fatalf("read PROJECT.md: %v", err)
-	}
-	if !strings.Contains(string(projectFile), "Project Guidance") {
-		t.Fatalf("expected default PROJECT template, got %q", string(projectFile))
 	}
 
 	agentsFile, err := os.ReadFile(filepath.Join(root, "AGENTS.md"))
@@ -114,7 +104,6 @@ func TestEnsureWorkspace_DoesNotOverwriteExistingFiles(t *testing.T) {
 	}
 	customHeartbeat := "custom heartbeat"
 	customMemory := "custom memory"
-	customProject := "custom project"
 	customAgents := "custom agents"
 	customUser := "custom user"
 	customIdentity := "custom identity"
@@ -124,9 +113,6 @@ func TestEnsureWorkspace_DoesNotOverwriteExistingFiles(t *testing.T) {
 	}
 	if err := os.WriteFile(filepath.Join(root, "MEMORY.md"), []byte(customMemory), 0o644); err != nil {
 		t.Fatalf("write MEMORY.md: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "PROJECT.md"), []byte(customProject), 0o644); err != nil {
-		t.Fatalf("write PROJECT.md: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte(customAgents), 0o644); err != nil {
 		t.Fatalf("write AGENTS.md: %v", err)
@@ -159,14 +145,6 @@ func TestEnsureWorkspace_DoesNotOverwriteExistingFiles(t *testing.T) {
 	}
 	if string(memoryFile) != customMemory {
 		t.Fatalf("expected existing MEMORY.md to remain unchanged, got %q", string(memoryFile))
-	}
-
-	projectFile, err := os.ReadFile(filepath.Join(root, "PROJECT.md"))
-	if err != nil {
-		t.Fatalf("read PROJECT.md: %v", err)
-	}
-	if string(projectFile) != customProject {
-		t.Fatalf("expected existing PROJECT.md to remain unchanged, got %q", string(projectFile))
 	}
 
 	agentsFile, err := os.ReadFile(filepath.Join(root, "AGENTS.md"))

--- a/internal/prompt/builder_test.go
+++ b/internal/prompt/builder_test.go
@@ -14,7 +14,6 @@ func TestBuild(t *testing.T) {
 	files := map[string]string{
 		"IDENTITY.md":  "# IDENTITY.md\n\nName: TARS",
 		"USER.md":      "# USER.md\n\nName: Alice",
-		"PROJECT.md":   "# PROJECT.md\n\nProject policy",
 		"AGENTS.md":    "# AGENTS.md\n\nOperating guidelines",
 		"TOOLS.md":     "# TOOLS.md\n\nAvailable tools",
 		"HEARTBEAT.md": "# HEARTBEAT.md\n\nCheck daily tasks",
@@ -42,10 +41,6 @@ func TestBuild(t *testing.T) {
 	if strings.Contains(result, files["MEMORY.md"]) {
 		t.Errorf("expected static prompt to exclude MEMORY.md content")
 	}
-	if strings.Contains(result, files["PROJECT.md"]) {
-		t.Errorf("expected prompt to exclude PROJECT.md content (project system removed)")
-	}
-
 	// Should have section headers
 	if !strings.Contains(result, "IDENTITY") {
 		t.Error("expected IDENTITY section")
@@ -58,7 +53,6 @@ func TestBuild_SubAgent(t *testing.T) {
 	files := map[string]string{
 		"IDENTITY.md":  "# IDENTITY.md\n\nName: TARS",
 		"USER.md":      "# USER.md\n\nName: Alice",
-		"PROJECT.md":   "# PROJECT.md\n\nProject policy",
 		"AGENTS.md":    "# AGENTS.md\n\nOperating guidelines",
 		"TOOLS.md":     "# TOOLS.md\n\nAvailable tools",
 		"HEARTBEAT.md": "# HEARTBEAT.md\n\nCheck daily tasks",
@@ -92,9 +86,6 @@ func TestBuild_SubAgent(t *testing.T) {
 	}
 	if strings.Contains(result, "Key facts") {
 		t.Error("sub-agent prompt should not contain MEMORY.md content")
-	}
-	if strings.Contains(result, "Project policy") {
-		t.Error("sub-agent prompt should not contain PROJECT.md content")
 	}
 }
 
@@ -172,8 +163,8 @@ func TestBuildResult_PrioritizesHigherOrderStaticSections(t *testing.T) {
 
 func TestBuildResult_ClampsRelevantMemoryToRemainingTotalBudget(t *testing.T) {
 	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, "PROJECT.md"), []byte(strings.Repeat("project ", 160)), 0o644); err != nil {
-		t.Fatalf("write PROJECT.md: %v", err)
+	if err := os.WriteFile(filepath.Join(root, "USER.md"), []byte(strings.Repeat("user ", 160)), 0o644); err != nil {
+		t.Fatalf("write USER.md: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(root, "MEMORY.md"), []byte("User prefers black coffee with oat milk.\n"), 0o644); err != nil {
 		t.Fatalf("write MEMORY.md: %v", err)

--- a/internal/prompt/memory_retrieval_test.go
+++ b/internal/prompt/memory_retrieval_test.go
@@ -35,9 +35,6 @@ func TestBuild_IncludesRelevantMemoryByQueryAndProject(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, "IDENTITY.md"), []byte("identity"), 0o644); err != nil {
 		t.Fatalf("write IDENTITY.md: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(root, "PROJECT.md"), []byte("project rules"), 0o644); err != nil {
-		t.Fatalf("write PROJECT.md: %v", err)
-	}
 	if err := os.WriteFile(filepath.Join(root, "MEMORY.md"), []byte("I prefer green tea.\n"), 0o644); err != nil {
 		t.Fatalf("write MEMORY.md: %v", err)
 	}

--- a/internal/sysprompt/sysprompt.go
+++ b/internal/sysprompt/sysprompt.go
@@ -47,7 +47,6 @@ func specs() []FileSpec {
 	return []FileSpec{
 		workspaceSpec("USER.md", lookup),
 		workspaceSpec("IDENTITY.md", lookup),
-		workspaceSpec("PROJECT.md", lookup),
 		workspaceSpec("HEARTBEAT.md", lookup),
 		agentSpec("AGENTS.md", lookup),
 		agentSpec("TOOLS.md", lookup),


### PR DESCRIPTION
## Summary
- Remove `PROJECT.md` from workspace bootstrap file specs and sysprompt page
- Remove `defaultProjectTemplate` and `workspace/projects/` directory creation
- Follow-up to #300 (project feature removal)

## Test plan
- [x] `make build` passes
- [x] `make test` passes
- [x] `make vet` clean