### PR TITLE
fix: make deprecated --run-once/--run-loop flags truly no-op

### DIFF
--- a/cmd/tars/main_test.go
+++ b/cmd/tars/main_test.go
@@ -63,26 +63,38 @@ func TestRootCommand_ServeSubcommandInvokesRunner(t *testing.T) {
 	}
 }
 
-func TestRootCommand_ServeRunOnceDoesNotForceServeAPI(t *testing.T) {
+func TestRootCommand_ServeDeprecatedFlagsDoNotDisableAPI(t *testing.T) {
 	original := serveRunner
 	defer func() { serveRunner = original }()
 
-	var got serveOptions
-	serveRunner = func(_ context.Context, opts serveOptions, _ io.Writer, _ io.Writer) error {
-		got = opts
-		return nil
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"run-once", []string{"serve", "--run-once"}},
+		{"run-loop", []string{"serve", "--run-loop"}},
 	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got serveOptions
+			serveRunner = func(_ context.Context, opts serveOptions, _ io.Writer, _ io.Writer) error {
+				got = opts
+				return nil
+			}
 
-	cmd := newRootCommand(strings.NewReader(""), io.Discard, io.Discard)
-	cmd.SetArgs([]string{"serve", "--run-once"})
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("serve command: %v", err)
-	}
-	if !got.runOnce {
-		t.Fatalf("expected runOnce=true, got %#v", got)
-	}
-	if got.serveAPI {
-		t.Fatalf("did not expect serveAPI=true when run-once is set, got %#v", got)
+			var stderr strings.Builder
+			cmd := newRootCommand(strings.NewReader(""), io.Discard, &stderr)
+			cmd.SetArgs(tc.args)
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("serve command: %v", err)
+			}
+			if !got.serveAPI {
+				t.Fatalf("deprecated flag must not disable serveAPI, got serveAPI=%v", got.serveAPI)
+			}
+			if !strings.Contains(stderr.String(), "deprecated") {
+				t.Fatalf("expected deprecation warning on stderr, got %q", stderr.String())
+			}
+		})
 	}
 }
 

--- a/cmd/tars/server_main.go
+++ b/cmd/tars/server_main.go
@@ -43,7 +43,10 @@ func newServeCommand(stdout, stderr io.Writer) *cobra.Command {
 			if opts.runOnce && opts.runLoop {
 				return fmt.Errorf("--run-once and --run-loop are mutually exclusive")
 			}
-			return serveRunner(cmd.Context(), normalizeServeOptions(opts), stdout, stderr)
+			if opts.runOnce || opts.runLoop {
+				fmt.Fprintln(stderr, "warning: --run-once and --run-loop are deprecated no-ops; pulse runs automatically when the server is up")
+			}
+			return serveRunner(cmd.Context(), opts, stdout, stderr)
 		},
 	}
 	cmd.Flags().StringVar(&opts.configPath, "config", "", "path to config file")
@@ -56,14 +59,6 @@ func newServeCommand(stdout, stderr io.Writer) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.serveAPI, "serve-api", opts.serveAPI, "serve tars http api")
 	cmd.Flags().StringVar(&opts.apiAddr, "api-addr", opts.apiAddr, "http api listen address")
 	return cmd
-}
-
-func normalizeServeOptions(opts serveOptions) serveOptions {
-	normalized := opts
-	if normalized.runOnce || normalized.runLoop {
-		normalized.serveAPI = false
-	}
-	return normalized
 }
 
 func runServeCommand(ctx context.Context, opts serveOptions, stdout, stderr io.Writer) error {

--- a/internal/tarsserver/main_bootstrap.go
+++ b/internal/tarsserver/main_bootstrap.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/devlikebear/tars/internal/cli"
 	"github.com/devlikebear/tars/internal/config"
 	"github.com/devlikebear/tars/internal/llm"
 	"github.com/devlikebear/tars/internal/memory"
@@ -106,7 +105,7 @@ func buildRuntimeDeps(opts *options, nowFn func() time.Time, logger zerolog.Logg
 	}
 	deps.usageTracker = tracker
 
-	needLLM := opts.RunOnce || opts.RunLoop || opts.ServeAPI
+	needLLM := opts.ServeAPI
 	if !needLLM {
 		return deps, nil
 	}
@@ -158,26 +157,6 @@ func validateAPIAuthSecurity(cfg config.Config, serveAPI bool) error {
 		if !cfg.APIAllowInsecureLocalAuth {
 			return fmt.Errorf("api_auth_mode=%s requires api_allow_insecure_local_auth=true for explicit insecure local auth opt-in", mode)
 		}
-	}
-	return nil
-}
-
-// runHeartbeatModes used to execute heartbeat one-shot and loop modes,
-// but heartbeat has been replaced by the pulse surface. The CLI flags
-// that triggered these modes are now deprecated and the server treats
-// them as a request to run the HTTP server instead.
-func runHeartbeatModes(
-	_ context.Context,
-	opts *options,
-	_ runtimeDeps,
-	_ func() time.Time,
-	logger zerolog.Logger,
-) error {
-	if opts == nil {
-		return &cli.ExitError{Code: 1, Err: fmt.Errorf("options are required")}
-	}
-	if opts.RunOnce || opts.RunLoop {
-		logger.Warn().Msg("--run-once and --run-loop are deprecated; pulse runs automatically when the server is up")
 	}
 	return nil
 }

--- a/internal/tarsserver/main_cli.go
+++ b/internal/tarsserver/main_cli.go
@@ -99,11 +99,11 @@ func newRootCmd(opts *options, stdout, stderr io.Writer, nowFn func() time.Time)
 				}
 				return &cli.ExitError{Code: 1, Err: err}
 			}
+			if opts.RunOnce || opts.RunLoop {
+				logger.Warn().Msg("--run-once and --run-loop are deprecated no-ops; pulse runs automatically when the server is up")
+			}
 			if opts.ServeAPI {
 				return runServeAPICommand(parentCtx, opts, deps, nowFn, stdout, stderr, logger)
-			}
-			if err := runHeartbeatModes(parentCtx, opts, deps, nowFn, logger); err != nil {
-				return err
 			}
 
 			logger.Info().


### PR DESCRIPTION
## Summary
- Remove the hidden `serveAPI=false` side effect from `normalizeServeOptions` that silently disabled the HTTP API when `--run-once` or `--run-loop` was set
- Remove dead `runHeartbeatModes` function and simplify `needLLM` condition
- Add regression tests verifying both deprecated flags no longer change behavior

## Test plan
- [x] `make test` — all tests pass
- [x] `make vet` + `make fmt` — clean
- [x] New test `TestRootCommand_ServeDeprecatedFlagsDoNotDisableAPI` covers both `--run-once` and `--run-loop`

Closes #333