### PR TITLE
fix: validate planner tier field against enum in subagents_plan

### DIFF
--- a/internal/tool/tool_subagents_plan.go
+++ b/internal/tool/tool_subagents_plan.go
@@ -147,7 +147,10 @@ func NewSubagentsPlanTool(runtime *gateway.Runtime, router llm.Router) Tool {
 			if len(plan.Steps) > maxSteps {
 				return JSONTextResult(map[string]any{"message": fmt.Sprintf("planner returned %d steps, exceeds max_steps=%d", len(plan.Steps), maxSteps)}, true), nil
 			}
-			normalization := normalizeSubagentFlowPlan(&plan)
+			normalization, normErr := normalizeSubagentFlowPlan(&plan)
+			if normErr != nil {
+				return JSONTextResult(map[string]any{"message": normErr.Error()}, true), nil
+			}
 			targetInjectionCount := ensurePlannerTargetsInPlan(&plan, requiredTargets)
 			if normalization.Changed {
 				zlog.Debug().
@@ -323,9 +326,9 @@ type plannerNormalizationResult struct {
 var plannerIdentifierSanitizer = regexp.MustCompile(`[^a-z0-9]+`)
 var plannerTargetExtractor = regexp.MustCompile("(?i)(?:`([^`]+)`|(/[^\\s,;:()\\[\\]{}]+)|((?:\\.?\\.?(?:/[^\\s,;:()\\[\\]{}]+)+)))")
 
-func normalizeSubagentFlowPlan(plan *subagentFlowInput) plannerNormalizationResult {
+func normalizeSubagentFlowPlan(plan *subagentFlowInput) (plannerNormalizationResult, error) {
 	if plan == nil || len(plan.Steps) == 0 {
-		return plannerNormalizationResult{}
+		return plannerNormalizationResult{}, nil
 	}
 	var result plannerNormalizationResult
 	stepCounts := map[string]int{}
@@ -343,6 +346,15 @@ func normalizeSubagentFlowPlan(plan *subagentFlowInput) plannerNormalizationResu
 
 		for taskIndex := range step.Tasks {
 			task := &step.Tasks[taskIndex]
+
+			if raw := strings.TrimSpace(task.Tier); raw != "" {
+				tier, err := llm.ParseTier(raw)
+				if err != nil {
+					return plannerNormalizationResult{}, fmt.Errorf("task %q: invalid tier %q (must be heavy, standard, or light)", task.ID, raw)
+				}
+				task.Tier = string(tier)
+			}
+
 			rewrittenDependsOn, depChanges := rewritePlannerDependsOn(task.DependsOn, references)
 			task.DependsOn = rewrittenDependsOn
 			result.ReferenceChanges += depChanges
@@ -368,7 +380,7 @@ func normalizeSubagentFlowPlan(plan *subagentFlowInput) plannerNormalizationResu
 		}
 	}
 
-	return result
+	return result, nil
 }
 
 func rewritePlannerDependsOn(dependsOn []string, references map[string]string) ([]string, int) {

--- a/internal/tool/tool_subagents_plan_test.go
+++ b/internal/tool/tool_subagents_plan_test.go
@@ -391,6 +391,89 @@ func TestSubagentsPlanTool_NormalizesDuplicateTaskIDsAndReferences(t *testing.T)
 	}
 }
 
+func TestNormalizeSubagentFlowPlan_ValidTiers(t *testing.T) {
+	plan := &subagentFlowInput{
+		Steps: []subagentFlowStepInput{
+			{
+				ID:   "step1",
+				Mode: "parallel",
+				Tasks: []subagentFlowTaskInput{
+					{ID: "t1", Prompt: "do something", Tier: "heavy"},
+					{ID: "t2", Prompt: "do another", Tier: "STANDARD"},
+					{ID: "t3", Prompt: "quick thing", Tier: "  Light  "},
+					{ID: "t4", Prompt: "no tier"},
+				},
+			},
+		},
+	}
+
+	_, err := normalizeSubagentFlowPlan(plan)
+	if err != nil {
+		t.Fatalf("expected no error for valid tiers, got %v", err)
+	}
+	if plan.Steps[0].Tasks[0].Tier != "heavy" {
+		t.Errorf("expected tier 'heavy', got %q", plan.Steps[0].Tasks[0].Tier)
+	}
+	if plan.Steps[0].Tasks[1].Tier != "standard" {
+		t.Errorf("expected tier 'standard', got %q", plan.Steps[0].Tasks[1].Tier)
+	}
+	if plan.Steps[0].Tasks[2].Tier != "light" {
+		t.Errorf("expected tier 'light', got %q", plan.Steps[0].Tasks[2].Tier)
+	}
+	if plan.Steps[0].Tasks[3].Tier != "" {
+		t.Errorf("expected empty tier to stay empty, got %q", plan.Steps[0].Tasks[3].Tier)
+	}
+}
+
+func TestNormalizeSubagentFlowPlan_InvalidTier(t *testing.T) {
+	cases := []struct {
+		name string
+		tier string
+	}{
+		{"unknown value", "xxl"},
+		{"typo", "heavi"},
+		{"numeric", "1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := &subagentFlowInput{
+				Steps: []subagentFlowStepInput{
+					{
+						ID:   "step1",
+						Mode: "parallel",
+						Tasks: []subagentFlowTaskInput{
+							{ID: "bad_task", Prompt: "do something", Tier: tc.tier},
+						},
+					},
+				},
+			}
+
+			_, err := normalizeSubagentFlowPlan(plan)
+			if err == nil {
+				t.Fatalf("expected error for invalid tier %q, got nil", tc.tier)
+			}
+			if !strings.Contains(err.Error(), "bad_task") || !strings.Contains(err.Error(), tc.tier) {
+				t.Errorf("error should mention task ID and offending tier, got %q", err.Error())
+			}
+		})
+	}
+}
+
+func TestNormalizeSubagentFlowPlan_NilAndEmpty(t *testing.T) {
+	t.Run("nil plan", func(t *testing.T) {
+		_, err := normalizeSubagentFlowPlan(nil)
+		if err != nil {
+			t.Fatalf("expected no error for nil plan, got %v", err)
+		}
+	})
+	t.Run("empty steps", func(t *testing.T) {
+		_, err := normalizeSubagentFlowPlan(&subagentFlowInput{})
+		if err != nil {
+			t.Fatalf("expected no error for empty steps, got %v", err)
+		}
+	})
+}
+
 func TestSubagentsPlanTool_EnsuresExactTargetsRemainInTaskPrompts(t *testing.T) {
 	rt, _ := newGatewayRuntimeForSubagentToolTests(t, 4, 1, func(_ context.Context, _ string, prompt string, _ []string, _ string) (string, error) {
 		return "summary for " + prompt, nil


### PR DESCRIPTION
## Summary
- Validate each task's `tier` field in `normalizeSubagentFlowPlan` using `llm.ParseTier`
- Reject planner output containing a tier value outside `{"", "heavy", "standard", "light"}` with a clear error including the task ID and offending value
- Normalize case (e.g. `"HEAVY"` → `"heavy"`) for valid tiers

## Test plan
- [x] `make test` — all tests pass
- [x] `make vet` + `make fmt` — clean
- [x] `TestNormalizeSubagentFlowPlan_ValidTiers` — accepts heavy/STANDARD/Light/empty, verifies normalization
- [x] `TestNormalizeSubagentFlowPlan_InvalidTier` — rejects xxl/heavi/1
- [x] `TestNormalizeSubagentFlowPlan_NilAndEmpty` — nil plan and empty steps

Closes #328