### PR TITLE
feat: per-session artifacts dir and auto-refresh panels on tool use

### DIFF
--- a/frontend/console/src/components/ArtifactPanel.svelte
+++ b/frontend/console/src/components/ArtifactPanel.svelte
@@ -210,6 +210,10 @@
     openFile(artifact.path)
   }
 
+  export function refresh() {
+    void browseDir(currentPath)
+  }
+
   $effect(() => {
     if (activeTab === 'workspace') {
       void loadWorkDirs().then(() => browseDir(currentPath))

--- a/frontend/console/src/components/Chat.svelte
+++ b/frontend/console/src/components/Chat.svelte
@@ -193,6 +193,20 @@
   }
 
   let chatPanelRef: ChatPanel | undefined = $state()
+  let tasksPanelRef: { load: () => void } | undefined = $state()
+  let artifactPanelRef: { refresh: () => void } | undefined = $state()
+
+  function handleToolComplete(toolName: string) {
+    const taskTools = ['tasks']
+    const fileTools = ['write_file', 'edit_file', 'exec', 'list_dir', 'read_file']
+
+    if (taskTools.includes(toolName)) {
+      tasksPanelRef?.load()
+    }
+    if (fileTools.includes(toolName) && rightPanel === 'artifacts') {
+      artifactPanelRef?.refresh()
+    }
+  }
 
   function handleCopyChat() {
     const md = chatPanelRef?.exportAsMarkdown()
@@ -324,6 +338,7 @@
           {initialPrompt}
           onSessionChange={handleSessionChange}
           onArtifactsChange={handleArtifactsChange}
+          onToolComplete={handleToolComplete}
         />
       {/key}
     </main>
@@ -332,7 +347,7 @@
     {#if rightPanel !== 'none'}
       <aside class="chat-right-panel">
         {#if rightPanel === 'artifacts'}
-          <ArtifactPanel artifacts={chatArtifacts} sessionId={selectedSessionId || ''} onClose={() => { rightPanel = 'none' }} />
+          <ArtifactPanel bind:this={artifactPanelRef} artifacts={chatArtifacts} sessionId={selectedSessionId || ''} onClose={() => { rightPanel = 'none' }} />
         {:else if rightPanel === 'config' && (selectedSessionId || true)}
           <SessionConfigPanel sessionId={selectedSessionId ?? ''} onClose={() => { rightPanel = 'none' }} />
         {:else if rightPanel === 'context'}
@@ -340,7 +355,7 @@
         {:else if rightPanel === 'prompt'}
           <PromptEditor sessionId={selectedSessionId ?? ''} onClose={() => { rightPanel = 'none' }} />
         {:else if rightPanel === 'tasks' && selectedSessionId}
-          <TasksPanel sessionId={selectedSessionId} onClose={() => rightPanel = 'none'} />
+          <TasksPanel bind:this={tasksPanelRef} sessionId={selectedSessionId} onClose={() => rightPanel = 'none'} />
         {/if}
       </aside>
     {/if}

--- a/frontend/console/src/components/ChatPanel.svelte
+++ b/frontend/console/src/components/ChatPanel.svelte
@@ -23,9 +23,10 @@
     autoSend?: boolean
     onSessionChange?: () => void
     onArtifactsChange?: (artifacts: Artifact[]) => void
+    onToolComplete?: (toolName: string) => void
   }
 
-  let { sessionId, initialPrompt, autoSend, onSessionChange, onArtifactsChange }: Props = $props()
+  let { sessionId, initialPrompt, autoSend, onSessionChange, onArtifactsChange, onToolComplete }: Props = $props()
 
   let artifacts: Artifact[] = $state([])
 
@@ -111,6 +112,8 @@
               }
               onArtifactsChange?.(artifacts)
             }
+
+            onToolComplete?.(event.tool_name || '')
           }
         } else if (event.phase === 'skill_selected' && event.skill_name) {
           const skillMsg: ChatMessage = {

--- a/frontend/console/src/components/TasksPanel.svelte
+++ b/frontend/console/src/components/TasksPanel.svelte
@@ -15,7 +15,7 @@
   let error = $state('')
   let planExpanded = $state(true)
 
-  async function load() {
+  export async function load() {
     loading = true
     error = ''
     try {

--- a/internal/prompt/builder.go
+++ b/internal/prompt/builder.go
@@ -108,7 +108,15 @@ func BuildResultFor(opts BuildOptions) BuildResult {
 				dirSection.WriteString(fmt.Sprintf("- `%s`\n", d))
 			}
 		}
-		dirSection.WriteString("\nFile tool paths resolve relative to the current directory. Use absolute paths to access other directories.\n\n")
+		dirSection.WriteString("\nFile tool paths resolve relative to the current directory. Use absolute paths to access other directories.\n")
+		// Add artifacts usage hint
+		for _, d := range opts.WorkDirs {
+			if strings.Contains(d, "/artifacts/") {
+				dirSection.WriteString(fmt.Sprintf("Use `%s` for file outputs (reports, scripts, generated files).\n", d))
+				break
+			}
+		}
+		dirSection.WriteString("\n")
 		content := dirSection.String()
 		b.WriteString(content)
 		sectionTokens := estimateTokens(content)

--- a/internal/tarsserver/handler_chat_context.go
+++ b/internal/tarsserver/handler_chat_context.go
@@ -2,6 +2,8 @@ package tarsserver
 
 import (
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -74,17 +76,22 @@ func prepareChatRunState(r *http.Request, req chatRequestPayload, deps chatHandl
 	// Fetch session early for WorkDirs
 	sess, sessErr := reqStore.Get(sessionID)
 
+	// Session artifacts directory — always available, isolated per session
+	artifactsDir := filepath.Join(requestWorkspaceDir, "artifacts", sessionID)
+	_ = os.MkdirAll(artifactsDir, 0o755)
+
 	// Build PathPolicy from session work_dirs
 	var policy tool.PathPolicy
 	var sessionWorkDirs []string
 	var sessionCurrentDir string
 	if sessErr == nil && len(sess.WorkDirs) > 0 {
-		policy = tool.NewPathPolicy(requestWorkspaceDir, sess.WorkDirs, sess.CurrentDir)
-		sessionWorkDirs = sess.WorkDirs
+		sessionWorkDirs = append(sess.WorkDirs, artifactsDir)
 		sessionCurrentDir = sess.CurrentDir
 	} else {
-		policy = tool.SingleDirPolicy(requestWorkspaceDir)
+		sessionWorkDirs = []string{artifactsDir}
+		sessionCurrentDir = ""
 	}
+	policy = tool.NewPathPolicy(requestWorkspaceDir, sessionWorkDirs, sessionCurrentDir)
 
 	registry := buildChatToolRegistry(
 		reqStore,


### PR DESCRIPTION
## Summary

### Per-session artifacts directory
- `workspace/artifacts/{session_id}/` auto-created per chat session
- Always included in PathPolicy — agent can always write files there
- Isolated per session — no cross-session file conflicts
- System prompt tells agent to use it for file outputs (reports, scripts, etc.)

### Auto-refresh panels on tool completion
- Tasks panel auto-refreshes when `tasks` tool completes (no manual refresh needed)
- Files panel auto-refreshes when file tools (`write_file`, `edit_file`, `exec`, `list_dir`, `read_file`) complete
- New `onToolComplete` callback from ChatPanel to Chat

## Test plan
- [x] `make build` + `make test` + `make vet` pass
- [ ] Manual: chat with tasks → verify Tasks panel updates live
- [ ] Manual: chat with file writes → verify Files panel updates live
- [ ] Manual: verify artifacts dir created at `workspace/artifacts/{session_id}/`