### PR TITLE
feat: add explicit_targets_only flag to subagents_plan

### DIFF
--- a/internal/tool/tool_subagents_plan.go
+++ b/internal/tool/tool_subagents_plan.go
@@ -30,7 +30,8 @@ func NewSubagentsPlanTool(runtime *gateway.Runtime, router llm.Router) Tool {
     "max_steps":{"type":"integer","minimum":1,"maximum":8,"default":4},
     "max_parallel_tasks":{"type":"integer","minimum":1,"maximum":8},
     "constraints":{"type":"array","items":{"type":"string"}},
-    "hints":{"type":"array","items":{"type":"string"}}
+    "hints":{"type":"array","items":{"type":"string"}},
+    "explicit_targets_only":{"type":"boolean","description":"When true, only paths in the targets array become required target paths. Paths mentioned in goal/constraints/hints are not auto-extracted."}
   },
   "required":["goal"],
   "additionalProperties":false
@@ -44,15 +45,16 @@ func NewSubagentsPlanTool(runtime *gateway.Runtime, router llm.Router) Tool {
 			}
 
 			var input struct {
-				Goal             string   `json:"goal"`
-				Agent            string   `json:"agent,omitempty"`
-				FlowID           string   `json:"flow_id,omitempty"`
-				Targets          []string `json:"targets,omitempty"`
-				TimeoutMS        int      `json:"timeout_ms,omitempty"`
-				MaxSteps         int      `json:"max_steps,omitempty"`
-				MaxParallelTasks int      `json:"max_parallel_tasks,omitempty"`
-				Constraints      []string `json:"constraints,omitempty"`
-				Hints            []string `json:"hints,omitempty"`
+				Goal                string   `json:"goal"`
+				Agent               string   `json:"agent,omitempty"`
+				FlowID              string   `json:"flow_id,omitempty"`
+				Targets             []string `json:"targets,omitempty"`
+				TimeoutMS           int      `json:"timeout_ms,omitempty"`
+				MaxSteps            int      `json:"max_steps,omitempty"`
+				MaxParallelTasks    int      `json:"max_parallel_tasks,omitempty"`
+				Constraints         []string `json:"constraints,omitempty"`
+				Hints               []string `json:"hints,omitempty"`
+				ExplicitTargetsOnly bool     `json:"explicit_targets_only,omitempty"`
 			}
 			if err := json.Unmarshal(params, &input); err != nil {
 				return JSONTextResult(map[string]any{"message": fmt.Sprintf("invalid arguments: %v", err)}, true), nil
@@ -93,7 +95,7 @@ func NewSubagentsPlanTool(runtime *gateway.Runtime, router llm.Router) Tool {
 			if flowID == "" {
 				flowID = fmt.Sprintf("flow_%d", time.Now().UnixNano())
 			}
-			requiredTargets := collectPlannerTargets(goal, input.Targets, input.Constraints, input.Hints)
+			requiredTargets := collectPlannerTargets(goal, input.Targets, input.Constraints, input.Hints, input.ExplicitTargetsOnly)
 
 			plannerClient, resolution, err := router.ClientFor(llm.RoleGatewayPlanner)
 			if err != nil {
@@ -513,14 +515,8 @@ func nextPlannerUniqueID(base string, counts map[string]int) string {
 	return fmt.Sprintf("%s_%d", sanitizedBase, counts[sanitizedBase])
 }
 
-func collectPlannerTargets(goal string, explicitTargets, constraints, hints []string) []string {
-	candidates := make([]string, 0, len(explicitTargets)+len(constraints)+len(hints)+1)
-	candidates = append(candidates, explicitTargets...)
-	candidates = append(candidates, goal)
-	candidates = append(candidates, constraints...)
-	candidates = append(candidates, hints...)
-
-	out := make([]string, 0, len(candidates))
+func collectPlannerTargets(goal string, explicitTargets, constraints, hints []string, explicitOnly bool) []string {
+	out := make([]string, 0, len(explicitTargets))
 	seen := map[string]struct{}{}
 	add := func(value string) {
 		target := normalizePlannerTarget(value)
@@ -534,7 +530,17 @@ func collectPlannerTargets(goal string, explicitTargets, constraints, hints []st
 		out = append(out, target)
 	}
 
-	for _, candidate := range candidates {
+	// Explicit targets are always included.
+	for _, t := range explicitTargets {
+		add(t)
+	}
+
+	if explicitOnly {
+		return out
+	}
+
+	// Auto-extract paths from goal, constraints, and hints.
+	for _, candidate := range append(append([]string{goal}, constraints...), hints...) {
 		add(candidate)
 		for _, match := range plannerTargetExtractor.FindAllStringSubmatch(candidate, -1) {
 			for _, part := range match[1:] {

--- a/internal/tool/tool_subagents_plan_test.go
+++ b/internal/tool/tool_subagents_plan_test.go
@@ -613,29 +613,63 @@ func TestNormalizePlannerTarget(t *testing.T) {
 }
 
 func TestCollectPlannerTargets(t *testing.T) {
-	targets := collectPlannerTargets(
-		"review /etc/nginx/nginx.conf and `./scripts/deploy.sh`",
-		[]string{"/explicit/target.go"},
-		[]string{"constraint mentioning /some/path.yaml"},
-		nil,
-	)
+	t.Run("auto-extraction enabled", func(t *testing.T) {
+		targets := collectPlannerTargets(
+			"review /etc/nginx/nginx.conf and `./scripts/deploy.sh`",
+			[]string{"/explicit/target.go"},
+			[]string{"constraint mentioning /some/path.yaml"},
+			nil,
+			false,
+		)
 
-	expected := map[string]bool{
-		"/explicit/target.go":   false,
-		"/etc/nginx/nginx.conf": false,
-		"scripts/deploy.sh":     false,
-		"/some/path.yaml":       false,
-	}
-	for _, t2 := range targets {
-		if _, ok := expected[t2]; ok {
-			expected[t2] = true
+		expected := map[string]bool{
+			"/explicit/target.go":   false,
+			"/etc/nginx/nginx.conf": false,
+			"scripts/deploy.sh":     false,
+			"/some/path.yaml":       false,
 		}
-	}
-	for path, found := range expected {
-		if !found {
-			t.Errorf("expected target %q not found in collected targets: %v", path, targets)
+		for _, t2 := range targets {
+			if _, ok := expected[t2]; ok {
+				expected[t2] = true
+			}
 		}
-	}
+		for path, found := range expected {
+			if !found {
+				t.Errorf("expected target %q not found in collected targets: %v", path, targets)
+			}
+		}
+	})
+
+	t.Run("explicit_targets_only suppresses auto-extraction", func(t *testing.T) {
+		targets := collectPlannerTargets(
+			"debug the auth flow, see /etc/passwd for context",
+			[]string{"/explicit/target.go"},
+			[]string{"failure in /opt/tars/workspace"},
+			[]string{"check /var/log/syslog"},
+			true,
+		)
+
+		if len(targets) != 1 {
+			t.Fatalf("expected 1 target with explicit_targets_only, got %d: %v", len(targets), targets)
+		}
+		if targets[0] != "/explicit/target.go" {
+			t.Fatalf("expected only explicit target, got %q", targets[0])
+		}
+	})
+
+	t.Run("explicit_targets_only with no explicit targets", func(t *testing.T) {
+		targets := collectPlannerTargets(
+			"debug /etc/passwd",
+			nil,
+			nil,
+			nil,
+			true,
+		)
+
+		if len(targets) != 0 {
+			t.Fatalf("expected 0 targets with explicit_targets_only and no explicit targets, got %v", targets)
+		}
+	})
 }
 
 func TestSubagentsPlanTool_EnsuresExactTargetsRemainInTaskPrompts(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `explicit_targets_only` boolean to `subagents_plan` schema
- When true, `collectPlannerTargets` only returns paths from the `targets` array, skipping auto-extraction from goal/constraints/hints
- Default false preserves existing behavior

## Test plan
- [x] `TestCollectPlannerTargets/auto-extraction_enabled` — existing behavior preserved
- [x] `TestCollectPlannerTargets/explicit_targets_only_suppresses_auto-extraction` — only explicit targets returned
- [x] `TestCollectPlannerTargets/explicit_targets_only_with_no_explicit_targets` — empty result
- [x] All existing `TestSubagentsPlanTool_*` tests pass
- [x] `go vet` + `go fmt` clean

Closes #325