### PR TITLE
feat: wire session work_dirs into file tools and system prompt

### DIFF
--- a/internal/prompt/builder.go
+++ b/internal/prompt/builder.go
@@ -12,8 +12,10 @@ import (
 
 // BuildOptions configures system prompt generation.
 type BuildOptions struct {
-	WorkspaceDir         string // path to workspace root
-	SubAgent             bool   // if true, only inject AGENTS.md and TOOLS.md
+	WorkspaceDir         string   // path to workspace root
+	WorkDirs             []string // additional working directories the session can access
+	CurrentDir           string   // session's current working directory (overrides WorkspaceDir for relative paths)
+	SubAgent             bool     // if true, only inject AGENTS.md and TOOLS.md
 	Query                string
 	SessionID            string
 	MemorySearcher       memory.Searcher
@@ -91,6 +93,30 @@ func BuildResultFor(opts BuildOptions) BuildResult {
 		remainingStaticTokens -= sectionTokens
 		remainingTotalTokens -= sectionTokens
 	}
+	// Inject working directories section if session has work_dirs
+	if len(opts.WorkDirs) > 0 {
+		var dirSection strings.Builder
+		dirSection.WriteString("## Working Directories\n\n")
+		if opts.CurrentDir != "" {
+			dirSection.WriteString(fmt.Sprintf("Current directory: `%s`\n", opts.CurrentDir))
+		}
+		dirSection.WriteString("Available directories:\n")
+		for _, d := range opts.WorkDirs {
+			if d == opts.CurrentDir {
+				dirSection.WriteString(fmt.Sprintf("- `%s` (current)\n", d))
+			} else {
+				dirSection.WriteString(fmt.Sprintf("- `%s`\n", d))
+			}
+		}
+		dirSection.WriteString("\nFile tool paths resolve relative to the current directory. Use absolute paths to access other directories.\n\n")
+		content := dirSection.String()
+		b.WriteString(content)
+		sectionTokens := estimateTokens(content)
+		staticTokens += sectionTokens
+		totalTokens += sectionTokens
+		remainingTotalTokens -= sectionTokens
+	}
+
 	relevantTokens := 0
 	relevantCount := 0
 	if !opts.SubAgent {

--- a/internal/tarsserver/handler_chat.go
+++ b/internal/tarsserver/handler_chat.go
@@ -94,7 +94,7 @@ func prepareChatContextDetailsWithExtensions(
 	invokedSkill *skill.Definition,
 	semanticCfg ...memory.SemanticConfig,
 ) (preparedChatContext, error) {
-	return prepareChatContextDetailsWithCache(workspaceDir, sessionID, userMessage, extSnapshot, invokedSkill, nil, semanticCfg...)
+	return prepareChatContextDetailsWithCache(workspaceDir, sessionID, userMessage, extSnapshot, invokedSkill, nil, firstSemanticConfig(semanticCfg...), nil, "")
 }
 
 func prepareChatContextDetailsWithCache(
@@ -104,7 +104,9 @@ func prepareChatContextDetailsWithCache(
 	extSnapshot extensions.Snapshot,
 	invokedSkill *skill.Definition,
 	cache *memoryCache,
-	semanticCfg ...memory.SemanticConfig,
+	semanticCfg memory.SemanticConfig,
+	workDirs []string,
+	currentDir string,
 ) (preparedChatContext, error) {
 	forceRelevantMemory := shouldForceMemoryToolCall(userMessage)
 	extSnapshot = filterSkillSnapshotForProject(extSnapshot, workspaceDir)
@@ -114,9 +116,11 @@ func prepareChatContextDetailsWithCache(
 		return buildContextFromResult(cached, extSnapshot, invokedSkill, forceRelevantMemory), nil
 	}
 
-	memService := buildSemanticMemoryService(workspaceDir, firstSemanticConfig(semanticCfg...))
+	memService := buildSemanticMemoryService(workspaceDir, semanticCfg)
 	buildResult := prompt.BuildResultFor(prompt.BuildOptions{
 		WorkspaceDir:        workspaceDir,
+		WorkDirs:            workDirs,
+		CurrentDir:          currentDir,
 		Query:               userMessage,
 		SessionID:           sessionID,
 		MemorySearcher:      memService,
@@ -602,7 +606,7 @@ func newChatAPIHandlerWithRuntimeConfig(
 			return
 		}
 		registry := buildChatToolRegistry(
-			reqStore, "", "", requestWorkspaceDir, nil, chatHandlerDeps{
+			reqStore, "", "", requestWorkspaceDir, tool.SingleDirPolicy(requestWorkspaceDir), nil, chatHandlerDeps{
 				workspaceDir:  workspaceDir,
 				store:         store,
 				client:        client,
@@ -671,9 +675,17 @@ func newChatAPIHandlerWithRuntimeConfig(
 		if tooling.Extensions != nil {
 			extSnapshot = tooling.Extensions.Snapshot()
 		}
+		// Build PathPolicy from session work_dirs for context preview
+		var previewPolicy tool.PathPolicy
+		if len(sess.WorkDirs) > 0 {
+			previewPolicy = tool.NewPathPolicy(requestWorkspaceDir, sess.WorkDirs, sess.CurrentDir)
+		} else {
+			previewPolicy = tool.SingleDirPolicy(requestWorkspaceDir)
+		}
 		contextDetails, err := prepareChatContextDetailsWithCache(
 			requestWorkspaceDir, sessionID, "(context preview)",
 			extSnapshot, nil, tooling.MemoryCache, tooling.MemorySemanticConfig,
+			sess.WorkDirs, sess.CurrentDir,
 		)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "", "prepare context failed")
@@ -684,7 +696,7 @@ func newChatAPIHandlerWithRuntimeConfig(
 			systemPrompt += "\n\n## Session Prompt Override\n" + strings.TrimSpace(sess.PromptOverride) + "\n"
 		}
 		registry := buildChatToolRegistry(
-			reqStore, "", sessionID, requestWorkspaceDir, historySnapshot.Messages, chatHandlerDeps{
+			reqStore, "", sessionID, requestWorkspaceDir, previewPolicy, historySnapshot.Messages, chatHandlerDeps{
 				workspaceDir:  workspaceDir,
 				store:         store,
 				client:        client,

--- a/internal/tarsserver/handler_chat_context.go
+++ b/internal/tarsserver/handler_chat_context.go
@@ -71,11 +71,27 @@ func prepareChatRunState(r *http.Request, req chatRequestPayload, deps chatHandl
 	}
 	history := historySnapshot.Messages
 
+	// Fetch session early for WorkDirs
+	sess, sessErr := reqStore.Get(sessionID)
+
+	// Build PathPolicy from session work_dirs
+	var policy tool.PathPolicy
+	var sessionWorkDirs []string
+	var sessionCurrentDir string
+	if sessErr == nil && len(sess.WorkDirs) > 0 {
+		policy = tool.NewPathPolicy(requestWorkspaceDir, sess.WorkDirs, sess.CurrentDir)
+		sessionWorkDirs = sess.WorkDirs
+		sessionCurrentDir = sess.CurrentDir
+	} else {
+		policy = tool.SingleDirPolicy(requestWorkspaceDir)
+	}
+
 	registry := buildChatToolRegistry(
 		reqStore,
 		workspaceID,
 		sessionID,
 		requestWorkspaceDir,
+		policy,
 		history,
 		deps,
 	)
@@ -85,7 +101,7 @@ func prepareChatRunState(r *http.Request, req chatRequestPayload, deps chatHandl
 	}
 	resolvedSkill := resolveSkillSelection(req.Message, deps.tooling.Extensions, requestWorkspaceDir, sessionID)
 	invokedSkill := resolvedSkill.Definition
-	contextDetails, err := prepareChatContextDetailsWithCache(requestWorkspaceDir, sessionID, req.Message, extSnapshot, invokedSkill, deps.tooling.MemoryCache, deps.tooling.MemorySemanticConfig)
+	contextDetails, err := prepareChatContextDetailsWithCache(requestWorkspaceDir, sessionID, req.Message, extSnapshot, invokedSkill, deps.tooling.MemoryCache, deps.tooling.MemorySemanticConfig, sessionWorkDirs, sessionCurrentDir)
 	if err != nil {
 		return chatRunState{}, http.StatusInternalServerError, "prepare chat context failed", err
 	}
@@ -109,8 +125,7 @@ func prepareChatRunState(r *http.Request, req chatRequestPayload, deps chatHandl
 		return chatRunState{}, http.StatusInternalServerError, "save message failed", err
 	}
 
-	// Apply session-level prompt override
-	sess, sessErr := reqStore.Get(sessionID)
+	// Apply session-level prompt override (reuse sess fetched earlier)
 	if sessErr == nil && strings.TrimSpace(sess.PromptOverride) != "" {
 		systemPrompt += "\n\n## Session Prompt Override\n" + strings.TrimSpace(sess.PromptOverride) + "\n"
 	}

--- a/internal/tarsserver/handler_chat_pipeline_tools_test.go
+++ b/internal/tarsserver/handler_chat_pipeline_tools_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestResolveInjectedToolSchemas_FiltersHighRiskToolsForUserRole(t *testing.T) {
-	registry := newBaseToolRegistryWithProcess(t.TempDir(), tool.NewProcessManager())
+	registry := newBaseToolRegistryWithProcess(t.TempDir(), tool.SingleDirPolicy(t.TempDir()), tool.NewProcessManager())
 	registry.Register(tool.NewApplyPatchTool(t.TempDir(), true))
 
 	schemas := resolveInjectedToolSchemas(registry, "standard", nil, "user", false)
@@ -23,7 +23,7 @@ func TestResolveInjectedToolSchemas_FiltersHighRiskToolsForUserRole(t *testing.T
 }
 
 func TestResolveInjectedToolSchemas_AllowAdminHighRiskTools(t *testing.T) {
-	registry := newBaseToolRegistryWithProcess(t.TempDir(), tool.NewProcessManager())
+	registry := newBaseToolRegistryWithProcess(t.TempDir(), tool.SingleDirPolicy(t.TempDir()), tool.NewProcessManager())
 	registry.Register(tool.NewApplyPatchTool(t.TempDir(), true))
 
 	schemas := resolveInjectedToolSchemas(registry, "standard", nil, "admin", false)
@@ -36,7 +36,7 @@ func TestResolveInjectedToolSchemas_AllowAdminHighRiskTools(t *testing.T) {
 }
 
 func TestResolveInjectedToolSchemas_AllowHighRiskUserOverride(t *testing.T) {
-	registry := newBaseToolRegistryWithProcess(t.TempDir(), tool.NewProcessManager())
+	registry := newBaseToolRegistryWithProcess(t.TempDir(), tool.SingleDirPolicy(t.TempDir()), tool.NewProcessManager())
 
 	schemas := resolveInjectedToolSchemas(registry, "standard", nil, "user", true)
 	names := toolNamesFromSchemas(schemas)
@@ -48,7 +48,7 @@ func TestResolveInjectedToolSchemas_AllowHighRiskUserOverride(t *testing.T) {
 }
 
 func TestResolveInjectedToolSchemas_PassesThroughWithoutProjectPolicy(t *testing.T) {
-	registry := newBaseToolRegistryWithProcess(t.TempDir(), tool.NewProcessManager())
+	registry := newBaseToolRegistryWithProcess(t.TempDir(), tool.SingleDirPolicy(t.TempDir()), tool.NewProcessManager())
 
 	// Without project policy, all tools should pass through (only role-based filtering)
 	schemas := resolveInjectedToolSchemas(registry, "standard", nil, "admin", true)

--- a/internal/tarsserver/handler_chat_policy.go
+++ b/internal/tarsserver/handler_chat_policy.go
@@ -15,10 +15,11 @@ func buildChatToolRegistry(
 	workspaceID string,
 	sessionID string,
 	requestWorkspaceDir string,
+	policy tool.PathPolicy,
 	history []session.Message,
 	deps chatHandlerDeps,
 ) *tool.Registry {
-	registry := newBaseToolRegistryWithProcess(requestWorkspaceDir, deps.tooling.ProcessManager, deps.tooling.MemorySemanticConfig)
+	registry := newBaseToolRegistryWithProcess(requestWorkspaceDir, policy, deps.tooling.ProcessManager, deps.tooling.MemorySemanticConfig)
 
 	// Re-register ops aggregator with deps manager
 	registry.Register(tool.NewOpsTool(deps.tooling.OpsManager))

--- a/internal/tarsserver/helpers_agent.go
+++ b/internal/tarsserver/helpers_agent.go
@@ -43,10 +43,10 @@ func agentPromptTelemetryFromContext(ctx context.Context) *agentPromptTelemetry 
 }
 
 func newBaseToolRegistry(workspaceDir string) *tool.Registry {
-	return newBaseToolRegistryWithProcess(workspaceDir, nil)
+	return newBaseToolRegistryWithProcess(workspaceDir, tool.SingleDirPolicy(workspaceDir), nil)
 }
 
-func newBaseToolRegistryWithProcess(workspaceDir string, processManager *tool.ProcessManager, semanticCfg ...memory.SemanticConfig) *tool.Registry {
+func newBaseToolRegistryWithProcess(workspaceDir string, policy tool.PathPolicy, processManager *tool.ProcessManager, semanticCfg ...memory.SemanticConfig) *tool.Registry {
 	registry := tool.NewRegistry()
 	memService := buildSemanticMemoryService(workspaceDir, firstSemanticConfig(semanticCfg...))
 
@@ -66,18 +66,18 @@ func newBaseToolRegistryWithProcess(workspaceDir string, processManager *tool.Pr
 	}
 
 	// File I/O (no aliases — canonical names only)
-	registry.Register(tool.NewReadFileTool(workspaceDir))
-	registry.Register(tool.NewWriteFileTool(workspaceDir))
-	registry.Register(tool.NewEditFileTool(workspaceDir))
-	registry.Register(tool.NewListDirTool(workspaceDir))
-	registry.Register(tool.NewGlobTool(workspaceDir))
+	registry.Register(tool.NewReadFileToolWithPolicy(policy))
+	registry.Register(tool.NewWriteFileToolWithPolicy(policy))
+	registry.Register(tool.NewEditFileToolWithPolicy(policy))
+	registry.Register(tool.NewListDirToolWithPolicy(policy))
+	registry.Register(tool.NewGlobToolWithPolicy(policy))
 
 	// Exec / process
 	if processManager != nil {
 		registry.Register(tool.NewProcessTool(processManager))
-		registry.Register(tool.NewExecToolWithManager(workspaceDir, processManager))
+		registry.Register(tool.NewExecToolWithPolicy(policy, processManager))
 	} else {
-		registry.Register(tool.NewExecTool(workspaceDir))
+		registry.Register(tool.NewExecToolWithPolicy(policy, nil))
 	}
 	return registry
 }
@@ -149,7 +149,7 @@ func newAgentPromptRunnerWithToolsAndMemory(
 
 		profile := agentPromptProfileForLabel(label)
 		systemPrompt := buildAgentSystemPrompt(targetWorkspaceDir, profile, semanticCfg)
-		baseRegistry := newBaseToolRegistryWithProcess(targetWorkspaceDir, nil, semanticCfg)
+		baseRegistry := newBaseToolRegistryWithProcess(targetWorkspaceDir, tool.SingleDirPolicy(targetWorkspaceDir), nil, semanticCfg)
 		for _, extra := range extraTools {
 			if strings.TrimSpace(extra.Name) == "" {
 				continue
@@ -248,7 +248,7 @@ func buildAgentSystemPrompt(workspaceDir string, profile agentPromptProfile, sem
 }
 
 func newToolRegistryForAgentProfile(workspaceDir string, profile agentPromptProfile, extraAllowed []string, semanticCfg ...memory.SemanticConfig) *tool.Registry {
-	registry := newBaseToolRegistryWithProcess(workspaceDir, nil, semanticCfg...)
+	registry := newBaseToolRegistryWithProcess(workspaceDir, tool.SingleDirPolicy(workspaceDir), nil, semanticCfg...)
 	return filterToolRegistryForAgentProfile(registry, profile, extraAllowed)
 }
 

--- a/internal/tarsserver/telegram_inbound_process.go
+++ b/internal/tarsserver/telegram_inbound_process.go
@@ -10,6 +10,7 @@ import (
 	"github.com/devlikebear/tars/internal/agent"
 	"github.com/devlikebear/tars/internal/extensions"
 	"github.com/devlikebear/tars/internal/session"
+	"github.com/devlikebear/tars/internal/tool"
 	"github.com/devlikebear/tars/internal/usage"
 )
 
@@ -44,6 +45,7 @@ func (h *telegramInboundHandler) processMessage(
 		defaultWorkspaceID,
 		sessionID,
 		h.workspaceDir,
+		tool.SingleDirPolicy(h.workspaceDir),
 		history,
 		chatHandlerDeps{
 			workspaceDir: h.workspaceDir,

--- a/internal/tool/edit_file.go
+++ b/internal/tool/edit_file.go
@@ -23,7 +23,15 @@ func NewEditFileTool(workspaceDir string) Tool {
 	return newEditToolWithName("edit_file", workspaceDir)
 }
 
+func NewEditFileToolWithPolicy(policy PathPolicy) Tool {
+	return newEditToolWithPolicy("edit_file", policy)
+}
+
 func newEditToolWithName(name, workspaceDir string) Tool {
+	return newEditToolWithPolicy(name, SingleDirPolicy(workspaceDir))
+}
+
+func newEditToolWithPolicy(name string, policy PathPolicy) Tool {
 	return Tool{
 		Name:        name,
 		Description: "Edit a workspace file by replacing exact text.",
@@ -55,7 +63,7 @@ func newEditToolWithName(name, workspaceDir string) Tool {
 				return JSONTextResult(editFileResponse{Message: "old_text is required"}, true), nil
 			}
 
-			absPath, err := resolveWorkspacePath(workspaceDir, input.Path)
+			absPath, err := resolvePathWithPolicy(policy, input.Path)
 			if err != nil {
 				return JSONTextResult(editFileResponse{Message: err.Error()}, true), nil
 			}
@@ -91,7 +99,7 @@ func newEditToolWithName(name, workspaceDir string) Tool {
 				replacements = count
 			}
 			return JSONTextResult(editFileResponse{
-				Path:         workspaceRelativePath(workspaceDir, absPath),
+				Path:         policyRelativePath(policy, absPath),
 				Replacements: replacements,
 			}, false), nil
 		},

--- a/internal/tool/exec.go
+++ b/internal/tool/exec.go
@@ -49,6 +49,10 @@ func NewExecTool(workspaceDir string) Tool {
 }
 
 func NewExecToolWithManager(workspaceDir string, manager *ProcessManager) Tool {
+	return NewExecToolWithPolicy(SingleDirPolicy(workspaceDir), manager)
+}
+
+func NewExecToolWithPolicy(policy PathPolicy, manager *ProcessManager) Tool {
 	return Tool{
 		Name:        "exec",
 		Description: "Run a shell command in workspace with timeout and safety restrictions.",
@@ -94,7 +98,7 @@ func NewExecToolWithManager(workspaceDir string, manager *ProcessManager) Tool {
 				if manager == nil {
 					return execErrorResult(commandLine, "background execution requires process manager", -1, "", "", 0, false), nil
 				}
-				snap, err := manager.Start(ctx, workspaceDir, commandLine, timeoutMS)
+				snap, err := manager.Start(ctx, policy.PrimaryDir, commandLine, timeoutMS)
 				if err != nil {
 					return execErrorResult(commandLine, err.Error(), -1, "", "", 0, false), nil
 				}
@@ -111,7 +115,7 @@ func NewExecToolWithManager(workspaceDir string, manager *ProcessManager) Tool {
 			defer cancel()
 
 			cmd := exec.CommandContext(runCtx, command, fields[1:]...)
-			cmd.Dir = workspaceDir
+			cmd.Dir = policy.PrimaryDir
 
 			var stdout bytes.Buffer
 			var stderr bytes.Buffer

--- a/internal/tool/glob.go
+++ b/internal/tool/glob.go
@@ -22,6 +22,10 @@ const (
 )
 
 func NewGlobTool(workspaceDir string) Tool {
+	return NewGlobToolWithPolicy(SingleDirPolicy(workspaceDir))
+}
+
+func NewGlobToolWithPolicy(policy PathPolicy) Tool {
 	return Tool{
 		Name:        "glob",
 		Description: "Find workspace paths matching a glob pattern.",
@@ -56,11 +60,11 @@ func NewGlobTool(workspaceDir string) Tool {
 
 			limit := resolvePositiveBoundedInt(defaultGlobLimit, maxGlobLimit, input.Limit)
 
-			rootAbs, err := filepath.Abs(workspaceDir)
+			primaryAbs, err := filepath.Abs(policy.PrimaryDir)
 			if err != nil {
 				return JSONTextResult(globResponse{Message: fmt.Sprintf("resolve workspace failed: %v", err)}, true), nil
 			}
-			fullPattern := filepath.Join(rootAbs, cleanPattern)
+			fullPattern := filepath.Join(primaryAbs, cleanPattern)
 			matches, err := filepath.Glob(fullPattern)
 			if err != nil {
 				return JSONTextResult(globResponse{Message: fmt.Sprintf("invalid glob pattern: %v", err)}, true), nil
@@ -69,14 +73,21 @@ func NewGlobTool(workspaceDir string) Tool {
 			result := make([]string, 0, len(matches))
 			truncated := false
 			for _, m := range matches {
-				if !pathWithinWorkspace(rootAbs, m) {
+				allowed := false
+				for _, dir := range policy.AllowedDirs {
+					if pathWithinWorkspace(dir, m) {
+						allowed = true
+						break
+					}
+				}
+				if !allowed {
 					continue
 				}
 				if len(result) >= limit {
 					truncated = true
 					break
 				}
-				result = append(result, workspaceRelativePath(workspaceDir, m))
+				result = append(result, policyRelativePath(policy, m))
 			}
 			return JSONTextResult(globResponse{
 				Pattern:   pattern,

--- a/internal/tool/list_dir.go
+++ b/internal/tool/list_dir.go
@@ -30,6 +30,10 @@ type listDirResponse struct {
 }
 
 func NewListDirTool(workspaceDir string) Tool {
+	return NewListDirToolWithPolicy(SingleDirPolicy(workspaceDir))
+}
+
+func NewListDirToolWithPolicy(policy PathPolicy) Tool {
 	return Tool{
 		Name:        "list_dir",
 		Description: "List files and directories under a workspace path.",
@@ -54,7 +58,7 @@ func NewListDirTool(workspaceDir string) Tool {
 
 			maxEntries := resolvePositiveBoundedInt(defaultListDirMaxEntries, maxListDirMaxEntries, input.MaxEntries)
 
-			absPath, err := resolveWorkspacePath(workspaceDir, input.Path)
+			absPath, err := resolvePathWithPolicy(policy, input.Path)
 			if err != nil {
 				return listDirErrorResult(err.Error()), nil
 			}
@@ -70,13 +74,13 @@ func NewListDirTool(workspaceDir string) Tool {
 				return listDirErrorResult("path is not a directory"), nil
 			}
 
-			entries, truncated, err := collectDirEntries(workspaceDir, absPath, input.Recursive, maxEntries)
+			entries, truncated, err := collectDirEntriesWithPolicy(policy, absPath, input.Recursive, maxEntries)
 			if err != nil {
 				return listDirErrorResult(fmt.Sprintf("list directory failed: %v", err)), nil
 			}
 
 			return JSONTextResult(listDirResponse{
-				Path:      workspaceRelativePath(workspaceDir, absPath),
+				Path:      policyRelativePath(policy, absPath),
 				Recursive: input.Recursive,
 				Count:     len(entries),
 				Truncated: truncated,
@@ -87,6 +91,10 @@ func NewListDirTool(workspaceDir string) Tool {
 }
 
 func collectDirEntries(workspaceDir, absPath string, recursive bool, maxEntries int) ([]listDirEntry, bool, error) {
+	return collectDirEntriesWithPolicy(SingleDirPolicy(workspaceDir), absPath, recursive, maxEntries)
+}
+
+func collectDirEntriesWithPolicy(policy PathPolicy, absPath string, recursive bool, maxEntries int) ([]listDirEntry, bool, error) {
 	if !recursive {
 		dirEntries, err := os.ReadDir(absPath)
 		if err != nil {
@@ -99,7 +107,7 @@ func collectDirEntries(workspaceDir, absPath string, recursive bool, maxEntries 
 				truncated = true
 				break
 			}
-			entry, err := buildListDirEntry(workspaceDir, filepath.Join(absPath, item.Name()), item.Type())
+			entry, err := buildListDirEntryWithPolicy(policy, filepath.Join(absPath, item.Name()), item.Type())
 			if err != nil {
 				continue
 			}
@@ -121,7 +129,7 @@ func collectDirEntries(workspaceDir, absPath string, recursive bool, maxEntries 
 			truncated = true
 			return fs.SkipAll
 		}
-		entry, buildErr := buildListDirEntry(workspaceDir, path, d.Type())
+		entry, buildErr := buildListDirEntryWithPolicy(policy, path, d.Type())
 		if buildErr != nil {
 			return nil
 		}
@@ -132,6 +140,10 @@ func collectDirEntries(workspaceDir, absPath string, recursive bool, maxEntries 
 }
 
 func buildListDirEntry(workspaceDir, absPath string, mode fs.FileMode) (listDirEntry, error) {
+	return buildListDirEntryWithPolicy(SingleDirPolicy(workspaceDir), absPath, mode)
+}
+
+func buildListDirEntryWithPolicy(policy PathPolicy, absPath string, mode fs.FileMode) (listDirEntry, error) {
 	entryType := "file"
 	if mode.IsDir() {
 		entryType = "dir"
@@ -144,7 +156,7 @@ func buildListDirEntry(workspaceDir, absPath string, mode fs.FileMode) (listDirE
 		return listDirEntry{}, err
 	}
 	entry := listDirEntry{
-		Path: workspaceRelativePath(workspaceDir, absPath),
+		Path: policyRelativePath(policy, absPath),
 		Type: entryType,
 	}
 	if !info.IsDir() {

--- a/internal/tool/read_file.go
+++ b/internal/tool/read_file.go
@@ -42,7 +42,15 @@ func NewReadFileTool(workspaceDir string) Tool {
 	return newReadToolWithName("read_file", workspaceDir)
 }
 
+func NewReadFileToolWithPolicy(policy PathPolicy) Tool {
+	return newReadToolWithPolicy("read_file", policy)
+}
+
 func newReadToolWithName(name, workspaceDir string) Tool {
+	return newReadToolWithPolicy(name, SingleDirPolicy(workspaceDir))
+}
+
+func newReadToolWithPolicy(name string, policy PathPolicy) Tool {
 	return Tool{
 		Name:        name,
 		Description: "Read a UTF-8 text file from the workspace using line-oriented pagination.",
@@ -75,7 +83,7 @@ func newReadToolWithName(name, workspaceDir string) Tool {
 				return readFileErrorResult("path is required"), nil
 			}
 
-			absPath, err := resolveWorkspacePath(workspaceDir, input.Path)
+			absPath, err := resolvePathWithPolicy(policy, input.Path)
 			if err != nil {
 				return readFileErrorResult(err.Error()), nil
 			}
@@ -113,7 +121,7 @@ func newReadToolWithName(name, workspaceDir string) Tool {
 			}
 
 			payload := readFileResponse{
-				Path:       workspaceRelativePath(workspaceDir, absPath),
+				Path:       policyRelativePath(policy, absPath),
 				Bytes:      len(raw),
 				TotalLines: totalLines,
 			}

--- a/internal/tool/workspace_path.go
+++ b/internal/tool/workspace_path.go
@@ -120,6 +120,118 @@ func pathWithinWorkspace(rootAbs, pathAbs string) bool {
 	return strings.HasPrefix(pathClean, rootClean+string(filepath.Separator))
 }
 
+// PathPolicy controls which directories file I/O tools can access.
+type PathPolicy struct {
+	PrimaryDir  string   // base for relative path resolution
+	AllowedDirs []string // all directories the tool can access (absolute paths)
+}
+
+// NewPathPolicy builds a PathPolicy. When currentDir is set, it becomes PrimaryDir;
+// otherwise workspaceDir is used. AllowedDirs includes workspaceDir and all workDirs.
+func NewPathPolicy(workspaceDir string, workDirs []string, currentDir string) PathPolicy {
+	primary := workspaceDir
+	if strings.TrimSpace(currentDir) != "" {
+		primary = currentDir
+	}
+	seen := map[string]struct{}{}
+	var allowed []string
+	addDir := func(d string) {
+		d = strings.TrimSpace(d)
+		if d == "" {
+			return
+		}
+		abs, err := filepath.Abs(d)
+		if err != nil {
+			return
+		}
+		if _, ok := seen[abs]; ok {
+			return
+		}
+		seen[abs] = struct{}{}
+		allowed = append(allowed, abs)
+	}
+	addDir(workspaceDir)
+	for _, d := range workDirs {
+		addDir(d)
+	}
+	return PathPolicy{PrimaryDir: primary, AllowedDirs: allowed}
+}
+
+// SingleDirPolicy creates a PathPolicy equivalent to the old single-workspaceDir behavior.
+func SingleDirPolicy(workspaceDir string) PathPolicy {
+	abs, _ := filepath.Abs(workspaceDir)
+	return PathPolicy{PrimaryDir: workspaceDir, AllowedDirs: []string{abs}}
+}
+
+// resolvePathWithPolicy resolves a path against a PathPolicy.
+// Relative paths resolve against PrimaryDir.
+// Absolute paths are allowed if within any AllowedDir.
+func resolvePathWithPolicy(policy PathPolicy, rawPath string) (string, error) {
+	candidate := strings.TrimSpace(rawPath)
+	if candidate == "" {
+		candidate = "."
+	}
+	if !filepath.IsAbs(candidate) {
+		return resolveWorkspacePath(policy.PrimaryDir, candidate)
+	}
+	candidateAbs, err := filepath.Abs(filepath.Clean(candidate))
+	if err != nil {
+		return "", fmt.Errorf("resolve target path: %w", err)
+	}
+	for _, dir := range policy.AllowedDirs {
+		rootAbs, rootCanonical, err := resolveWorkspaceRoot(dir)
+		if err != nil {
+			continue
+		}
+		if pathWithinWorkspace(rootAbs, candidateAbs) || pathWithinWorkspace(rootCanonical, candidateAbs) {
+			resolved, err := filepath.EvalSymlinks(candidateAbs)
+			if err == nil {
+				return resolved, nil
+			}
+			if os.IsNotExist(err) {
+				return candidateAbs, nil
+			}
+			return "", fmt.Errorf("resolve symlink: %w", err)
+		}
+	}
+	return "", fmt.Errorf("path outside allowed directories: %s", rawPath)
+}
+
+// resolveWritePathWithPolicy is the write-safe variant.
+func resolveWritePathWithPolicy(policy PathPolicy, rawPath string) (string, error) {
+	candidate := strings.TrimSpace(rawPath)
+	if candidate == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	if !filepath.IsAbs(candidate) {
+		return resolveWorkspaceWritePath(policy.PrimaryDir, candidate)
+	}
+	candidateAbs, err := filepath.Abs(filepath.Clean(candidate))
+	if err != nil {
+		return "", fmt.Errorf("resolve target path: %w", err)
+	}
+	for _, dir := range policy.AllowedDirs {
+		rootAbs, _, err := resolveWorkspaceRoot(dir)
+		if err != nil {
+			continue
+		}
+		if pathWithinWorkspace(rootAbs, candidateAbs) {
+			return resolveWorkspaceWritePath(dir, candidate)
+		}
+	}
+	return "", fmt.Errorf("path outside allowed directories: %s", rawPath)
+}
+
+// policyRelativePath returns a display-friendly path.
+// If within PrimaryDir, returns relative. Otherwise returns absolute.
+func policyRelativePath(policy PathPolicy, absPath string) string {
+	rel := workspaceRelativePath(policy.PrimaryDir, absPath)
+	if !filepath.IsAbs(rel) && !strings.HasPrefix(rel, "..") {
+		return rel
+	}
+	return absPath
+}
+
 func workspaceRelativePath(workspaceDir, absPath string) string {
 	_, rootCanonical, err := resolveWorkspaceRoot(workspaceDir)
 	if err != nil {

--- a/internal/tool/write_file.go
+++ b/internal/tool/write_file.go
@@ -25,7 +25,15 @@ func NewWriteFileTool(workspaceDir string) Tool {
 	return newWriteToolWithName("write_file", workspaceDir)
 }
 
+func NewWriteFileToolWithPolicy(policy PathPolicy) Tool {
+	return newWriteToolWithPolicy("write_file", policy)
+}
+
 func newWriteToolWithName(name, workspaceDir string) Tool {
+	return newWriteToolWithPolicy(name, SingleDirPolicy(workspaceDir))
+}
+
+func newWriteToolWithPolicy(name string, policy PathPolicy) Tool {
 	return Tool{
 		Name:        name,
 		Description: "Write UTF-8 text content to a workspace file using safe, atomic writes.",
@@ -51,7 +59,7 @@ func newWriteToolWithName(name, workspaceDir string) Tool {
 			if input.Path == "" {
 				return JSONTextResult(writeFileResponse{Message: "path is required"}, true), nil
 			}
-			absPath, err := resolveWorkspaceWritePath(workspaceDir, input.Path)
+			absPath, err := resolveWritePathWithPolicy(policy, input.Path)
 			if err != nil {
 				return JSONTextResult(writeFileResponse{Message: err.Error()}, true), nil
 			}
@@ -83,7 +91,7 @@ func newWriteToolWithName(name, workspaceDir string) Tool {
 				return JSONTextResult(writeFileResponse{Message: fmt.Sprintf("write file failed: %v", err)}, true), nil
 			}
 			return JSONTextResult(writeFileResponse{
-				Path:    workspaceRelativePath(workspaceDir, absPath),
+				Path:    policyRelativePath(policy, absPath),
 				Bytes:   len(input.Content),
 				Created: created,
 			}, false), nil


### PR DESCRIPTION
## Summary
- Add `PathPolicy` type for multi-root file path resolution
- File I/O tools (`list_dir`, `glob`, `read_file`, `write_file`, `edit_file`, `exec`) now resolve paths against session's `CurrentDir` and allow access to all configured `WorkDirs`
- System prompt injects `## Working Directories` section so the agent knows available directories
- Memory/ops tools remain workspace-scoped (unchanged behavior)
- Full backward compatibility: when no work_dirs configured, behaves identically to before

**Before**: Agent tools could only access files within `workspace/` directory, and had no idea about session work_dirs.
**After**: When work_dirs are configured on a session, the agent sees them in the system prompt and can read/write/execute within any of them.

## Test plan
- [x] `make build` passes
- [x] `make test` — all tests pass  
- [x] `make vet` — clean
- [x] `make fmt` — clean
- [ ] Manual test: set work_dirs on a session, ask agent to analyze files in a work_dir