### PR TITLE
feat: improve session compaction quality

### DIFF
--- a/internal/session/compaction.go
+++ b/internal/session/compaction.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"unicode"
 )
 
 const (
@@ -41,7 +42,7 @@ func CompactTranscript(path string, keepRecent int, now time.Time) (CompactResul
 
 type CompactOptions struct {
 	BeforeRewrite       func(summary string, compactedCount int, originalCount int) error
-	SummaryBuilder      func(messages []Message) (string, error)
+	SummaryBuilder      func(messages []Message, previousContext string) (string, error)
 	KeepRecentTokens    int
 	KeepRecentFraction  float64
 	SummaryInstructions string
@@ -49,6 +50,7 @@ type CompactOptions struct {
 
 type CompactionSummaryOptions struct {
 	FocusInstructions string
+	PreviousContext   string
 }
 
 func CompactTranscriptWithOptions(path string, keepRecent int, now time.Time, opts CompactOptions) (CompactResult, error) {
@@ -115,17 +117,28 @@ func CompactTranscriptWithOptions(path string, keepRecent int, now time.Time, op
 		tail = messages[cutoff:]
 	}
 
+	// Stacking carry-forward: extract previous compaction summary before pruning
+	var previousContext string
+	if len(head) > 0 && head[0].Role == "system" && strings.Contains(head[0].Content, "[COMPACTION SUMMARY]") {
+		previousContext = extractCompactionBody(head[0].Content)
+		head = head[1:]
+	}
+
+	// Pre-compaction: prune long tool results to prevent code dumps in summary
+	prunedHead := pruneToolResults(head, defaultToolPruneMaxLen)
+
 	var summary string
 	if opts.SummaryBuilder != nil {
-		built, err := opts.SummaryBuilder(head)
+		built, err := opts.SummaryBuilder(prunedHead, previousContext)
 		if err != nil {
 			return CompactResult{}, err
 		}
 		summary = strings.TrimSpace(built)
 	}
 	if summary == "" {
-		summary = BuildCompactionSummaryWithOptions(head, CompactionSummaryOptions{
+		summary = BuildCompactionSummaryWithOptions(prunedHead, CompactionSummaryOptions{
 			FocusInstructions: opts.SummaryInstructions,
+			PreviousContext:   previousContext,
 		})
 	}
 	compactionMessage := Message{
@@ -170,20 +183,34 @@ func BuildCompactionSummaryWithOptions(messages []Message, opts CompactionSummar
 		_, _ = fmt.Fprintf(&b, "Span: %s\n", span)
 	}
 
+	// Cross-section deduplication
+	globalSeen := map[string]struct{}{}
+	appendDedup := func(title string, lines []string) {
+		fresh := make([]string, 0, len(lines))
+		for _, line := range uniqueNonEmptyLines(lines) {
+			if _, dup := globalSeen[line]; dup {
+				continue
+			}
+			globalSeen[line] = struct{}{}
+			fresh = append(fresh, line)
+		}
+		appendCompactionSection(&b, title, fresh)
+	}
+
+	// Prior context from previous compaction (populated by stacking carry-forward)
+	if opts.PreviousContext != "" {
+		appendDedup("Prior Context", []string{opts.PreviousContext})
+	}
+
 	if focus := normalizeSummaryLine(opts.FocusInstructions, 240); focus != "" {
-		appendCompactionSection(&b, "Requested Focus", []string{focus})
+		appendDedup("Requested Focus", []string{focus})
 	}
 
-	appendCompactionSection(&b, "Current Goal", currentGoalLines(messages))
-	appendCompactionSection(&b, "Constraints And Preferences", constraintLines(messages))
-	appendCompactionSection(&b, "Key Facts", keyFactLines(messages))
-	appendCompactionSection(&b, "Identifiers To Preserve", identifierLines(messages))
-	appendCompactionSection(&b, "Recent Context", recentContextLines(messages))
-	appendCompactionSection(&b, "Open State", openStateLines(messages))
+	appendDedup("Topic", currentGoalLines(messages))
+	appendDedup("Key Decisions", keyDecisionLines(messages))
+	appendDedup("Active Identifiers", identifierLines(messages))
+	appendDedup("Current State", currentStateLines(messages))
 
-	if strings.Count(b.String(), "\n\n") == 0 {
-		appendCompactionSection(&b, "Recent Context", recentContextLines(messages))
-	}
 	return b.String()
 }
 
@@ -283,11 +310,38 @@ func adjustCompactionCutoff(messages []Message, cutoff int, minMessages int) int
 }
 
 func estimateMessageTokenCost(msg Message) int {
-	cost := len(msg.Content) / 4
+	return estimateStringTokens(msg.Content)
+}
+
+// EstimateMessageTokenCost is the exported wrapper for single-message token estimation.
+func EstimateMessageTokenCost(msg Message) int {
+	return estimateMessageTokenCost(msg)
+}
+
+func estimateStringTokens(s string) int {
+	if len(s) == 0 {
+		return 1
+	}
+	units := 0
+	for _, r := range s {
+		if isCJKRune(r) {
+			units += 6 // CJK rune: ~1.5 tokens → weight as 6 quarter-tokens
+		} else {
+			units += 1 // ASCII/Latin byte: ~0.25 tokens
+		}
+	}
+	cost := units / 4
 	if cost < 1 {
 		cost = 1
 	}
 	return cost
+}
+
+func isCJKRune(r rune) bool {
+	return unicode.Is(unicode.Han, r) ||
+		unicode.Is(unicode.Hangul, r) ||
+		unicode.Is(unicode.Katakana, r) ||
+		unicode.Is(unicode.Hiragana, r)
 }
 
 func EstimateTokens(messages []Message) int {
@@ -322,40 +376,28 @@ func currentGoalLines(messages []Message) []string {
 	return lines
 }
 
-func constraintLines(messages []Message) []string {
+func keyDecisionLines(messages []Message) []string {
 	return keywordLines(messages, []string{
-		"must", "should", "avoid", "do not", "don't", "keep", "use", "only", "never", "always",
-		"required", "rule", "focus", "반드시", "하지 마", "유지", "사용", "규칙", "집중",
+		"decided", "decision", "agreed", "chosen", "approach", "strategy", "plan",
+		"priority", "confirmed", "approved", "rejected",
+		"결정", "합의", "방향", "전략", "우선순위", "확인", "승인",
 	}, 5)
-}
-
-func keyFactLines(messages []Message) []string {
-	lines := keywordLines(messages, []string{
-		"already", "current", "existing", "found", "supports", "because", "error", "failed",
-		"path", "file", "issue", "branch", "현재", "기존", "이미", "발견", "오류", "파일", "브랜치",
-	}, 5)
-	if len(lines) > 0 {
-		return lines
-	}
-	firstAssistant := firstMessageForRole(messages, "assistant")
-	if firstAssistant == nil {
-		firstAssistant = firstMessageForRole(messages, "system")
-	}
-	if firstAssistant == nil {
-		return nil
-	}
-	return []string{normalizeSummaryLine(firstAssistant.Content, 220)}
 }
 
 func identifierLines(messages []Message) []string {
 	lines := make([]string, 0, 12)
 	seen := map[string]struct{}{}
 	for _, msg := range messages {
+		if strings.EqualFold(strings.TrimSpace(msg.Role), "tool") {
+			continue
+		}
 		for _, token := range collectIdentifiers(msg.Content) {
-			if _, ok := seen[token]; ok {
+			// Normalize: strip backticks for dedup comparison
+			normalized := strings.Trim(token, "`")
+			if _, ok := seen[normalized]; ok {
 				continue
 			}
-			seen[token] = struct{}{}
+			seen[normalized] = struct{}{}
 			lines = append(lines, token)
 			if len(lines) == 12 {
 				return lines
@@ -365,19 +407,7 @@ func identifierLines(messages []Message) []string {
 	return lines
 }
 
-func recentContextLines(messages []Message) []string {
-	start := len(messages) - 6
-	if start < 0 {
-		start = 0
-	}
-	lines := make([]string, 0, len(messages)-start)
-	for _, msg := range messages[start:] {
-		lines = append(lines, formatCompactionMessageLine(msg, 180))
-	}
-	return lines
-}
-
-func openStateLines(messages []Message) []string {
+func currentStateLines(messages []Message) []string {
 	lines := make([]string, 0, 2)
 	if lastUser := lastMessageForRole(messages, "user"); lastUser != nil {
 		lines = append(lines, formatCompactionMessageLine(*lastUser, 180))
@@ -395,6 +425,9 @@ func keywordLines(messages []Message, keywords []string, limit int) []string {
 	lines := make([]string, 0, limit)
 	seen := map[string]struct{}{}
 	for _, msg := range messages {
+		if strings.EqualFold(strings.TrimSpace(msg.Role), "tool") {
+			continue
+		}
 		content := strings.ToLower(strings.TrimSpace(msg.Content))
 		if content == "" {
 			continue
@@ -488,12 +521,62 @@ func formatCompactionMessageLine(msg Message, maxLen int) string {
 func normalizeSummaryLine(content string, maxLen int) string {
 	content = strings.Join(strings.Fields(strings.TrimSpace(content)), " ")
 	if content == "" {
-		return "(empty)"
+		return ""
 	}
 	if maxLen > 0 && len(content) > maxLen {
 		return content[:maxLen] + "..."
 	}
 	return content
+}
+
+const defaultToolPruneMaxLen = 200
+
+// pruneToolResults replaces long tool message content with a short placeholder.
+// This prevents code dumps from polluting the compaction summary.
+// Returns a new slice; the input is not mutated.
+func pruneToolResults(messages []Message, maxContentLen int) []Message {
+	out := make([]Message, len(messages))
+	copy(out, messages)
+	for i := range out {
+		if !strings.EqualFold(strings.TrimSpace(out[i].Role), "tool") {
+			continue
+		}
+		if len(out[i].Content) <= maxContentLen {
+			continue
+		}
+		name := out[i].ToolName
+		if name == "" {
+			name = "unknown"
+		}
+		out[i].Content = fmt.Sprintf("[tool:%s] output cleared (%d chars)", name, len(out[i].Content))
+	}
+	return out
+}
+
+// extractCompactionBody strips the [COMPACTION SUMMARY] header and message
+// count line, returning only the body sections for carry-forward.
+func extractCompactionBody(summary string) string {
+	// Skip lines: "[COMPACTION SUMMARY]", "Compacted N messages.", "Span: ..."
+	lines := strings.Split(summary, "\n")
+	bodyStart := 0
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "[COMPACTION SUMMARY]") ||
+			strings.HasPrefix(trimmed, "Compacted ") || strings.HasPrefix(trimmed, "Span:") {
+			bodyStart = i + 1
+			continue
+		}
+		break
+	}
+	if bodyStart >= len(lines) {
+		return ""
+	}
+	body := strings.TrimSpace(strings.Join(lines[bodyStart:], "\n"))
+	// Truncate to keep carry-forward compact
+	if len(body) > 800 {
+		body = body[:800] + "..."
+	}
+	return body
 }
 
 func compactionTimeSpan(messages []Message) string {

--- a/internal/session/compaction_test.go
+++ b/internal/session/compaction_test.go
@@ -34,10 +34,9 @@ func TestBuildCompactionSummaryWithOptions_StructuredSectionsAndIdentifiers(t *t
 	for _, needle := range []string{
 		"[COMPACTION SUMMARY]",
 		"Requested Focus:",
-		"Current Goal:",
-		"Identifiers To Preserve:",
-		"Recent Context:",
-		"Open State:",
+		"Topic:",
+		"Active Identifiers:",
+		"Current State:",
 		"/compact",
 		"internal/session/compaction.go",
 		"feat/session-compaction-upgrade",

--- a/internal/session/transcript.go
+++ b/internal/session/transcript.go
@@ -171,9 +171,5 @@ func historyTokenCost(messages []Message) int {
 }
 
 func messageTokenCost(msg Message) int {
-	cost := len(msg.Content) / 4
-	if cost < 1 {
-		return 1
-	}
-	return cost
+	return estimateMessageTokenCost(msg)
 }

--- a/internal/tarsserver/helpers_chat.go
+++ b/internal/tarsserver/helpers_chat.go
@@ -95,11 +95,12 @@ func compactWithMemoryFlush(workspaceDir, transcriptPath, sessionID string, keep
 		KeepRecentTokens:    compaction.KeepRecentTokens,
 		KeepRecentFraction:  compaction.KeepRecentFraction,
 		SummaryInstructions: instructions,
-		SummaryBuilder: func(messages []session.Message) (string, error) {
+		SummaryBuilder: func(messages []session.Message, previousContext string) (string, error) {
 			if client == nil {
 				summaryMode = "deterministic"
 				return session.BuildCompactionSummaryWithOptions(messages, session.CompactionSummaryOptions{
 					FocusInstructions: instructions,
+					PreviousContext:   previousContext,
 				}), nil
 			}
 			ctx := context.Background()
@@ -108,7 +109,7 @@ func compactWithMemoryFlush(workspaceDir, transcriptPath, sessionID string, keep
 				ctx, cancel = context.WithTimeout(context.Background(), time.Duration(compaction.LLMTimeoutSeconds)*time.Second)
 				defer cancel()
 			}
-			built, usedLLM, err := buildLLMCompactionSummaryWithContext(ctx, messages, client, now, instructions)
+			built, usedLLM, err := buildLLMCompactionSummaryWithContext(ctx, messages, client, now, instructions, previousContext)
 			if usedLLM {
 				summaryMode = "llm"
 			} else {
@@ -158,23 +159,47 @@ func compactWithMemoryFlush(workspaceDir, transcriptPath, sessionID string, keep
 // because its caller (compactWithMemoryFlush) has already resolved the
 // router to a concrete client; passing the already-resolved client keeps
 // this pure-function boundary intact and testable.
-func buildLLMCompactionSummary(messages []session.Message, client llm.Client, now time.Time, instructions string) (string, error) {
-	summary, _, err := buildLLMCompactionSummaryWithContext(context.Background(), messages, client, now, instructions)
+func buildLLMCompactionSummary(messages []session.Message, client llm.Client, now time.Time, instructions string, previousContext string) (string, error) {
+	summary, _, err := buildLLMCompactionSummaryWithContext(context.Background(), messages, client, now, instructions, previousContext)
 	return summary, err
 }
 
-func buildLLMCompactionSummaryWithContext(ctx context.Context, messages []session.Message, client llm.Client, now time.Time, instructions string) (string, bool, error) {
-	const maxMessages = 80
-	msgs := messages
-	if len(msgs) > maxMessages {
-		msgs = msgs[len(msgs)-maxMessages:]
+func buildLLMCompactionSummaryWithContext(ctx context.Context, messages []session.Message, client llm.Client, now time.Time, instructions string, previousContext string) (string, bool, error) {
+	const inputTokenBudget = 8000
+
+	// Select messages within token budget, walking backward for recency bias
+	var selected []session.Message
+	tokens := 0
+	for i := len(messages) - 1; i >= 0; i-- {
+		cost := session.EstimateMessageTokenCost(messages[i])
+		if tokens+cost > inputTokenBudget && len(selected) > 0 {
+			break
+		}
+		selected = append(selected, messages[i])
+		tokens += cost
+	}
+	// Reverse to chronological order
+	for i, j := 0, len(selected)-1; i < j; i, j = i+1, j-1 {
+		selected[i], selected[j] = selected[j], selected[i]
+	}
+
+	// Proportional content length: more messages → shorter each; fewer → longer each
+	maxContentLen := 800
+	if len(selected) > 0 {
+		maxContentLen = inputTokenBudget * 4 / len(selected)
+		if maxContentLen < 240 {
+			maxContentLen = 240
+		}
+		if maxContentLen > 800 {
+			maxContentLen = 800
+		}
 	}
 
 	var b strings.Builder
-	for _, m := range msgs {
+	for _, m := range selected {
 		content := strings.TrimSpace(strings.ReplaceAll(m.Content, "\n", " "))
-		if len(content) > 240 {
-			content = content[:240] + "..."
+		if len(content) > maxContentLen {
+			content = content[:maxContentLen] + "..."
 		}
 		_, _ = fmt.Fprintf(&b, "- [%s] %s\n", m.Role, content)
 	}
@@ -184,12 +209,19 @@ func buildLLMCompactionSummaryWithContext(ctx context.Context, messages []sessio
 		focusBlock = "Requested focus:\n" + focus + "\n\n"
 	}
 
+	previousBlock := ""
+	if strings.TrimSpace(previousContext) != "" {
+		previousBlock = "Previous compaction summary (PRESERVE all existing info, ADD new progress, move completed items to Done):\n" + previousContext + "\n\n"
+	}
+
 	userPrompt := fmt.Sprintf(
 		"Create a compact context summary for old chat messages.\n"+
+			"%s"+
 			"%s"+
 			"Keep concrete facts, goals, decisions, user preferences, unresolved tasks.\n"+
 			"Return plain markdown under 900 characters.\n"+
 			"Current UTC: %s\n\nMessages:\n%s",
+		previousBlock,
 		focusBlock,
 		now.UTC().Format(time.RFC3339),
 		b.String(),
@@ -208,6 +240,7 @@ func buildLLMCompactionSummaryWithContext(ctx context.Context, messages []sessio
 	if err != nil {
 		return session.BuildCompactionSummaryWithOptions(messages, session.CompactionSummaryOptions{
 			FocusInstructions: instructions,
+			PreviousContext:   previousContext,
 		}), false, nil
 	}
 
@@ -215,6 +248,7 @@ func buildLLMCompactionSummaryWithContext(ctx context.Context, messages []sessio
 	if summary == "" {
 		return session.BuildCompactionSummaryWithOptions(messages, session.CompactionSummaryOptions{
 			FocusInstructions: instructions,
+			PreviousContext:   previousContext,
 		}), false, nil
 	}
 	if strings.Contains(summary, "[COMPACTION SUMMARY]") {


### PR DESCRIPTION
## Summary

- **CJK-aware token estimation**: rune-based calculation with Han/Hangul/Katakana/Hiragana detection (Korean: 39→72 tokens, closer to actual)
- **Tool result pruning**: pre-compaction phase replaces long tool outputs (>200 chars) with placeholder, eliminating code dump pollution in summaries
- **Summary restructure**: Topic → Key Decisions → Active Identifiers → Current State, with cross-section dedup and empty section removal (3606→1481 chars, -59%)
- **Stacking carry-forward**: previous `[COMPACTION SUMMARY]` detected and passed as Prior Context, preserving info across re-compactions
- **LLM input upgrade**: fixed 80msg×240char → 8K token budget with proportional content allocation

## Test plan

- [x] All existing compaction tests pass (`TestCompactTranscript*`, `TestCutoff*`, `TestBuild*`)
- [x] All tarsserver compaction tests pass (`TestCompactionClient*`, `TestCompactWithMemoryFlush*`, `TestCompactAPI*`)
- [x] `make test` — full suite passes
- [x] `make build` — binary builds successfully