### PR TITLE
fix: directory picker uses absolute paths and New Chat creates session eagerly

### DIFF
--- a/frontend/console/src/components/ArtifactPanel.svelte
+++ b/frontend/console/src/components/ArtifactPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Artifact } from '../lib/artifacts'
   import { fileIcon } from '../lib/artifacts'
-  import { listWorkspaceFiles, readWorkspaceFile, getSessionWorkDirs, updateSessionWorkDirs, type WorkspaceFileEntry, type WorkspaceFileContent } from '../lib/api'
+  import { listWorkspaceFiles, readWorkspaceFile, getSessionWorkDirs, updateSessionWorkDirs, browseFilesystem, type WorkspaceFileEntry, type WorkspaceFileContent } from '../lib/api'
   import type { SessionWorkDirs } from '../lib/types'
 
   interface Props {
@@ -18,7 +18,8 @@
   // WorkDirs state
   let workDirs: SessionWorkDirs = $state({ work_dirs: [], current_dir: '' })
   let pickingDir = $state(false)
-  let pickPath = $state('.')
+  let pickPath = $state('')
+  let pickParent = $state('')
   let pickFiles: WorkspaceFileEntry[] = $state([])
   let pickLoading = $state(false)
 
@@ -64,21 +65,26 @@
   // Directory picker — browse filesystem to select a working directory
   async function startPicking() {
     pickingDir = true
-    pickPath = '.'
-    await browsePick('.')
+    pickPath = ''
+    pickParent = ''
+    await browsePick(undefined)
   }
 
   function cancelPicking() {
     pickingDir = false
   }
 
-  async function browsePick(path: string) {
+  async function browsePick(path: string | undefined) {
     pickLoading = true
     try {
-      // Browse from user home directory
-      const result = await listWorkspaceFiles(path, '~')
-      pickFiles = (result.files || []).filter(f => f.is_dir)
-      pickPath = result.path || path
+      const result = await browseFilesystem(path)
+      pickFiles = result.entries.filter(e => e.is_dir).map(e => ({
+        name: e.name,
+        path: result.path + '/' + e.name,
+        is_dir: true,
+      }))
+      pickPath = result.path
+      pickParent = result.parent
     } catch {
       pickFiles = []
     } finally {
@@ -88,7 +94,7 @@
 
   async function selectPickedDir() {
     if (!sessionId) return
-    const absPath = pickPath === '.' ? '/' : '/' + pickPath
+    const absPath = pickPath
     const dirs = [...workDirs.work_dirs, absPath]
     await updateSessionWorkDirs(sessionId, { work_dirs: dirs, current_dir: absPath })
     workDirs = { work_dirs: dirs, current_dir: absPath }
@@ -281,16 +287,13 @@
             <button type="button" class="btn btn-ghost btn-sm" onclick={cancelPicking}>Cancel</button>
           </div>
         </div>
-        <div class="pick-current">{pickPath === '.' ? '/' : '/' + pickPath}</div>
+        <div class="pick-current">{pickPath || '/'}</div>
         <div class="pick-list">
           {#if pickLoading}
             <div class="artifact-empty">Loading...</div>
           {:else}
-            {#if pickPath !== '.'}
-              <button type="button" class="artifact-item" onclick={() => {
-                const parts = pickPath.split('/').filter(Boolean)
-                browsePick(parts.length <= 1 ? '.' : parts.slice(0, -1).join('/'))
-              }}>
+            {#if pickParent}
+              <button type="button" class="artifact-item" onclick={() => browsePick(pickParent)}>
                 <span class="artifact-icon">&#x2191;</span>
                 <span class="artifact-name">..</span>
               </button>
@@ -301,7 +304,7 @@
                 <span class="artifact-name">{entry.name}</span>
               </button>
             {/each}
-            {#if pickFiles.length === 0 && pickPath !== '.'}
+            {#if pickFiles.length === 0 && pickParent}
               <div class="artifact-empty">No subdirectories</div>
             {/if}
           {/if}

--- a/frontend/console/src/components/Chat.svelte
+++ b/frontend/console/src/components/Chat.svelte
@@ -2,7 +2,7 @@
   import { onMount, onDestroy } from 'svelte'
   import {
     getEventsHistory, getHeartbeatStatus, streamEvents,
-    getSession, renameSession, deleteSession, compactSession, getSessionHistory,
+    getSession, createSession, renameSession, deleteSession, compactSession, getSessionHistory,
   } from '../lib/api'
   import type { HeartbeatStatus, NotificationMessage, Session } from '../lib/types'
   import type { Artifact } from '../lib/artifacts'
@@ -86,15 +86,21 @@
     onNavigate(`/console/chat/${encodeURIComponent(session.id)}`)
   }
 
-  function handleNewSession() {
-    selectedSessionId = null
-    selectedSession = null
+  async function handleNewSession() {
+    try {
+      const sess = await createSession()
+      selectedSessionId = sess.id
+      selectedSession = sess
+    } catch {
+      selectedSessionId = null
+      selectedSession = null
+    }
     chatKey++
     chatArtifacts = []
     rightPanel = 'none'
     renaming = false
     deleteConfirm = false
-    onNavigate('/console/chat')
+    onNavigate(selectedSessionId ? `/console/chat/${encodeURIComponent(selectedSessionId)}` : '/console/chat')
   }
 
   function handleSessionChange() {

--- a/frontend/console/src/lib/api.ts
+++ b/frontend/console/src/lib/api.ts
@@ -129,6 +129,14 @@ export async function listSessions(includeHidden = false): Promise<Session[]> {
   return requestJSON<Session[]>(`/v1/admin/sessions${params}`)
 }
 
+export async function createSession(title?: string): Promise<Session> {
+  return requestJSON<Session>('/v1/admin/sessions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title: title || 'New Chat' }),
+  })
+}
+
 export async function getSession(sessionId: string): Promise<Session> {
   return requestJSON<Session>(`/v1/admin/sessions/${encodeURIComponent(sessionId)}`)
 }

--- a/internal/tarsserver/handler_session.go
+++ b/internal/tarsserver/handler_session.go
@@ -210,7 +210,7 @@ func newSessionAPIHandler(store *session.Store, logger zerolog.Logger) http.Hand
 		if !requireAdmin(w, r) {
 			return
 		}
-		if !requireMethod(w, r, http.MethodGet) {
+		if !requireMethod(w, r, http.MethodGet, http.MethodPost) {
 			return
 		}
 		reqStore, err := resolveStore(r)
@@ -219,19 +219,39 @@ func newSessionAPIHandler(store *session.Store, logger zerolog.Logger) http.Hand
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "resolve workspace failed"})
 			return
 		}
-		includeHidden := strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("hidden")), "1") || strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("hidden")), "true")
-		var sessions []session.Session
-		if includeHidden {
-			sessions, err = reqStore.ListAll()
-		} else {
-			sessions, err = reqStore.List()
+		switch r.Method {
+		case http.MethodGet:
+			includeHidden := strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("hidden")), "1") || strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("hidden")), "true")
+			var sessions []session.Session
+			if includeHidden {
+				sessions, err = reqStore.ListAll()
+			} else {
+				sessions, err = reqStore.List()
+			}
+			if err != nil {
+				logger.Error().Err(err).Msg("list sessions failed")
+				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "list sessions failed"})
+				return
+			}
+			writeJSON(w, http.StatusOK, sessions)
+		case http.MethodPost:
+			var req struct {
+				Title string `json:"title,omitempty"`
+			}
+			if !decodeJSONBody(w, r, &req) {
+				return
+			}
+			title := strings.TrimSpace(req.Title)
+			if title == "" {
+				title = "New Chat"
+			}
+			sess, err := reqStore.Create(title)
+			if err != nil {
+				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+				return
+			}
+			writeJSON(w, http.StatusCreated, sess)
 		}
-		if err != nil {
-			logger.Error().Err(err).Msg("list sessions failed")
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "list sessions failed"})
-			return
-		}
-		writeJSON(w, http.StatusOK, sessions)
 	})
 
 	mux.HandleFunc("/v1/admin/sessions/", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Directory picker now uses `browseFilesystem` API (absolute paths) instead of `listWorkspaceFiles(path, '~')` (relative paths), fixing 404 errors when browsing selected work_dirs
- New Chat eagerly creates a session via `POST /v1/admin/sessions`, so session ID is available for work_dirs configuration before any messages are sent
- Add `POST /v1/admin/sessions` backend endpoint and `createSession()` frontend API

## Test plan
- [x] `make build` + `make test` + `make vet` pass
- [ ] Manual: New Chat → Files → add directory → browse files