### PR TITLE
fix: keep duplicate kimi tool messages with latest content

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,5 +1,11 @@
 492b7b58f28d02e785a141d801722058d1caefb8:internal/secrets/secrets_test.go:generic-api-key:57
 08a26499e44fc20857f1677c50577885c679aac6:internal/config/llm_providers_field_test.go:generic-api-key:62
+# Phase 1 onboarding test fixtures (intentional fake API keys for masking-coverage tests).
+# Both the squash-merge commit on main and the original feature-branch commit are listed
+# so local clones with stale refs don't get false positives.
+58cb86efbc7e429ba9b76ec86e5b58783d5b44d3:internal/tarsserver/handler_setup_test.go:generic-api-key:60
+58cb86efbc7e429ba9b76ec86e5b58783d5b44d3:internal/tarsserver/handler_setup_test.go:generic-api-key:105
+58cb86efbc7e429ba9b76ec86e5b58783d5b44d3:internal/tarsserver/handler_setup_test.go:generic-api-key:142
 6a30cbf650aac28ea962ca29fbc792bd12743ffd:internal/tarsserver/handler_setup_test.go:generic-api-key:60
 6a30cbf650aac28ea962ca29fbc792bd12743ffd:internal/tarsserver/handler_setup_test.go:generic-api-key:105
 6a30cbf650aac28ea962ca29fbc792bd12743ffd:internal/tarsserver/handler_setup_test.go:generic-api-key:142

--- a/internal/llm/openai_compat_client.go
+++ b/internal/llm/openai_compat_client.go
@@ -487,24 +487,11 @@ func toOpenAIWireMessages(messages []ChatMessage, includeKimiReasoningContent bo
 		}
 	}
 
-	latestAssistantIndex := map[string]int{}
-	for i, m := range messages {
-		if strings.TrimSpace(m.Role) != "assistant" {
-			continue
-		}
-		for _, tc := range m.ToolCalls {
-			id := strings.TrimSpace(tc.ID)
-			if id == "" {
-				continue
-			}
-			if strings.TrimSpace(tc.Name) == "" {
-				continue
-			}
-			latestAssistantIndex[id] = i
-		}
-	}
-
-	toolMessageIndexes := map[int]struct{}{}
+	// Collect the latest tool message for each tool_call_id so we can keep
+	// every tool slot in the original assistant→tool sequence (kimi's API
+	// rejects orphan assistant tool_calls) while ensuring all duplicates
+	// surface the most recent result content.
+	latestToolMessageByID := map[string]ChatMessage{}
 	seenToolID := map[string]bool{}
 	for i := len(messages) - 1; i >= 0; i-- {
 		m := messages[i]
@@ -515,22 +502,15 @@ func toOpenAIWireMessages(messages []ChatMessage, includeKimiReasoningContent bo
 		if id == "" {
 			continue
 		}
-		assistantIdx, ok := latestAssistantIndex[id]
-		if !ok {
-			continue
-		}
-		if i <= assistantIdx {
-			continue
-		}
 		if seenToolID[id] {
 			continue
 		}
 		seenToolID[id] = true
-		toolMessageIndexes[i] = struct{}{}
+		latestToolMessageByID[id] = m
 	}
 
 	out := make([]openAIWireMessage, 0, len(messages))
-	for i, m := range messages {
+	for _, m := range messages {
 		if strings.TrimSpace(m.Role) == "tool" {
 			if len(assistantToolCalls) == 0 {
 				continue
@@ -539,8 +519,9 @@ func toOpenAIWireMessages(messages []ChatMessage, includeKimiReasoningContent bo
 			if _, ok := assistantToolCalls[id]; !ok {
 				continue
 			}
-			if _, ok := toolMessageIndexes[i]; !ok {
-				continue
+			if latest, ok := latestToolMessageByID[id]; ok {
+				m = latest
+				m.ToolCallID = id
 			}
 		}
 		wire := openAIWireMessage{


### PR DESCRIPTION
## Summary

Fixes the long-standing red CI test \`TestOpenAICompatibleChat_KimiFiltersStaleToolMessagesAndKeepsLatestForDuplicatedToolCallID\` introduced in #629. The test asserts that when an \`assistant→tool→assistant→tool\` sequence reuses the same \`tool_call_id\`, both tool slots stay in place with the latest content. The previous dedup pass dropped the earlier tool slot, leaving the first assistant tool_call orphaned — which kimi's API rejects.

The fix replaces dedup-by-position with content-rewrite:
- Every tool message whose \`tool_call_id\` matches a real assistant tool_call is **kept in its original position**.
- Its content is **replaced with the latest result** for that \`tool_call_id\` (latest wins, walking from the end).
- Orphan tool messages (no matching assistant) are still filtered out — covered by \`KimiFiltersToolMessagesWithoutMatchingAssistantToolCalls\`.

Also includes a small chore commit to refresh \`.gitleaksignore\` SHAs after the Phase 1 squash merge (#638) so CI's gitleaks pass stays green.

Closes #639

## Commits

1. \`fix: keep duplicate kimi tool messages with latest content\` — the actual fix (~30-line diff in \`internal/llm/openai_compat_client.go\`)
2. \`chore: refresh gitleaksignore SHAs after Phase 1 squash\` — adds the new squash-merge SHA to the existing fixture-key whitelist; old SHA preserved for local clones with stale refs

## Test plan

- [x] All 5 \`TestOpenAICompatibleChat_Kimi*\` subtests pass:
  - \`KimiSkipsReasoningAndServiceTierWithTools\`
  - \`KimiRequestIncludesReasoningContentForAssistantToolCallMessage\`
  - \`KimiFiltersToolMessagesWithoutMatchingAssistantToolCalls\` (orphan still dropped)
  - \`KimiFiltersStaleToolMessagesAndKeepsLatestForDuplicatedToolCallID\` (this PR's target)
  - \`KimiTrimsToolCallIDsForWirePayload\`
- [x] \`make test\` — green
- [x] \`make vet\` — clean
- [x] \`make security-scan\` — green

## Wire-payload behavior change

Before this PR (input = assistant₁ → tool[old] → assistant₂ → tool[new], all sharing \`cron:1\`):
\`\`\`
[assistant₁ + tool_call cron:1, assistant₂ + tool_call cron:1, tool cron:1 → "new"]
\`\`\`
↑ assistant₁ has an orphaned tool_call.

After this PR:
\`\`\`
[assistant₁ + tool_call cron:1, tool cron:1 → "new", assistant₂ + tool_call cron:1, tool cron:1 → "new"]
\`\`\`
↑ structural pairing intact, both tool slots reflect the latest result.