### PR TITLE
refactor: consolidate duplicated hub package-management commands

### DIFF
--- a/cmd/tars/hub_commands.go
+++ b/cmd/tars/hub_commands.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+// hubResourceSpec describes a hub-managed resource type (skill, plugin, or MCP
+// server) and the callbacks needed to wire the standard search/install/
+// uninstall/list/update/info subcommand tree.
+type hubResourceSpec struct {
+	// Use and Short for the parent cobra command.
+	Use   string
+	Short string
+	// Singular noun for messages (e.g. "skill", "plugin", "MCP server").
+	Noun string
+
+	// Operation callbacks. Each receives the standard context/writer/args.
+	Search    func(ctx context.Context, stdout io.Writer, query string) error
+	Install   func(ctx context.Context, stdout, stderr io.Writer, workspaceDir, name string) error
+	Uninstall func(stdout, stderr io.Writer, workspaceDir, name string) error
+	List      func(stdout io.Writer, workspaceDir string) error
+	Update    func(ctx context.Context, stdout, stderr io.Writer, workspaceDir string) error
+	Info      func(ctx context.Context, stdout io.Writer, name string) error
+}
+
+// newHubResourceCommand builds the full search/install/uninstall/list/update/
+// info subcommand tree from a hubResourceSpec.
+func newHubResourceCommand(spec hubResourceSpec, stdout, stderr io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   spec.Use,
+		Short: spec.Short,
+	}
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "search [query]",
+		Short: fmt.Sprintf("Search the %s registry", spec.Noun),
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			query := ""
+			if len(args) > 0 {
+				query = args[0]
+			}
+			return spec.Search(cmd.Context(), stdout, query)
+		},
+	})
+
+	installCmd := &cobra.Command{
+		Use:   "install <name>",
+		Short: fmt.Sprintf("Install a %s from the hub", spec.Noun),
+		Args:  cobra.ExactArgs(1),
+	}
+	var installWorkspaceDir string
+	installCmd.Flags().StringVar(&installWorkspaceDir, "workspace-dir", defaultWorkspaceDir(), "workspace directory")
+	installCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		dir, err := resolveWorkspaceDir(installWorkspaceDir)
+		if err != nil {
+			return err
+		}
+		return spec.Install(cmd.Context(), stdout, stderr, dir, args[0])
+	}
+	cmd.AddCommand(installCmd)
+
+	uninstallCmd := &cobra.Command{
+		Use:   "uninstall <name>",
+		Short: fmt.Sprintf("Uninstall a %s", spec.Noun),
+		Args:  cobra.ExactArgs(1),
+	}
+	var uninstallWorkspaceDir string
+	uninstallCmd.Flags().StringVar(&uninstallWorkspaceDir, "workspace-dir", defaultWorkspaceDir(), "workspace directory")
+	uninstallCmd.RunE = func(_ *cobra.Command, args []string) error {
+		dir, err := resolveWorkspaceDir(uninstallWorkspaceDir)
+		if err != nil {
+			return err
+		}
+		return spec.Uninstall(stdout, stderr, dir, args[0])
+	}
+	cmd.AddCommand(uninstallCmd)
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: fmt.Sprintf("List installed hub %ss", spec.Noun),
+	}
+	var listWorkspaceDir string
+	listCmd.Flags().StringVar(&listWorkspaceDir, "workspace-dir", defaultWorkspaceDir(), "workspace directory")
+	listCmd.RunE = func(_ *cobra.Command, _ []string) error {
+		dir, err := resolveWorkspaceDir(listWorkspaceDir)
+		if err != nil {
+			return err
+		}
+		return spec.List(stdout, dir)
+	}
+	cmd.AddCommand(listCmd)
+
+	updateCmd := &cobra.Command{
+		Use:   "update",
+		Short: fmt.Sprintf("Update all installed hub %ss to latest", spec.Noun),
+	}
+	var updateWorkspaceDir string
+	updateCmd.Flags().StringVar(&updateWorkspaceDir, "workspace-dir", defaultWorkspaceDir(), "workspace directory")
+	updateCmd.RunE = func(cmd *cobra.Command, _ []string) error {
+		dir, err := resolveWorkspaceDir(updateWorkspaceDir)
+		if err != nil {
+			return err
+		}
+		return spec.Update(cmd.Context(), stdout, stderr, dir)
+	}
+	cmd.AddCommand(updateCmd)
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "info <name>",
+		Short: fmt.Sprintf("Show detailed info about a %s in the registry", spec.Noun),
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return spec.Info(cmd.Context(), stdout, args[0])
+		},
+	})
+
+	return cmd
+}

--- a/cmd/tars/mcp_main.go
+++ b/cmd/tars/mcp_main.go
@@ -11,208 +11,106 @@ import (
 )
 
 func newMCPCommand(stdout, stderr io.Writer) *cobra.Command {
-	cmd := &cobra.Command{
+	return newHubResourceCommand(hubResourceSpec{
 		Use:   "mcp",
-		Short: "Manage MCP servers from the trusted TARS Hub",
-	}
-	cmd.AddCommand(newMCPSearchCommand(stdout))
-	cmd.AddCommand(newMCPInstallCommand(stdout, stderr))
-	cmd.AddCommand(newMCPUninstallCommand(stdout, stderr))
-	cmd.AddCommand(newMCPListCommand(stdout))
-	cmd.AddCommand(newMCPUpdateCommand(stdout, stderr))
-	cmd.AddCommand(newMCPInfoCommand(stdout))
-	return cmd
-}
+		Short: "Manage MCP servers from the TARS Hub",
+		Noun:  "MCP server",
 
-func newMCPSearchCommand(stdout io.Writer) *cobra.Command {
-	return &cobra.Command{
-		Use:   "search [query]",
-		Short: "Search the MCP registry",
-		Args:  cobra.MaximumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			query := ""
-			if len(args) > 0 {
-				query = args[0]
+		Search: func(ctx context.Context, stdout io.Writer, query string) error {
+			reg := skillhub.NewRegistry()
+			results, err := reg.SearchMCPServers(ctx, query)
+			if err != nil {
+				return fmt.Errorf("search failed: %w", err)
 			}
-			return runMCPSearch(cmd.Context(), stdout, query)
+			if len(results) == 0 {
+				fmt.Fprintln(stdout, "No MCP servers found.")
+				return nil
+			}
+			for _, entry := range results {
+				tags := ""
+				if len(entry.Tags) > 0 {
+					tags = " (" + strings.Join(entry.Tags, ", ") + ")"
+				}
+				fmt.Fprintf(stdout, "  %s@%s%s\n    %s\n", entry.Name, entry.Version, tags, entry.Description)
+			}
+			fmt.Fprintf(stdout, "\n%d MCP server(s) found.\n", len(results))
+			return nil
 		},
-	}
-}
 
-func runMCPSearch(ctx context.Context, stdout io.Writer, query string) error {
-	reg := skillhub.NewRegistry()
-	results, err := reg.SearchMCPServers(ctx, query)
-	if err != nil {
-		return fmt.Errorf("search failed: %w", err)
-	}
-	if len(results) == 0 {
-		fmt.Fprintln(stdout, "No MCP servers found.")
-		return nil
-	}
-	for _, entry := range results {
-		tags := ""
-		if len(entry.Tags) > 0 {
-			tags = " (" + strings.Join(entry.Tags, ", ") + ")"
-		}
-		fmt.Fprintf(stdout, "  %s@%s%s\n    %s\n", entry.Name, entry.Version, tags, entry.Description)
-	}
-	fmt.Fprintf(stdout, "\n%d MCP server(s) found.\n", len(results))
-	return nil
-}
+		Install: func(ctx context.Context, stdout, _ io.Writer, workspaceDir, name string) error {
+			inst := skillhub.NewInstaller(workspaceDir)
+			if err := inst.InstallMCP(ctx, name); err != nil {
+				return fmt.Errorf("install mcp server %q: %w", name, err)
+			}
+			fmt.Fprintf(stdout, "Installed MCP server %q to %s/mcp-servers/%s\n", name, workspaceDir, name)
+			return nil
+		},
 
-func newMCPInstallCommand(stdout, stderr io.Writer) *cobra.Command {
-	var workspaceDir string
-	cmd := &cobra.Command{
-		Use:   "install <name>",
-		Short: "Install an MCP server from the hub",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			dir, err := resolveWorkspaceDir(workspaceDir)
+		Uninstall: func(stdout, _ io.Writer, workspaceDir, name string) error {
+			inst := skillhub.NewInstaller(workspaceDir)
+			if err := inst.UninstallMCP(name); err != nil {
+				return fmt.Errorf("uninstall mcp server %q: %w", name, err)
+			}
+			fmt.Fprintf(stdout, "Uninstalled MCP server %q\n", name)
+			return nil
+		},
+
+		List: func(stdout io.Writer, workspaceDir string) error {
+			inst := skillhub.NewInstaller(workspaceDir)
+			mcps, err := inst.ListMCPs()
 			if err != nil {
 				return err
 			}
-			return runMCPInstall(cmd.Context(), stdout, stderr, dir, args[0])
+			if len(mcps) == 0 {
+				fmt.Fprintln(stdout, "No hub MCP servers installed.")
+				return nil
+			}
+			for _, m := range mcps {
+				fmt.Fprintf(stdout, "  %s@%s  (%s)  %s\n", m.Name, m.Version, m.Source, m.Dir)
+			}
+			fmt.Fprintf(stdout, "\n%d MCP server(s) installed.\n", len(mcps))
+			return nil
 		},
-	}
-	cmd.Flags().StringVar(&workspaceDir, "workspace-dir", defaultWorkspaceDir(), "workspace directory")
-	return cmd
-}
 
-func runMCPInstall(ctx context.Context, stdout, _ io.Writer, workspaceDir, name string) error {
-	inst := skillhub.NewInstaller(workspaceDir)
-	if err := inst.InstallMCP(ctx, name); err != nil {
-		return fmt.Errorf("install mcp server %q: %w", name, err)
-	}
-	fmt.Fprintf(stdout, "Installed MCP server %q to %s/mcp-servers/%s\n", name, workspaceDir, name)
-	return nil
-}
-
-func newMCPUninstallCommand(stdout, stderr io.Writer) *cobra.Command {
-	var workspaceDir string
-	cmd := &cobra.Command{
-		Use:   "uninstall <name>",
-		Short: "Uninstall a managed MCP server",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			dir, err := resolveWorkspaceDir(workspaceDir)
+		Update: func(ctx context.Context, stdout, _ io.Writer, workspaceDir string) error {
+			inst := skillhub.NewInstaller(workspaceDir)
+			updated, err := inst.UpdateMCPs(ctx)
 			if err != nil {
 				return err
 			}
-			return runMCPUninstall(stdout, stderr, dir, args[0])
+			if len(updated) == 0 {
+				fmt.Fprintln(stdout, "All MCP servers are up to date.")
+				return nil
+			}
+			for _, name := range updated {
+				fmt.Fprintf(stdout, "  Updated: %s\n", name)
+			}
+			fmt.Fprintf(stdout, "\n%d MCP server(s) updated.\n", len(updated))
+			return nil
 		},
-	}
-	cmd.Flags().StringVar(&workspaceDir, "workspace-dir", defaultWorkspaceDir(), "workspace directory")
-	return cmd
-}
 
-func runMCPUninstall(stdout, _ io.Writer, workspaceDir, name string) error {
-	inst := skillhub.NewInstaller(workspaceDir)
-	if err := inst.UninstallMCP(name); err != nil {
-		return fmt.Errorf("uninstall mcp server %q: %w", name, err)
-	}
-	fmt.Fprintf(stdout, "Uninstalled MCP server %q\n", name)
-	return nil
-}
-
-func newMCPListCommand(stdout io.Writer) *cobra.Command {
-	var workspaceDir string
-	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List installed hub MCP servers",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			dir, err := resolveWorkspaceDir(workspaceDir)
+		Info: func(ctx context.Context, stdout io.Writer, name string) error {
+			reg := skillhub.NewRegistry()
+			entry, err := reg.FindMCPByName(ctx, name)
 			if err != nil {
 				return err
 			}
-			return runMCPList(stdout, dir)
-		},
-	}
-	cmd.Flags().StringVar(&workspaceDir, "workspace-dir", defaultWorkspaceDir(), "workspace directory")
-	return cmd
-}
-
-func runMCPList(stdout io.Writer, workspaceDir string) error {
-	inst := skillhub.NewInstaller(workspaceDir)
-	mcps, err := inst.ListMCPs()
-	if err != nil {
-		return err
-	}
-	if len(mcps) == 0 {
-		fmt.Fprintln(stdout, "No hub MCP servers installed.")
-		return nil
-	}
-	for _, mcp := range mcps {
-		fmt.Fprintf(stdout, "  %s@%s  (%s)  %s\n", mcp.Name, mcp.Version, mcp.Source, mcp.Dir)
-	}
-	fmt.Fprintf(stdout, "\n%d MCP server(s) installed.\n", len(mcps))
-	return nil
-}
-
-func newMCPUpdateCommand(stdout, stderr io.Writer) *cobra.Command {
-	var workspaceDir string
-	cmd := &cobra.Command{
-		Use:   "update",
-		Short: "Update all installed hub MCP servers to latest",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			dir, err := resolveWorkspaceDir(workspaceDir)
-			if err != nil {
-				return err
+			fmt.Fprintf(stdout, "Name:        %s\n", entry.Name)
+			fmt.Fprintf(stdout, "Version:     %s\n", entry.Version)
+			fmt.Fprintf(stdout, "Author:      %s\n", entry.Author)
+			fmt.Fprintf(stdout, "Description: %s\n", entry.Description)
+			fmt.Fprintf(stdout, "Manifest:    %s\n", entry.Manifest)
+			if len(entry.Tags) > 0 {
+				fmt.Fprintf(stdout, "Tags:        %s\n", strings.Join(entry.Tags, ", "))
 			}
-			return runMCPUpdate(cmd.Context(), stdout, stderr, dir)
+			if len(entry.Files) > 0 {
+				fileNames := make([]string, 0, len(entry.Files))
+				for _, file := range entry.Files {
+					fileNames = append(fileNames, file.Path)
+				}
+				fmt.Fprintf(stdout, "Files:       %s\n", strings.Join(fileNames, ", "))
+			}
+			return nil
 		},
-	}
-	cmd.Flags().StringVar(&workspaceDir, "workspace-dir", defaultWorkspaceDir(), "workspace directory")
-	return cmd
-}
-
-func runMCPUpdate(ctx context.Context, stdout, _ io.Writer, workspaceDir string) error {
-	inst := skillhub.NewInstaller(workspaceDir)
-	updated, err := inst.UpdateMCPs(ctx)
-	if err != nil {
-		return err
-	}
-	if len(updated) == 0 {
-		fmt.Fprintln(stdout, "All MCP servers are up to date.")
-		return nil
-	}
-	for _, name := range updated {
-		fmt.Fprintf(stdout, "  Updated: %s\n", name)
-	}
-	fmt.Fprintf(stdout, "\n%d MCP server(s) updated.\n", len(updated))
-	return nil
-}
-
-func newMCPInfoCommand(stdout io.Writer) *cobra.Command {
-	return &cobra.Command{
-		Use:   "info <name>",
-		Short: "Show detailed info about an MCP server in the registry",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runMCPInfo(cmd.Context(), stdout, args[0])
-		},
-	}
-}
-
-func runMCPInfo(ctx context.Context, stdout io.Writer, name string) error {
-	reg := skillhub.NewRegistry()
-	entry, err := reg.FindMCPByName(ctx, name)
-	if err != nil {
-		return err
-	}
-	fmt.Fprintf(stdout, "Name:        %s\n", entry.Name)
-	fmt.Fprintf(stdout, "Version:     %s\n", entry.Version)
-	fmt.Fprintf(stdout, "Author:      %s\n", entry.Author)
-	fmt.Fprintf(stdout, "Description: %s\n", entry.Description)
-	fmt.Fprintf(stdout, "Manifest:    %s\n", entry.Manifest)
-	if len(entry.Tags) > 0 {
-		fmt.Fprintf(stdout, "Tags:        %s\n", strings.Join(entry.Tags, ", "))
-	}
-	if len(entry.Files) > 0 {
-		fileNames := make([]string, 0, len(entry.Files))
-		for _, file := range entry.Files {
-			fileNames = append(fileNames, file.Path)
-		}
-		fmt.Fprintf(stdout, "Files:       %s\n", strings.Join(fileNames, ", "))
-	}
-	return nil
+	}, stdout, stderr)
 }

--- a/cmd/tars/plugin_main.go
+++ b/cmd/tars/plugin_main.go
@@ -11,203 +11,101 @@ import (
 )
 
 func newPluginCommand(stdout, stderr io.Writer) *cobra.Command {
-	cmd := &cobra.Command{
+	return newHubResourceCommand(hubResourceSpec{
 		Use:   "plugin",
 		Short: "Manage plugins from the TARS Hub",
-	}
-	cmd.AddCommand(newPluginSearchCommand(stdout))
-	cmd.AddCommand(newPluginInstallCommand(stdout, stderr))
-	cmd.AddCommand(newPluginUninstallCommand(stdout, stderr))
-	cmd.AddCommand(newPluginListCommand(stdout))
-	cmd.AddCommand(newPluginUpdateCommand(stdout, stderr))
-	cmd.AddCommand(newPluginInfoCommand(stdout))
-	return cmd
-}
+		Noun:  "plugin",
 
-func newPluginSearchCommand(stdout io.Writer) *cobra.Command {
-	return &cobra.Command{
-		Use:   "search [query]",
-		Short: "Search the plugin registry",
-		Args:  cobra.MaximumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			query := ""
-			if len(args) > 0 {
-				query = args[0]
+		Search: func(ctx context.Context, stdout io.Writer, query string) error {
+			reg := skillhub.NewRegistry()
+			results, err := reg.SearchPlugins(ctx, query)
+			if err != nil {
+				return fmt.Errorf("search failed: %w", err)
 			}
-			return runPluginSearch(cmd.Context(), stdout, query)
+			if len(results) == 0 {
+				fmt.Fprintln(stdout, "No plugins found.")
+				return nil
+			}
+			for _, entry := range results {
+				tags := ""
+				if len(entry.Tags) > 0 {
+					tags = " (" + strings.Join(entry.Tags, ", ") + ")"
+				}
+				fmt.Fprintf(stdout, "  %s@%s%s\n    %s\n", entry.Name, entry.Version, tags, entry.Description)
+			}
+			fmt.Fprintf(stdout, "\n%d plugin(s) found.\n", len(results))
+			return nil
 		},
-	}
-}
 
-func runPluginSearch(ctx context.Context, stdout io.Writer, query string) error {
-	reg := skillhub.NewRegistry()
-	results, err := reg.SearchPlugins(ctx, query)
-	if err != nil {
-		return fmt.Errorf("search failed: %w", err)
-	}
-	if len(results) == 0 {
-		fmt.Fprintln(stdout, "No plugins found.")
-		return nil
-	}
-	for _, entry := range results {
-		tags := ""
-		if len(entry.Tags) > 0 {
-			tags = " (" + strings.Join(entry.Tags, ", ") + ")"
-		}
-		fmt.Fprintf(stdout, "  %s@%s%s\n    %s\n", entry.Name, entry.Version, tags, entry.Description)
-	}
-	fmt.Fprintf(stdout, "\n%d plugin(s) found.\n", len(results))
-	return nil
-}
+		Install: func(ctx context.Context, stdout, _ io.Writer, workspaceDir, name string) error {
+			inst := skillhub.NewInstaller(workspaceDir)
+			if err := inst.InstallPlugin(ctx, name); err != nil {
+				return fmt.Errorf("install plugin %q: %w", name, err)
+			}
+			fmt.Fprintf(stdout, "Installed plugin %q to %s/plugins/%s\n", name, workspaceDir, name)
+			return nil
+		},
 
-func newPluginInstallCommand(stdout, stderr io.Writer) *cobra.Command {
-	var workspaceDir string
-	cmd := &cobra.Command{
-		Use:   "install <name>",
-		Short: "Install a plugin from the hub",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			dir, err := resolveWorkspaceDir(workspaceDir)
+		Uninstall: func(stdout, _ io.Writer, workspaceDir, name string) error {
+			inst := skillhub.NewInstaller(workspaceDir)
+			if err := inst.UninstallPlugin(name); err != nil {
+				return fmt.Errorf("uninstall plugin %q: %w", name, err)
+			}
+			fmt.Fprintf(stdout, "Uninstalled plugin %q\n", name)
+			return nil
+		},
+
+		List: func(stdout io.Writer, workspaceDir string) error {
+			inst := skillhub.NewInstaller(workspaceDir)
+			plugins, err := inst.ListPlugins()
 			if err != nil {
 				return err
 			}
-			return runPluginInstall(cmd.Context(), stdout, stderr, dir, args[0])
+			if len(plugins) == 0 {
+				fmt.Fprintln(stdout, "No hub plugins installed.")
+				return nil
+			}
+			for _, p := range plugins {
+				fmt.Fprintf(stdout, "  %s@%s  (%s)  %s\n", p.Name, p.Version, p.Source, p.Dir)
+			}
+			fmt.Fprintf(stdout, "\n%d plugin(s) installed.\n", len(plugins))
+			return nil
 		},
-	}
-	cmd.Flags().StringVar(&workspaceDir, "workspace-dir", defaultWorkspaceDir(), "workspace directory")
-	return cmd
-}
 
-func runPluginInstall(ctx context.Context, stdout, _ io.Writer, workspaceDir, name string) error {
-	inst := skillhub.NewInstaller(workspaceDir)
-	if err := inst.InstallPlugin(ctx, name); err != nil {
-		return fmt.Errorf("install plugin %q: %w", name, err)
-	}
-	fmt.Fprintf(stdout, "Installed plugin %q to %s/plugins/%s\n", name, workspaceDir, name)
-	return nil
-}
-
-func newPluginUninstallCommand(stdout, stderr io.Writer) *cobra.Command {
-	var workspaceDir string
-	cmd := &cobra.Command{
-		Use:   "uninstall <name>",
-		Short: "Uninstall a plugin",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			dir, err := resolveWorkspaceDir(workspaceDir)
+		Update: func(ctx context.Context, stdout, _ io.Writer, workspaceDir string) error {
+			inst := skillhub.NewInstaller(workspaceDir)
+			updated, err := inst.UpdatePlugins(ctx)
 			if err != nil {
 				return err
 			}
-			return runPluginUninstall(stdout, stderr, dir, args[0])
+			if len(updated) == 0 {
+				fmt.Fprintln(stdout, "All plugins are up to date.")
+				return nil
+			}
+			for _, name := range updated {
+				fmt.Fprintf(stdout, "  Updated: %s\n", name)
+			}
+			fmt.Fprintf(stdout, "\n%d plugin(s) updated.\n", len(updated))
+			return nil
 		},
-	}
-	cmd.Flags().StringVar(&workspaceDir, "workspace-dir", defaultWorkspaceDir(), "workspace directory")
-	return cmd
-}
 
-func runPluginUninstall(stdout, _ io.Writer, workspaceDir, name string) error {
-	inst := skillhub.NewInstaller(workspaceDir)
-	if err := inst.UninstallPlugin(name); err != nil {
-		return fmt.Errorf("uninstall plugin %q: %w", name, err)
-	}
-	fmt.Fprintf(stdout, "Uninstalled plugin %q\n", name)
-	return nil
-}
-
-func newPluginListCommand(stdout io.Writer) *cobra.Command {
-	var workspaceDir string
-	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List installed hub plugins",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			dir, err := resolveWorkspaceDir(workspaceDir)
+		Info: func(ctx context.Context, stdout io.Writer, name string) error {
+			reg := skillhub.NewRegistry()
+			entry, err := reg.FindPluginByName(ctx, name)
 			if err != nil {
 				return err
 			}
-			return runPluginList(stdout, dir)
-		},
-	}
-	cmd.Flags().StringVar(&workspaceDir, "workspace-dir", defaultWorkspaceDir(), "workspace directory")
-	return cmd
-}
-
-func runPluginList(stdout io.Writer, workspaceDir string) error {
-	inst := skillhub.NewInstaller(workspaceDir)
-	plugins, err := inst.ListPlugins()
-	if err != nil {
-		return err
-	}
-	if len(plugins) == 0 {
-		fmt.Fprintln(stdout, "No hub plugins installed.")
-		return nil
-	}
-	for _, p := range plugins {
-		fmt.Fprintf(stdout, "  %s@%s  (%s)  %s\n", p.Name, p.Version, p.Source, p.Dir)
-	}
-	fmt.Fprintf(stdout, "\n%d plugin(s) installed.\n", len(plugins))
-	return nil
-}
-
-func newPluginUpdateCommand(stdout, stderr io.Writer) *cobra.Command {
-	var workspaceDir string
-	cmd := &cobra.Command{
-		Use:   "update",
-		Short: "Update all installed hub plugins to latest",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			dir, err := resolveWorkspaceDir(workspaceDir)
-			if err != nil {
-				return err
+			fmt.Fprintf(stdout, "Name:        %s\n", entry.Name)
+			fmt.Fprintf(stdout, "Version:     %s\n", entry.Version)
+			fmt.Fprintf(stdout, "Author:      %s\n", entry.Author)
+			fmt.Fprintf(stdout, "Description: %s\n", entry.Description)
+			if len(entry.Tags) > 0 {
+				fmt.Fprintf(stdout, "Tags:        %s\n", strings.Join(entry.Tags, ", "))
 			}
-			return runPluginUpdate(cmd.Context(), stdout, stderr, dir)
+			if len(entry.Files) > 0 {
+				fmt.Fprintf(stdout, "Files:       %s\n", strings.Join(entry.Files.Paths(), ", "))
+			}
+			return nil
 		},
-	}
-	cmd.Flags().StringVar(&workspaceDir, "workspace-dir", defaultWorkspaceDir(), "workspace directory")
-	return cmd
-}
-
-func runPluginUpdate(ctx context.Context, stdout, _ io.Writer, workspaceDir string) error {
-	inst := skillhub.NewInstaller(workspaceDir)
-	updated, err := inst.UpdatePlugins(ctx)
-	if err != nil {
-		return err
-	}
-	if len(updated) == 0 {
-		fmt.Fprintln(stdout, "All plugins are up to date.")
-		return nil
-	}
-	for _, name := range updated {
-		fmt.Fprintf(stdout, "  Updated: %s\n", name)
-	}
-	fmt.Fprintf(stdout, "\n%d plugin(s) updated.\n", len(updated))
-	return nil
-}
-
-func newPluginInfoCommand(stdout io.Writer) *cobra.Command {
-	return &cobra.Command{
-		Use:   "info <name>",
-		Short: "Show detailed info about a plugin in the registry",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runPluginInfo(cmd.Context(), stdout, args[0])
-		},
-	}
-}
-
-func runPluginInfo(ctx context.Context, stdout io.Writer, name string) error {
-	reg := skillhub.NewRegistry()
-	entry, err := reg.FindPluginByName(ctx, name)
-	if err != nil {
-		return err
-	}
-	fmt.Fprintf(stdout, "Name:        %s\n", entry.Name)
-	fmt.Fprintf(stdout, "Version:     %s\n", entry.Version)
-	fmt.Fprintf(stdout, "Author:      %s\n", entry.Author)
-	fmt.Fprintf(stdout, "Description: %s\n", entry.Description)
-	if len(entry.Tags) > 0 {
-		fmt.Fprintf(stdout, "Tags:        %s\n", strings.Join(entry.Tags, ", "))
-	}
-	if len(entry.Files) > 0 {
-		fmt.Fprintf(stdout, "Files:       %s\n", strings.Join(entry.Files.Paths(), ", "))
-	}
-	return nil
+	}, stdout, stderr)
 }

--- a/cmd/tars/skill_main.go
+++ b/cmd/tars/skill_main.go
@@ -11,212 +11,110 @@ import (
 )
 
 func newSkillCommand(stdout, stderr io.Writer) *cobra.Command {
-	cmd := &cobra.Command{
+	return newHubResourceCommand(hubResourceSpec{
 		Use:   "skill",
-		Short: "Manage skills from the TARS Skill Hub",
-	}
-	cmd.AddCommand(newSkillSearchCommand(stdout))
-	cmd.AddCommand(newSkillInstallCommand(stdout, stderr))
-	cmd.AddCommand(newSkillUninstallCommand(stdout, stderr))
-	cmd.AddCommand(newSkillListCommand(stdout))
-	cmd.AddCommand(newSkillUpdateCommand(stdout, stderr))
-	cmd.AddCommand(newSkillInfoCommand(stdout))
-	return cmd
-}
+		Short: "Manage skills from the TARS Hub",
+		Noun:  "skill",
 
-func newSkillSearchCommand(stdout io.Writer) *cobra.Command {
-	return &cobra.Command{
-		Use:   "search [query]",
-		Short: "Search the skill registry",
-		Args:  cobra.MaximumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			query := ""
-			if len(args) > 0 {
-				query = args[0]
+		Search: func(ctx context.Context, stdout io.Writer, query string) error {
+			reg := skillhub.NewRegistry()
+			results, err := reg.Search(ctx, query)
+			if err != nil {
+				return fmt.Errorf("search failed: %w", err)
 			}
-			return runSkillSearch(cmd.Context(), stdout, query)
+			if len(results) == 0 {
+				fmt.Fprintln(stdout, "No skills found.")
+				return nil
+			}
+			for _, entry := range results {
+				invocable := ""
+				if entry.UserInvocable {
+					invocable = " [invocable]"
+				}
+				tags := ""
+				if len(entry.Tags) > 0 {
+					tags = " (" + strings.Join(entry.Tags, ", ") + ")"
+				}
+				fmt.Fprintf(stdout, "  %s@%s%s%s\n    %s\n", entry.Name, entry.Version, invocable, tags, entry.Description)
+			}
+			fmt.Fprintf(stdout, "\n%d skill(s) found.\n", len(results))
+			return nil
 		},
-	}
-}
 
-func runSkillSearch(ctx context.Context, stdout io.Writer, query string) error {
-	reg := skillhub.NewRegistry()
-	results, err := reg.Search(ctx, query)
-	if err != nil {
-		return fmt.Errorf("search failed: %w", err)
-	}
-	if len(results) == 0 {
-		fmt.Fprintln(stdout, "No skills found.")
-		return nil
-	}
-	for _, entry := range results {
-		invocable := ""
-		if entry.UserInvocable {
-			invocable = " [invocable]"
-		}
-		tags := ""
-		if len(entry.Tags) > 0 {
-			tags = " (" + strings.Join(entry.Tags, ", ") + ")"
-		}
-		fmt.Fprintf(stdout, "  %s@%s%s%s\n    %s\n", entry.Name, entry.Version, invocable, tags, entry.Description)
-	}
-	fmt.Fprintf(stdout, "\n%d skill(s) found.\n", len(results))
-	return nil
-}
+		Install: func(ctx context.Context, stdout, stderr io.Writer, workspaceDir, name string) error {
+			inst := skillhub.NewInstaller(workspaceDir)
+			result, err := inst.Install(ctx, name)
+			if err != nil {
+				return fmt.Errorf("install %q: %w", name, err)
+			}
+			fmt.Fprintf(stdout, "Installed skill %q to %s/skills/%s\n", name, workspaceDir, name)
+			if result.RequiresPlugin != "" {
+				fmt.Fprintf(stderr, "⚠ This skill requires plugin %q. Install it with: tars plugin install %s\n", result.RequiresPlugin, result.RequiresPlugin)
+			}
+			return nil
+		},
 
-func newSkillInstallCommand(stdout, stderr io.Writer) *cobra.Command {
-	var workspaceDir string
-	cmd := &cobra.Command{
-		Use:   "install <name>",
-		Short: "Install a skill from the hub",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			dir, err := resolveWorkspaceDir(workspaceDir)
+		Uninstall: func(stdout, _ io.Writer, workspaceDir, name string) error {
+			inst := skillhub.NewInstaller(workspaceDir)
+			if err := inst.Uninstall(name); err != nil {
+				return fmt.Errorf("uninstall %q: %w", name, err)
+			}
+			fmt.Fprintf(stdout, "Uninstalled skill %q\n", name)
+			return nil
+		},
+
+		List: func(stdout io.Writer, workspaceDir string) error {
+			inst := skillhub.NewInstaller(workspaceDir)
+			skills, err := inst.List()
 			if err != nil {
 				return err
 			}
-			return runSkillInstall(cmd.Context(), stdout, stderr, dir, args[0])
+			if len(skills) == 0 {
+				fmt.Fprintln(stdout, "No hub skills installed.")
+				return nil
+			}
+			for _, s := range skills {
+				fmt.Fprintf(stdout, "  %s@%s  (%s)  %s\n", s.Name, s.Version, s.Source, s.Dir)
+			}
+			fmt.Fprintf(stdout, "\n%d skill(s) installed.\n", len(skills))
+			return nil
 		},
-	}
-	cmd.Flags().StringVar(&workspaceDir, "workspace-dir", defaultWorkspaceDir(), "workspace directory")
-	return cmd
-}
 
-func runSkillInstall(ctx context.Context, stdout, stderr io.Writer, workspaceDir, name string) error {
-	inst := skillhub.NewInstaller(workspaceDir)
-	result, err := inst.Install(ctx, name)
-	if err != nil {
-		return fmt.Errorf("install %q: %w", name, err)
-	}
-	fmt.Fprintf(stdout, "Installed skill %q to %s/skills/%s\n", name, workspaceDir, name)
-	if result.RequiresPlugin != "" {
-		fmt.Fprintf(stderr, "⚠ This skill requires plugin %q. Install it with: tars plugin install %s\n", result.RequiresPlugin, result.RequiresPlugin)
-	}
-	return nil
-}
-
-func newSkillUninstallCommand(stdout, stderr io.Writer) *cobra.Command {
-	var workspaceDir string
-	cmd := &cobra.Command{
-		Use:   "uninstall <name>",
-		Short: "Uninstall a skill",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			dir, err := resolveWorkspaceDir(workspaceDir)
+		Update: func(ctx context.Context, stdout, _ io.Writer, workspaceDir string) error {
+			inst := skillhub.NewInstaller(workspaceDir)
+			updated, err := inst.Update(ctx)
 			if err != nil {
 				return err
 			}
-			return runSkillUninstall(stdout, stderr, dir, args[0])
+			if len(updated) == 0 {
+				fmt.Fprintln(stdout, "All skills are up to date.")
+				return nil
+			}
+			for _, name := range updated {
+				fmt.Fprintf(stdout, "  Updated: %s\n", name)
+			}
+			fmt.Fprintf(stdout, "\n%d skill(s) updated.\n", len(updated))
+			return nil
 		},
-	}
-	cmd.Flags().StringVar(&workspaceDir, "workspace-dir", defaultWorkspaceDir(), "workspace directory")
-	return cmd
-}
 
-func runSkillUninstall(stdout, _ io.Writer, workspaceDir, name string) error {
-	inst := skillhub.NewInstaller(workspaceDir)
-	if err := inst.Uninstall(name); err != nil {
-		return fmt.Errorf("uninstall %q: %w", name, err)
-	}
-	fmt.Fprintf(stdout, "Uninstalled skill %q\n", name)
-	return nil
-}
-
-func newSkillListCommand(stdout io.Writer) *cobra.Command {
-	var workspaceDir string
-	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List installed hub skills",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			dir, err := resolveWorkspaceDir(workspaceDir)
+		Info: func(ctx context.Context, stdout io.Writer, name string) error {
+			reg := skillhub.NewRegistry()
+			entry, err := reg.FindByName(ctx, name)
 			if err != nil {
 				return err
 			}
-			return runSkillList(stdout, dir)
-		},
-	}
-	cmd.Flags().StringVar(&workspaceDir, "workspace-dir", defaultWorkspaceDir(), "workspace directory")
-	return cmd
-}
-
-func runSkillList(stdout io.Writer, workspaceDir string) error {
-	inst := skillhub.NewInstaller(workspaceDir)
-	skills, err := inst.List()
-	if err != nil {
-		return err
-	}
-	if len(skills) == 0 {
-		fmt.Fprintln(stdout, "No hub skills installed.")
-		return nil
-	}
-	for _, s := range skills {
-		fmt.Fprintf(stdout, "  %s@%s  (%s)  %s\n", s.Name, s.Version, s.Source, s.Dir)
-	}
-	fmt.Fprintf(stdout, "\n%d skill(s) installed.\n", len(skills))
-	return nil
-}
-
-func newSkillUpdateCommand(stdout, stderr io.Writer) *cobra.Command {
-	var workspaceDir string
-	cmd := &cobra.Command{
-		Use:   "update",
-		Short: "Update all installed hub skills to latest",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			dir, err := resolveWorkspaceDir(workspaceDir)
-			if err != nil {
-				return err
+			fmt.Fprintf(stdout, "Name:        %s\n", entry.Name)
+			fmt.Fprintf(stdout, "Version:     %s\n", entry.Version)
+			fmt.Fprintf(stdout, "Author:      %s\n", entry.Author)
+			fmt.Fprintf(stdout, "Description: %s\n", entry.Description)
+			fmt.Fprintf(stdout, "Invocable:   %v\n", entry.UserInvocable)
+			if len(entry.Tags) > 0 {
+				fmt.Fprintf(stdout, "Tags:        %s\n", strings.Join(entry.Tags, ", "))
 			}
-			return runSkillUpdate(cmd.Context(), stdout, stderr, dir)
+			if entry.RequiresPlugin != "" {
+				fmt.Fprintf(stdout, "Plugin:      %s\n", entry.RequiresPlugin)
+			}
+			return nil
 		},
-	}
-	cmd.Flags().StringVar(&workspaceDir, "workspace-dir", defaultWorkspaceDir(), "workspace directory")
-	return cmd
-}
-
-func runSkillUpdate(ctx context.Context, stdout, _ io.Writer, workspaceDir string) error {
-	inst := skillhub.NewInstaller(workspaceDir)
-	updated, err := inst.Update(ctx)
-	if err != nil {
-		return err
-	}
-	if len(updated) == 0 {
-		fmt.Fprintln(stdout, "All skills are up to date.")
-		return nil
-	}
-	for _, name := range updated {
-		fmt.Fprintf(stdout, "  Updated: %s\n", name)
-	}
-	fmt.Fprintf(stdout, "\n%d skill(s) updated.\n", len(updated))
-	return nil
-}
-
-func newSkillInfoCommand(stdout io.Writer) *cobra.Command {
-	return &cobra.Command{
-		Use:   "info <name>",
-		Short: "Show detailed info about a skill in the registry",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runSkillInfo(cmd.Context(), stdout, args[0])
-		},
-	}
-}
-
-func runSkillInfo(ctx context.Context, stdout io.Writer, name string) error {
-	reg := skillhub.NewRegistry()
-	entry, err := reg.FindByName(ctx, name)
-	if err != nil {
-		return err
-	}
-	fmt.Fprintf(stdout, "Name:        %s\n", entry.Name)
-	fmt.Fprintf(stdout, "Version:     %s\n", entry.Version)
-	fmt.Fprintf(stdout, "Author:      %s\n", entry.Author)
-	fmt.Fprintf(stdout, "Description: %s\n", entry.Description)
-	fmt.Fprintf(stdout, "Invocable:   %v\n", entry.UserInvocable)
-	if len(entry.Tags) > 0 {
-		fmt.Fprintf(stdout, "Tags:        %s\n", strings.Join(entry.Tags, ", "))
-	}
-	if entry.RequiresPlugin != "" {
-		fmt.Fprintf(stdout, "Plugin:      %s\n", entry.RequiresPlugin)
-	}
-	return nil
+	}, stdout, stderr)
 }


### PR DESCRIPTION
## Summary
- Extract `hubResourceSpec` + `newHubResourceCommand` factory into `hub_commands.go`
- Factory wires the standard search/install/uninstall/list/update/info subcommand tree with shared flag binding and workspace resolution
- Each resource type (skill, plugin, MCP) provides only type-specific callbacks
- Consistent "TARS Hub" naming across all three command surfaces
- Net -183 lines of duplicated cobra wiring

## Test plan
- [x] `go build ./...` compiles
- [x] `go test ./cmd/tars/` — all tests pass
- [x] `go vet` + `go fmt` clean

Closes #335