### PR TITLE
fix: resolve console SSE exhaustion, compaction deadlock, and logging

### DIFF
--- a/frontend/console/src/components/Chat.svelte
+++ b/frontend/console/src/components/Chat.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy, tick } from 'svelte'
   import {
-    getEventsHistory, getPulseStatus, streamEvents,
+    getEventsHistory, getPulseStatus,
     getSession, createSession, renameSession, deleteSession, compactSession, getSessionHistory,
   } from '../lib/api'
   import type { PulseSnapshot, NotificationMessage, Session } from '../lib/types'
@@ -77,7 +77,13 @@
   let rightPanel = $state<RightPanel>('none')
 
   let sidebarRef: SessionSidebar | undefined = $state()
-  let stopStream: (() => void) | null = null
+  let actionFeedback = $state('')
+  let feedbackTimer: ReturnType<typeof setTimeout> | null = null
+  function showFeedback(msg: string, ms = 4000) {
+    if (feedbackTimer) clearTimeout(feedbackTimer)
+    actionFeedback = msg
+    feedbackTimer = setTimeout(() => { actionFeedback = '' }, ms)
+  }
 
   function relativeTime(value?: string): string {
     if (!value?.trim()) return 'never'
@@ -193,9 +199,19 @@
     if (!selectedSessionId) return
     actionBusy = true
     try {
-      await compactSession(selectedSessionId)
+      const r = await compactSession(selectedSessionId)
+      if (r.compacted) {
+        const saved = r.tokens_before - r.tokens_after
+        const pct = r.tokens_before > 0 ? Math.round((saved / r.tokens_before) * 100) : 0
+        showFeedback(`Compacted ${r.compacted_count} messages (${r.original_count} → ${r.final_count}), ${pct}% tokens saved`)
+      } else {
+        showFeedback(r.reason || 'Nothing to compact')
+      }
       sidebarRef?.load()
-    } catch { /* ignore */ }
+      chatKey++
+    } catch (e) {
+      showFeedback(e instanceof Error ? e.message : 'Compact failed')
+    }
     actionBusy = false
   }
 
@@ -269,13 +285,6 @@
 
   onMount(() => {
     void loadDashboard()
-    stopStream = streamEvents(
-      () => { unreadCount++ },
-    )
-  })
-
-  onDestroy(() => {
-    stopStream?.()
   })
 </script>
 
@@ -362,6 +371,10 @@
         </div>
       {/if}
 
+      {#if actionFeedback}
+        <div class="action-feedback">{actionFeedback}</div>
+      {/if}
+
       {#key chatKey}
         <ChatPanel
           bind:this={chatPanelRef}
@@ -414,6 +427,14 @@
 </div>
 
 <style>
+  .action-feedback {
+    padding: 6px 14px;
+    font-size: 0.82rem;
+    color: var(--accent);
+    background: color-mix(in srgb, var(--accent) 10%, transparent);
+    border-bottom: 1px solid color-mix(in srgb, var(--accent) 25%, transparent);
+    text-align: center;
+  }
   .chat-page {
     display: flex;
     flex-direction: column;

--- a/frontend/console/src/components/SessionSidebar.svelte
+++ b/frontend/console/src/components/SessionSidebar.svelte
@@ -129,7 +129,13 @@
     actionBusy = id
     actionError = ''
     try {
-      await compactSession(id)
+      const r = await compactSession(id)
+      if (r.compacted) {
+        const pct = r.tokens_before > 0 ? Math.round(((r.tokens_before - r.tokens_after) / r.tokens_before) * 100) : 0
+        actionError = `Compacted ${r.compacted_count} msgs (${pct}% saved)`
+      } else {
+        actionError = r.reason || 'Nothing to compact'
+      }
       await load()
     } catch (e) {
       actionError = e instanceof Error ? e.message : 'Compact failed'

--- a/frontend/console/src/components/Sessions.svelte
+++ b/frontend/console/src/components/Sessions.svelte
@@ -148,7 +148,13 @@
     actionBusy = id
     actionError = ''
     try {
-      await compactSession(id)
+      const r = await compactSession(id)
+      if (r.compacted) {
+        const pct = r.tokens_before > 0 ? Math.round(((r.tokens_before - r.tokens_after) / r.tokens_before) * 100) : 0
+        actionError = `Compacted ${r.compacted_count} msgs (${pct}% saved)`
+      } else {
+        actionError = r.reason || 'Nothing to compact'
+      }
       await load()
     } catch (e) {
       actionError = e instanceof Error ? e.message : 'Compact failed'

--- a/frontend/console/src/lib/api.ts
+++ b/frontend/console/src/lib/api.ts
@@ -211,8 +211,19 @@ export function streamGatewayRunEvents(
 	return () => stream.close()
 }
 
-export async function compactSession(sessionId: string): Promise<{ compacted: boolean }> {
-  return requestJSON<{ compacted: boolean }>(
+export interface CompactResult {
+  session_id: string
+  compacted: boolean
+  original_count: number
+  final_count: number
+  compacted_count: number
+  tokens_before: number
+  tokens_after: number
+  reason: string
+}
+
+export async function compactSession(sessionId: string): Promise<CompactResult> {
+  return requestJSON<CompactResult>(
     `/v1/admin/sessions/${encodeURIComponent(sessionId)}/compact`,
     { method: 'POST' },
   )
@@ -554,36 +565,63 @@ export async function reloadExtensions(): Promise<{ reloaded: boolean; skills: n
   return requestJSON<{ reloaded: boolean; skills: number; plugins: number; mcp_count: number }>('/v1/runtime/extensions/reload', { method: 'POST' })
 }
 
-// --- Events ---
+// --- Events (singleton SSE) ---
+//
+// A single EventSource is shared across all components to avoid exhausting the
+// browser's per-origin HTTP/1.1 connection limit (typically 6).  Components
+// call streamEvents() to subscribe and receive a cleanup function that
+// unsubscribes without closing the underlying connection.
+
+type EventListener = {
+  onEvent: (event: NotificationMessage) => void
+  onError?: (message: string) => void
+  onOpen?: () => void
+}
+
+let sharedStream: EventSource | null = null
+let listeners = new Map<number, EventListener>()
+let nextListenerId = 0
+
+function ensureStream() {
+  if (sharedStream && sharedStream.readyState !== EventSource.CLOSED) return
+  sharedStream = new EventSource('/v1/events/stream')
+  sharedStream.onopen = () => {
+    for (const l of listeners.values()) l.onOpen?.()
+  }
+  sharedStream.onmessage = (message) => {
+    if (!message.data) return
+    try {
+      const payload = JSON.parse(message.data) as NotificationMessage
+      if (payload.type === 'keepalive') return
+      for (const l of listeners.values()) l.onEvent(payload)
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Failed to parse event stream payload'
+      for (const l of listeners.values()) l.onError?.(msg)
+    }
+  }
+  sharedStream.onerror = () => {
+    for (const l of listeners.values()) l.onError?.('Event stream disconnected')
+  }
+}
+
+function maybeCloseStream() {
+  if (listeners.size === 0 && sharedStream) {
+    sharedStream.close()
+    sharedStream = null
+  }
+}
 
 export function streamEvents(
   onEvent: (event: NotificationMessage) => void,
   onError?: (message: string) => void,
   onOpen?: () => void,
 ): () => void {
-  const stream = new EventSource('/v1/events/stream')
-  stream.onopen = () => {
-    onOpen?.()
-  }
-  stream.onmessage = (message) => {
-    if (!message.data) {
-      return
-    }
-    try {
-      const payload = JSON.parse(message.data) as NotificationMessage
-      if (payload.type === 'keepalive') {
-        return
-      }
-      onEvent(payload)
-    } catch (error) {
-      onError?.(error instanceof Error ? error.message : 'Failed to parse event stream payload')
-    }
-  }
-  stream.onerror = () => {
-    onError?.('Event stream disconnected')
-  }
+  const id = nextListenerId++
+  listeners.set(id, { onEvent, onError, onOpen })
+  ensureStream()
   return () => {
-    stream.close()
+    listeners.delete(id)
+    maybeCloseStream()
   }
 }
 

--- a/internal/session/compaction.go
+++ b/internal/session/compaction.go
@@ -46,6 +46,10 @@ type CompactOptions struct {
 	KeepRecentTokens    int
 	KeepRecentFraction  float64
 	SummaryInstructions string
+	// PreloadedMessages supplies already-read messages to avoid a second ReadMessages
+	// call on the same path. When set, ReadMessages is skipped, preventing a
+	// reentrant-lock deadlock when the caller already holds the path lock.
+	PreloadedMessages []Message
 }
 
 type CompactionSummaryOptions struct {
@@ -64,9 +68,15 @@ func CompactTranscriptWithOptions(path string, keepRecent int, now time.Time, op
 		keepRecent = MaxKeepRecentMessages
 	}
 
-	messages, err := ReadMessages(path)
-	if err != nil {
-		return CompactResult{}, err
+	var messages []Message
+	if len(opts.PreloadedMessages) > 0 {
+		messages = opts.PreloadedMessages
+	} else {
+		var err error
+		messages, err = ReadMessages(path)
+		if err != nil {
+			return CompactResult{}, err
+		}
 	}
 	if len(messages) == 0 {
 		return CompactResult{Compacted: false}, nil

--- a/internal/tarsserver/handler_session.go
+++ b/internal/tarsserver/handler_session.go
@@ -323,16 +323,49 @@ func newSessionAPIHandler(store *session.Store, logger zerolog.Logger) http.Hand
 				return
 			}
 			path := reqStore.TranscriptPath(sessionID)
-			compacted, err := session.CompactTranscriptWithOptions(path, 0, time.Now().UTC(), session.CompactOptions{
-				KeepRecentTokens:   12000,
-				KeepRecentFraction: 0.30,
+			messages, err := session.ReadMessages(path)
+			if err != nil {
+				logger.Error().Err(err).Str("session_id", sessionID).Msg("read transcript for compact failed")
+				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "read transcript failed"})
+				return
+			}
+			tokensBefore := session.EstimateTokens(messages)
+			// Manual compact uses lower thresholds than auto-compact so it
+			// always does meaningful work when the user explicitly requests it.
+			result, err := session.CompactTranscriptWithOptions(path, 5, time.Now().UTC(), session.CompactOptions{
+				KeepRecentTokens:   2000,
+				KeepRecentFraction: 0.20,
+				PreloadedMessages:  messages,
 			})
 			if err != nil {
 				logger.Error().Err(err).Str("session_id", sessionID).Msg("compact session failed")
 				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "compact session failed"})
 				return
 			}
-			writeJSON(w, http.StatusOK, map[string]any{"compacted": compacted, "session_id": sessionID})
+			tokensAfter := tokensBefore
+			reason := ""
+			if result.Compacted {
+				after, _ := session.ReadMessages(path)
+				tokensAfter = session.EstimateTokens(after)
+			} else {
+				if len(messages) <= 5 {
+					reason = "too few messages to compact"
+				} else if tokensBefore <= 2000 {
+					reason = "transcript already within token budget"
+				} else {
+					reason = "no compactable messages found"
+				}
+			}
+			writeJSON(w, http.StatusOK, map[string]any{
+				"session_id":     sessionID,
+				"compacted":      result.Compacted,
+				"original_count": result.OriginalCount,
+				"final_count":    result.FinalCount,
+				"compacted_count": result.CompactedCount,
+				"tokens_before":  tokensBefore,
+				"tokens_after":   tokensAfter,
+				"reason":         reason,
+			})
 		case len(pathParts) == 2 && pathParts[1] == "history":
 			if !requireMethod(w, r, http.MethodGet) {
 				return
@@ -577,6 +610,7 @@ func newCompactAPIHandler(workspaceDir string, store *session.Store, router llm.
 			req.Instructions,
 			router,
 			now,
+			nil,
 		)
 		if err != nil {
 			logger.Error().Err(err).Str("session_id", sessionID).Msg("compact transcript failed")

--- a/internal/tarsserver/handlers.go
+++ b/internal/tarsserver/handlers.go
@@ -64,6 +64,10 @@ func (r *statusRecorder) Flush() {
 func requestDebugMiddleware(logger zerolog.Logger, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
+		logger.Debug().
+			Str("method", r.Method).
+			Str("path", r.URL.Path).
+			Msg("http request started")
 		rec := &statusRecorder{ResponseWriter: w}
 		next.ServeHTTP(rec, r)
 		if rec.status == 0 {

--- a/internal/tarsserver/helpers_chat.go
+++ b/internal/tarsserver/helpers_chat.go
@@ -66,6 +66,7 @@ func maybeAutoCompactSession(workspaceDir, transcriptPath, sessionID string, rou
 		"",
 		router,
 		now,
+		messages,
 		buildSemanticMemoryService(workspaceDir, firstSemanticConfig(semanticCfg...)),
 	)
 	if err != nil {
@@ -87,7 +88,7 @@ func maybeAutoCompactSession(workspaceDir, transcriptPath, sessionID string, rou
 	return info, nil
 }
 
-func compactWithMemoryFlush(workspaceDir, transcriptPath, sessionID string, keepRecent int, compaction chatCompactionOptions, instructions string, router llm.Router, now time.Time, semantic ...*memory.Service) (session.CompactResult, string, error) {
+func compactWithMemoryFlush(workspaceDir, transcriptPath, sessionID string, keepRecent int, compaction chatCompactionOptions, instructions string, router llm.Router, now time.Time, preloadedMessages []session.Message, semantic ...*memory.Service) (session.CompactResult, string, error) {
 	memService := firstSemanticService(semantic...)
 	client := compactionClient(router, compaction.LLMMode)
 	summaryMode := "deterministic"
@@ -95,6 +96,7 @@ func compactWithMemoryFlush(workspaceDir, transcriptPath, sessionID string, keep
 		KeepRecentTokens:    compaction.KeepRecentTokens,
 		KeepRecentFraction:  compaction.KeepRecentFraction,
 		SummaryInstructions: instructions,
+		PreloadedMessages:   preloadedMessages,
 		SummaryBuilder: func(messages []session.Message, previousContext string) (string, error) {
 			if client == nil {
 				summaryMode = "deterministic"

--- a/internal/tarsserver/helpers_chat_test.go
+++ b/internal/tarsserver/helpers_chat_test.go
@@ -112,7 +112,7 @@ func TestCompactWithMemoryFlush_IndexesSummaryAndExtractedMemories(t *testing.T)
 		extract: `{"memories":[{"category":"preference","summary":"User prefers decaf espresso.","importance":8}]}`,
 	}
 
-	if _, _, err := compactWithMemoryFlush(root, transcriptPath, sess.ID, 2, chatCompactionOptions{KeepRecentTokens: 20}, "", routerForCompactionClient(t, client), time.Date(2026, 3, 20, 8, 30, 0, 0, time.UTC), semantic); err != nil {
+	if _, _, err := compactWithMemoryFlush(root, transcriptPath, sess.ID, 2, chatCompactionOptions{KeepRecentTokens: 20}, "", routerForCompactionClient(t, client), time.Date(2026, 3, 20, 8, 30, 0, 0, time.UTC), nil, semantic); err != nil {
 		t.Fatalf("compact with memory flush: %v", err)
 	}
 
@@ -149,7 +149,7 @@ func TestCompactWithMemoryFlush_PassesInstructionsToLLMSummary(t *testing.T) {
 	client := &compactionLLMClient{
 		summary: "[COMPACTION SUMMARY]\nFocused summary.",
 	}
-	if _, _, err := compactWithMemoryFlush(root, transcriptPath, sess.ID, 2, chatCompactionOptions{KeepRecentTokens: 20}, "focus on decisions and open questions", routerForCompactionClient(t, client), time.Date(2026, 3, 20, 8, 30, 0, 0, time.UTC)); err != nil {
+	if _, _, err := compactWithMemoryFlush(root, transcriptPath, sess.ID, 2, chatCompactionOptions{KeepRecentTokens: 20}, "focus on decisions and open questions", routerForCompactionClient(t, client), time.Date(2026, 3, 20, 8, 30, 0, 0, time.UTC), nil); err != nil {
 		t.Fatalf("compact with memory flush: %v", err)
 	}
 

--- a/internal/tarsserver/main_cli.go
+++ b/internal/tarsserver/main_cli.go
@@ -64,13 +64,18 @@ func newRootCmd(opts *options, stdout, stderr io.Writer, nowFn func() time.Time)
 				if cfg.LogRotateMaxBackups > 0 {
 					logCfg.RotateMaxBackups = cfg.LogRotateMaxBackups
 				}
-				if needReconfigure {
-					newLogger, newCleanup := setupRuntimeLogger(logCfg, stderr)
-					// Replace global logger; previous cleanup runs via deferred Serve().
-					zlog.Logger = newLogger
-					logger = newLogger
-					_ = newCleanup // cleanup will be handled by the process lifecycle
-				}
+				// --verbose flag overrides config log_level
+			if opts.Verbose {
+				logCfg.Level = "debug"
+				needReconfigure = true
+			}
+			if needReconfigure {
+				newLogger, newCleanup := setupRuntimeLogger(logCfg, stderr)
+				// Replace global logger; previous cleanup runs via deferred Serve().
+				zlog.Logger = newLogger
+				logger = newLogger
+				_ = newCleanup // cleanup will be handled by the process lifecycle
+			}
 				logger.Info().
 					Str("log_level", logCfg.Level).
 					Str("log_file", logCfg.FilePath).


### PR DESCRIPTION
## Summary

- **SSE singleton**: per-component `new EventSource()` → shared singleton in `api.ts`, preventing HTTP/1.1 6-connection limit exhaustion on session switching
- **Compaction deadlock**: `PreloadedMessages` field avoids reentrant mutex on same transcript path
- **Verbose override**: `--verbose` now overrides `log_level: info` from workspace config
- **Request start log**: debug log emitted before handler execution for visibility
- **Manual compact UX**: aggressive thresholds + detailed API response + feedback banner

## Test plan

- [x] `make test` passes
- [x] `npm run check` passes
- [x] Manual: rapid session switching no longer causes pending requests
- [x] Manual: compact button shows result feedback (count, % saved, or reason)
- [x] Manual: `--verbose` shows HTTP request logs with workspace config