### PR TITLE
fix: OpenAICodex tool_choice mapping compile regression

### DIFF
--- a/internal/llm/openai_codex_client.go
+++ b/internal/llm/openai_codex_client.go
@@ -417,7 +417,7 @@ func buildOpenAICodexRequestBody(messages []ChatMessage, opts ChatOptions, model
 		if choice == nil {
 			choice = ToolChoiceAuto()
 		}
-		if tc := toOpenAIToolChoice(choice); tc != nil {
+		if tc := toOpenAICompatibleToolChoice(choice, openAICodexProviderLabel, opts.Tools); tc != nil {
 			body["tool_choice"] = tc
 		}
 		body["parallel_tool_calls"] = true


### PR DESCRIPTION
## Summary
- OpenAICodexClient was still calling removed toOpenAIToolChoice during kimi tool_choice compatibility change.
- Reuse OpenAI-compatible mapping helper so OpenAI-like clients compile and maintain required/auto behavior.

## Testing
- go build ./...