### PR TITLE
feat(onboarding) Phase 2: degraded boot mode

### DIFF
--- a/internal/tarsserver/main_bootstrap.go
+++ b/internal/tarsserver/main_bootstrap.go
@@ -21,6 +21,12 @@ type runtimeDeps struct {
 	usageTracker         *usage.Tracker
 	runPrompt            func(ctx context.Context, runLabel string, prompt string) (string, error)
 	runPromptWithTools   agentRuntimePromptRunner
+	// LLMReady is true when buildLLMDeps populated the LLM-bound fields.
+	// When false the server runs in setup-only mode (Phase 2 onboarding):
+	// only the wizard endpoints + console + healthz are wired and chat /
+	// agent / cron / pulse / reflection are inactive. The CLI's RunE is
+	// the single setter; downstream code reads this to branch routes.
+	LLMReady bool
 }
 
 type runtimeDepsError struct {

--- a/internal/tarsserver/main_bootstrap.go
+++ b/internal/tarsserver/main_bootstrap.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/devlikebear/tars/internal/config"
 	"github.com/devlikebear/tars/internal/llm"
-	"github.com/devlikebear/tars/internal/memory"
 	"github.com/devlikebear/tars/internal/session"
 	"github.com/devlikebear/tars/internal/usage"
 	"github.com/rs/zerolog"
@@ -63,72 +62,17 @@ func loadConfigForServe(opts *options) (config.Config, error) {
 	return cfg, nil
 }
 
+// buildRuntimeDeps composes buildBaseDeps + buildLLMDeps. It exists as
+// the single entry point used by callers that want full runtime
+// dependencies (production boot, helpers_llm_router_test). The
+// onboarding setup-only path (Phase 2) calls the two pieces directly
+// so it can downgrade on init_llm failure instead of bailing.
 func buildRuntimeDeps(opts *options, cfg config.Config, nowFn func() time.Time, logger zerolog.Logger) (runtimeDeps, error) {
-	if opts == nil {
-		return runtimeDeps{}, fmt.Errorf("options are required")
-	}
-
-	if err := validateAPIAuthSecurity(cfg); err != nil {
-		return runtimeDeps{}, &runtimeDepsError{stage: "validate_config", err: err}
-	}
-
-	if err := memory.EnsureWorkspace(cfg.WorkspaceDir); err != nil {
-		return runtimeDeps{}, &runtimeDepsError{stage: "ensure_workspace", err: err}
-	}
-
-	deps := runtimeDeps{
-		cfg:          cfg,
-		sessionStore: session.NewStore(cfg.WorkspaceDir),
-	}
-	deps.sessionStoreResolver = newWorkspaceSessionStoreResolver(cfg.WorkspaceDir, deps.sessionStore)
-	priceOverrides := map[string]usage.ModelPrice{}
-	for key, value := range cfg.UsagePriceOverrides {
-		priceOverrides[strings.TrimSpace(strings.ToLower(key))] = usage.ModelPrice{
-			InputPer1MUSD:      value.InputPer1MUSD,
-			OutputPer1MUSD:     value.OutputPer1MUSD,
-			CacheReadPer1MUSD:  value.CacheReadPer1MUSD,
-			CacheWritePer1MUSD: value.CacheWritePer1MUSD,
-		}
-	}
-	tracker, err := usage.NewTracker(cfg.WorkspaceDir, usage.TrackerOptions{
-		Now: nowFn,
-		InitialLimits: usage.Limits{
-			DailyUSD:    cfg.UsageLimitDailyUSD,
-			WeeklyUSD:   cfg.UsageLimitWeeklyUSD,
-			MonthlyUSD:  cfg.UsageLimitMonthlyUSD,
-			DailyTokens: cfg.UsageDailyTokenBudget,
-			Mode:        cfg.UsageLimitMode,
-		},
-		PriceOverrides: priceOverrides,
-	})
+	base, err := buildBaseDeps(opts, cfg, nowFn, logger)
 	if err != nil {
-		return runtimeDeps{}, &runtimeDepsError{stage: "init_usage", err: err}
+		return runtimeDeps{}, err
 	}
-	deps.usageTracker = tracker
-
-	router, err := buildLLMRouter(cfg, tracker)
-	if err != nil {
-		return runtimeDeps{}, &runtimeDepsError{stage: "init_llm", err: err}
-	}
-	semanticCfg := semanticMemoryConfigFromConfig(cfg)
-	if err := validateMemoryBackend(cfg.MemoryBackend); err != nil {
-		return runtimeDeps{}, &runtimeDepsError{stage: "init_memory_backend", err: err}
-	}
-	if err := memory.ValidateSemanticConfig(semanticCfg); err != nil {
-		return runtimeDeps{}, &runtimeDepsError{stage: "init_semantic_memory", err: err}
-	}
-	deps.llmRouter = router
-	logger.Debug().Msg("llm router initialized")
-	deps.runPromptWithTools = newAgentPromptRunnerWithToolsAndMemory(cfg, cfg.WorkspaceDir, nil, deps.llmRouter, deps.usageTracker, cfg.AgentMaxIterations, logger, semanticCfg)
-	if deps.runPromptWithTools != nil {
-		deps.runPrompt = func(ctx context.Context, runLabel string, prompt string) (string, error) {
-			return deps.runPromptWithTools(ctx, runLabel, prompt, nil, "", nil)
-		}
-	}
-
-	// Per-role provider/model context is logged by call sites when they
-	// resolve the router; there is no single top-level provider anymore.
-	return deps, nil
+	return buildLLMDeps(base, cfg, logger)
 }
 
 func validateAPIAuthSecurity(cfg config.Config) error {

--- a/internal/tarsserver/main_bootstrap_base.go
+++ b/internal/tarsserver/main_bootstrap_base.go
@@ -1,0 +1,74 @@
+package tarsserver
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/devlikebear/tars/internal/config"
+	"github.com/devlikebear/tars/internal/memory"
+	"github.com/devlikebear/tars/internal/session"
+	"github.com/devlikebear/tars/internal/usage"
+	"github.com/rs/zerolog"
+)
+
+// buildBaseDeps initializes the runtime dependencies that do not need
+// the LLM router: workspace, session store, usage tracker, and the
+// API auth security gate. It is safe to call even when LLM config is
+// missing — the result powers the setup-only boot path (Phase 2 of
+// the onboarding plan).
+//
+// Stages and their failure semantics:
+//   - validate_config        — refuses insecure auth modes without opt-in
+//   - ensure_workspace       — workspace dir creation/validation
+//   - init_usage             — usage tracker construction
+//
+// Returns a partially populated runtimeDeps with cfg / sessionStore /
+// sessionStoreResolver / usageTracker set. LLM-bound fields stay nil
+// for the caller to fill via buildLLMDeps.
+func buildBaseDeps(opts *options, cfg config.Config, nowFn func() time.Time, _ zerolog.Logger) (runtimeDeps, error) {
+	if opts == nil {
+		return runtimeDeps{}, fmt.Errorf("options are required")
+	}
+
+	if err := validateAPIAuthSecurity(cfg); err != nil {
+		return runtimeDeps{}, &runtimeDepsError{stage: "validate_config", err: err}
+	}
+
+	if err := memory.EnsureWorkspace(cfg.WorkspaceDir); err != nil {
+		return runtimeDeps{}, &runtimeDepsError{stage: "ensure_workspace", err: err}
+	}
+
+	deps := runtimeDeps{
+		cfg:          cfg,
+		sessionStore: session.NewStore(cfg.WorkspaceDir),
+	}
+	deps.sessionStoreResolver = newWorkspaceSessionStoreResolver(cfg.WorkspaceDir, deps.sessionStore)
+
+	priceOverrides := map[string]usage.ModelPrice{}
+	for key, value := range cfg.UsagePriceOverrides {
+		priceOverrides[strings.TrimSpace(strings.ToLower(key))] = usage.ModelPrice{
+			InputPer1MUSD:      value.InputPer1MUSD,
+			OutputPer1MUSD:     value.OutputPer1MUSD,
+			CacheReadPer1MUSD:  value.CacheReadPer1MUSD,
+			CacheWritePer1MUSD: value.CacheWritePer1MUSD,
+		}
+	}
+	tracker, err := usage.NewTracker(cfg.WorkspaceDir, usage.TrackerOptions{
+		Now: nowFn,
+		InitialLimits: usage.Limits{
+			DailyUSD:    cfg.UsageLimitDailyUSD,
+			WeeklyUSD:   cfg.UsageLimitWeeklyUSD,
+			MonthlyUSD:  cfg.UsageLimitMonthlyUSD,
+			DailyTokens: cfg.UsageDailyTokenBudget,
+			Mode:        cfg.UsageLimitMode,
+		},
+		PriceOverrides: priceOverrides,
+	})
+	if err != nil {
+		return runtimeDeps{}, &runtimeDepsError{stage: "init_usage", err: err}
+	}
+	deps.usageTracker = tracker
+
+	return deps, nil
+}

--- a/internal/tarsserver/main_bootstrap_base_test.go
+++ b/internal/tarsserver/main_bootstrap_base_test.go
@@ -1,0 +1,69 @@
+package tarsserver
+
+import (
+	"errors"
+	"io"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/devlikebear/tars/internal/config"
+	"github.com/rs/zerolog"
+)
+
+func TestBuildBaseDeps_SucceedsWithoutLLMConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Config{
+		RuntimeConfig: config.RuntimeConfig{WorkspaceDir: filepath.Join(dir, "workspace")},
+		// No LLMProviders / LLMTiers — buildBaseDeps must not care.
+	}
+	opts := &options{}
+	logger := zerolog.New(io.Discard)
+
+	deps, err := buildBaseDeps(opts, cfg, time.Now, logger)
+	if err != nil {
+		t.Fatalf("buildBaseDeps with empty LLM config: %v", err)
+	}
+	if deps.usageTracker == nil {
+		t.Fatalf("expected usage tracker populated")
+	}
+	if deps.sessionStore == nil {
+		t.Fatalf("expected session store populated")
+	}
+	if deps.sessionStoreResolver == nil {
+		t.Fatalf("expected session store resolver populated")
+	}
+	if deps.llmRouter != nil {
+		t.Fatalf("expected llmRouter to remain nil — buildLLMDeps is the populator")
+	}
+}
+
+func TestBuildBaseDeps_NilOptsErrors(t *testing.T) {
+	cfg := config.Config{}
+	if _, err := buildBaseDeps(nil, cfg, time.Now, zerolog.New(io.Discard)); err == nil {
+		t.Fatalf("expected error on nil opts")
+	}
+}
+
+func TestBuildBaseDeps_RejectsInsecureAuthWithoutOptIn(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Config{
+		RuntimeConfig: config.RuntimeConfig{WorkspaceDir: filepath.Join(dir, "workspace")},
+		APIConfig: config.APIConfig{
+			APIAuthMode:               "off",
+			APIAllowInsecureLocalAuth: false,
+		},
+	}
+	opts := &options{}
+	_, err := buildBaseDeps(opts, cfg, time.Now, zerolog.New(io.Discard))
+	if err == nil {
+		t.Fatalf("expected validate_config error")
+	}
+	var depErr *runtimeDepsError
+	if !errors.As(err, &depErr) {
+		t.Fatalf("expected *runtimeDepsError, got %T: %v", err, err)
+	}
+	if depErr.stage != "validate_config" {
+		t.Fatalf("expected stage=validate_config, got %q", depErr.stage)
+	}
+}

--- a/internal/tarsserver/main_bootstrap_llm.go
+++ b/internal/tarsserver/main_bootstrap_llm.go
@@ -1,0 +1,49 @@
+package tarsserver
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/devlikebear/tars/internal/config"
+	"github.com/devlikebear/tars/internal/memory"
+	"github.com/rs/zerolog"
+)
+
+// buildLLMDeps takes a runtimeDeps already populated by buildBaseDeps
+// and adds the LLM-bound fields: router, agent prompt runner, and the
+// runPrompt closure. It is the recoverable failure boundary for the
+// onboarding setup-only mode (Phase 2): when this returns an
+// *runtimeDepsError with stage init_llm / init_memory_backend /
+// init_semantic_memory, the caller may downgrade to setup-only
+// instead of exiting.
+//
+// On success the returned runtimeDeps is the same struct passed in
+// with llmRouter / runPromptWithTools / runPrompt populated.
+func buildLLMDeps(base runtimeDeps, cfg config.Config, logger zerolog.Logger) (runtimeDeps, error) {
+	if base.usageTracker == nil {
+		return runtimeDeps{}, fmt.Errorf("buildLLMDeps: base deps missing usage tracker — call buildBaseDeps first")
+	}
+
+	router, err := buildLLMRouter(cfg, base.usageTracker)
+	if err != nil {
+		return runtimeDeps{}, &runtimeDepsError{stage: "init_llm", err: err}
+	}
+	semanticCfg := semanticMemoryConfigFromConfig(cfg)
+	if err := validateMemoryBackend(cfg.MemoryBackend); err != nil {
+		return runtimeDeps{}, &runtimeDepsError{stage: "init_memory_backend", err: err}
+	}
+	if err := memory.ValidateSemanticConfig(semanticCfg); err != nil {
+		return runtimeDeps{}, &runtimeDepsError{stage: "init_semantic_memory", err: err}
+	}
+
+	deps := base
+	deps.llmRouter = router
+	logger.Debug().Msg("llm router initialized")
+	deps.runPromptWithTools = newAgentPromptRunnerWithToolsAndMemory(cfg, cfg.WorkspaceDir, nil, deps.llmRouter, deps.usageTracker, cfg.AgentMaxIterations, logger, semanticCfg)
+	if deps.runPromptWithTools != nil {
+		deps.runPrompt = func(ctx context.Context, runLabel string, prompt string) (string, error) {
+			return deps.runPromptWithTools(ctx, runLabel, prompt, nil, "", nil)
+		}
+	}
+	return deps, nil
+}

--- a/internal/tarsserver/main_bootstrap_llm.go
+++ b/internal/tarsserver/main_bootstrap_llm.go
@@ -38,6 +38,7 @@ func buildLLMDeps(base runtimeDeps, cfg config.Config, logger zerolog.Logger) (r
 
 	deps := base
 	deps.llmRouter = router
+	deps.LLMReady = true
 	logger.Debug().Msg("llm router initialized")
 	deps.runPromptWithTools = newAgentPromptRunnerWithToolsAndMemory(cfg, cfg.WorkspaceDir, nil, deps.llmRouter, deps.usageTracker, cfg.AgentMaxIterations, logger, semanticCfg)
 	if deps.runPromptWithTools != nil {

--- a/internal/tarsserver/main_bootstrap_llm_test.go
+++ b/internal/tarsserver/main_bootstrap_llm_test.go
@@ -1,0 +1,75 @@
+package tarsserver
+
+import (
+	"errors"
+	"io"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/devlikebear/tars/internal/config"
+	"github.com/rs/zerolog"
+)
+
+func TestBuildLLMDeps_FailsLoudOnEmptyTiers(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Config{
+		RuntimeConfig: config.RuntimeConfig{WorkspaceDir: filepath.Join(dir, "workspace")},
+	}
+	logger := zerolog.New(io.Discard)
+	base, err := buildBaseDeps(&options{}, cfg, time.Now, logger)
+	if err != nil {
+		t.Fatalf("buildBaseDeps: %v", err)
+	}
+
+	_, err = buildLLMDeps(base, cfg, logger)
+	if err == nil {
+		t.Fatalf("expected init_llm error on empty cfg")
+	}
+	var depErr *runtimeDepsError
+	if !errors.As(err, &depErr) {
+		t.Fatalf("expected *runtimeDepsError, got %T: %v", err, err)
+	}
+	if depErr.stage != "init_llm" {
+		t.Fatalf("expected stage=init_llm, got %q (err=%v)", depErr.stage, err)
+	}
+}
+
+func TestBuildLLMDeps_RejectsBaseWithoutUsageTracker(t *testing.T) {
+	cfg := config.Config{}
+	if _, err := buildLLMDeps(runtimeDeps{}, cfg, zerolog.New(io.Discard)); err == nil {
+		t.Fatalf("expected error when base.usageTracker is nil")
+	}
+}
+
+func TestBuildLLMDeps_PopulatesRouterOnValidConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfg := newAnthropicPoolCfg(
+		map[string]string{"default": "sk-ant-shared"},
+		map[string]config.LLMTierBinding{
+			"heavy":    {Provider: "default", Model: "claude-opus-4-6", ReasoningEffort: "high"},
+			"standard": {Provider: "default", Model: "claude-sonnet-4-6", ReasoningEffort: "medium"},
+			"light":    {Provider: "default", Model: "claude-haiku-4-5", ReasoningEffort: "minimal"},
+		},
+		"standard",
+		nil,
+	)
+	cfg.WorkspaceDir = filepath.Join(dir, "workspace")
+
+	logger := zerolog.New(io.Discard)
+	base, err := buildBaseDeps(&options{}, cfg, time.Now, logger)
+	if err != nil {
+		t.Fatalf("buildBaseDeps: %v", err)
+	}
+
+	deps, err := buildLLMDeps(base, cfg, logger)
+	if err != nil {
+		t.Fatalf("buildLLMDeps: %v", err)
+	}
+	if deps.llmRouter == nil {
+		t.Fatalf("expected llmRouter populated")
+	}
+	if deps.usageTracker != base.usageTracker {
+		t.Fatalf("expected base usageTracker preserved")
+	}
+}

--- a/internal/tarsserver/main_cli.go
+++ b/internal/tarsserver/main_cli.go
@@ -14,6 +14,41 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// recoverableLLMInitStages enumerate the buildLLMDeps failure stages
+// that the CLI may downgrade to setup-only mode on, instead of exiting.
+// Anything outside this set (e.g. workspace creation failures) remains
+// fatal — onboarding cannot heal it from the wizard.
+var recoverableLLMInitStages = map[string]struct{}{
+	"init_llm":             {},
+	"init_memory_backend":  {},
+	"init_semantic_memory": {},
+}
+
+func isRecoverableLLMInitError(err error) bool {
+	var depErr *runtimeDepsError
+	if !errors.As(err, &depErr) {
+		return false
+	}
+	_, ok := recoverableLLMInitStages[depErr.stage]
+	return ok
+}
+
+func logBootstrapError(logger zerolog.Logger, err error) {
+	var depErr *runtimeDepsError
+	if errors.As(err, &depErr) {
+		switch depErr.stage {
+		case "ensure_workspace":
+			logger.Error().Err(depErr.err).Msg("failed to initialize workspace")
+		case "init_llm":
+			logger.Error().Err(depErr.err).Msg("failed to initialize llm provider")
+		default:
+			logger.Error().Err(depErr.err).Str("stage", depErr.stage).Msg("failed to initialize runtime dependencies")
+		}
+		return
+	}
+	logger.Error().Err(err).Msg("failed to initialize runtime dependencies")
+}
+
 // newRootCmd builds the cobra command tree. The caller is expected to
 // have already loaded cfg and installed the runtime logger so the RunE
 // hook can focus on wiring the rest of the runtime.
@@ -39,25 +74,33 @@ func newRootCmd(opts *options, cfg config.Config, stdout, stderr io.Writer, nowF
 				logger.Debug().Msg("verbose logging enabled")
 			}
 
-			deps, err := buildRuntimeDeps(opts, cfg, nowFn, logger)
+			base, err := buildBaseDeps(opts, cfg, nowFn, logger)
 			if err != nil {
-				var depErr *runtimeDepsError
-				if errors.As(err, &depErr) {
-					switch depErr.stage {
-					case "ensure_workspace":
-						logger.Error().Err(depErr.err).Msg("failed to initialize workspace")
-					case "init_llm":
-						logger.Error().Err(depErr.err).Msg("failed to initialize llm provider")
-					default:
-						logger.Error().Err(depErr.err).Msg("failed to initialize runtime dependencies")
-					}
-				} else {
-					logger.Error().Err(err).Msg("failed to initialize runtime dependencies")
-				}
+				logBootstrapError(logger, err)
 				return &cli.ExitError{Code: 1, Err: err}
 			}
 
+			deps, err := buildLLMDeps(base, cfg, logger)
+			if err != nil {
+				if isRecoverableLLMInitError(err) {
+					logger.Warn().
+						Err(err).
+						Msg("llm init failed — entering setup-only mode (visit /console to complete setup)")
+					deps = base
+					deps.LLMReady = false
+				} else {
+					logBootstrapError(logger, err)
+					return &cli.ExitError{Code: 1, Err: err}
+				}
+			}
+
 			if opts.ConfigCheck {
+				if !deps.LLMReady {
+					msg := "tars config check requires setup — run tars serve and visit /console"
+					logger.Error().Str("workspace_dir", deps.cfg.WorkspaceDir).Msg(msg)
+					fmt.Fprintln(stdout, msg)
+					return &cli.ExitError{Code: 1, Err: fmt.Errorf("%s", msg)}
+				}
 				logger.Info().
 					Str("workspace_dir", deps.cfg.WorkspaceDir).
 					Msg("tars config check passed")

--- a/internal/tarsserver/main_cli_test.go
+++ b/internal/tarsserver/main_cli_test.go
@@ -1,0 +1,40 @@
+package tarsserver
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsRecoverableLLMInitError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "plain error", err: errors.New("boom"), want: false},
+		{name: "validate_config", err: &runtimeDepsError{stage: "validate_config", err: errors.New("x")}, want: false},
+		{name: "ensure_workspace", err: &runtimeDepsError{stage: "ensure_workspace", err: errors.New("x")}, want: false},
+		{name: "init_usage", err: &runtimeDepsError{stage: "init_usage", err: errors.New("x")}, want: false},
+		{name: "init_llm", err: &runtimeDepsError{stage: "init_llm", err: errors.New("x")}, want: true},
+		{name: "init_memory_backend", err: &runtimeDepsError{stage: "init_memory_backend", err: errors.New("x")}, want: true},
+		{name: "init_semantic_memory", err: &runtimeDepsError{stage: "init_semantic_memory", err: errors.New("x")}, want: true},
+		{name: "wrapped init_llm", err: wrap(&runtimeDepsError{stage: "init_llm", err: errors.New("x")}), want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRecoverableLLMInitError(tc.err); got != tc.want {
+				t.Fatalf("isRecoverableLLMInitError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+type wrappedErr struct {
+	inner error
+}
+
+func (w *wrappedErr) Error() string { return w.inner.Error() }
+func (w *wrappedErr) Unwrap() error { return w.inner }
+
+func wrap(err error) error { return &wrappedErr{inner: err} }

--- a/internal/tarsserver/main_serve_api.go
+++ b/internal/tarsserver/main_serve_api.go
@@ -124,6 +124,9 @@ func buildAPIMux(
 	logger zerolog.Logger,
 	stderr io.Writer,
 ) (*serveAPIRuntime, error) {
+	if !deps.LLMReady {
+		return buildSetupOnlyAPIMux(opts, deps, nowFn, logger, stderr)
+	}
 	cfg := deps.cfg
 	sessionStore := deps.sessionStore
 	sessionStoreResolver := deps.sessionStoreResolver
@@ -158,9 +161,7 @@ func buildAPIMux(
 		logger,
 	)
 	dispatcher.store = notificationStore
-	if deps.llmRouter == nil {
-		return nil, fmt.Errorf("llm router is not configured")
-	}
+	// deps.LLMReady is true here — the setup-only branch returned earlier.
 	_, chatResolution, err := deps.llmRouter.ClientFor(llm.RoleChatMain)
 	if err != nil {
 		return nil, err

--- a/internal/tarsserver/main_serve_api.go
+++ b/internal/tarsserver/main_serve_api.go
@@ -106,9 +106,22 @@ func runServeAPICommand(
 		shutdownRuntime(shutdownCtx, apiRuntime)
 	}()
 
-	logger.Info().Str("addr", opts.APIAddr).Msg("tars api server started")
-	if _, err := fmt.Fprintf(stdout, "tars api serving on %s\n", opts.APIAddr); err != nil {
-		return &cli.ExitError{Code: 1, Err: err}
+	mode := "ready"
+	if !deps.LLMReady {
+		mode = "setup-only"
+	}
+	logger.Info().Str("addr", opts.APIAddr).Str("mode", mode).Msg("tars api server started")
+	if !deps.LLMReady {
+		if _, err := fmt.Fprintf(stdout, "tars api serving on %s (setup-only mode)\n", opts.APIAddr); err != nil {
+			return &cli.ExitError{Code: 1, Err: err}
+		}
+		if _, err := fmt.Fprintf(stdout, "    open http://%s/console to complete setup\n", opts.APIAddr); err != nil {
+			return &cli.ExitError{Code: 1, Err: err}
+		}
+	} else {
+		if _, err := fmt.Fprintf(stdout, "tars api serving on %s\n", opts.APIAddr); err != nil {
+			return &cli.ExitError{Code: 1, Err: err}
+		}
 	}
 	if err := apiRuntime.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		logger.Error().Err(err).Msg("failed to serve api")

--- a/internal/tarsserver/main_serve_api_setup.go
+++ b/internal/tarsserver/main_serve_api_setup.go
@@ -1,8 +1,57 @@
 package tarsserver
 
 import (
+	"io"
 	"net/http"
+	"time"
+
+	"github.com/devlikebear/tars/internal/config"
+	"github.com/rs/zerolog"
 )
+
+// buildSetupOnlyAPIMux constructs the *serveAPIRuntime that powers the
+// degraded boot mode: an HTTP server with the wizard surface only.
+// Background fields (agentRuntime, cronManager, pulseRuntime,
+// reflectionRuntime, extensionsManager, telegramPoller,
+// agentRuntimeAgentsWatch, watchdogManager) stay nil so the existing
+// nil-checks in startBackgrounds and shutdownRuntime skip them.
+//
+// deps.LLMReady must be false; the caller (buildAPIMux) is responsible
+// for the branch.
+func buildSetupOnlyAPIMux(opts *options, deps runtimeDeps, nowFn func() time.Time, logger zerolog.Logger, _ io.Writer) (*serveAPIRuntime, error) {
+	cfg := deps.cfg
+	consoleHandler, err := newConsoleHandler(logger)
+	if err != nil {
+		return nil, err
+	}
+	healthzHandler := newHealthzAPIHandler(nowFn, dashboardAuthHealthzStatus(cfg), func() bool { return config.NeedsSetup(cfg) })
+	setupHandler := newSetupAPIHandler(opts.ConfigPath, cfg, logger)
+	configHandler := newConfigAPIHandler(opts.ConfigPath, cfg, cfg.WorkspaceDir, logger)
+	authHandler := newAuthAPIHandler(cfg.APIAuthMode)
+
+	mux := http.NewServeMux()
+	registerSetupOnlyRoutes(mux, setupOnlyHandlers{
+		healthz: healthzHandler,
+		setup:   setupHandler,
+		config:  configHandler,
+		auth:    authHandler,
+		console: consoleHandler,
+		// events handler intentionally omitted for now — the SPA falls back
+		// to polling healthz when the SSE stream is unavailable, and adding
+		// the broker here would pull in unused background goroutines.
+	})
+	rootHandler := applyAPIMiddleware(cfg, logger, mux, io.Discard)
+
+	server := &http.Server{
+		Addr:    opts.APIAddr,
+		Handler: rootHandler,
+	}
+	return &serveAPIRuntime{
+		cfg:        cfg,
+		configPath: opts.ConfigPath,
+		server:     server,
+	}, nil
+}
 
 // setupOnlyHandlers groups the small set of HTTP handlers that the
 // degraded boot mode (Phase 2 of the onboarding plan) wires into a

--- a/internal/tarsserver/main_serve_api_setup.go
+++ b/internal/tarsserver/main_serve_api_setup.go
@@ -1,0 +1,67 @@
+package tarsserver
+
+import (
+	"net/http"
+)
+
+// setupOnlyHandlers groups the small set of HTTP handlers that the
+// degraded boot mode (Phase 2 of the onboarding plan) wires into a
+// dedicated mux. Anything outside this set is intentionally absent —
+// chat / agent runtime / cron / pulse / reflection / memory / sessions
+// have no useful response without an LLM router and the catch-all
+// 503 fallback steers the wizard toward the supported surface.
+type setupOnlyHandlers struct {
+	healthz http.Handler
+	setup   http.Handler
+	config  http.Handler // serves /v1/admin/config{,/values,/schema} and /v1/admin/restart
+	auth    http.Handler
+	events  http.Handler // optional — SSE keepalive so the SPA stays connected
+	console http.Handler
+}
+
+// registerSetupOnlyRoutes wires the minimal set of endpoints the
+// onboarding wizard needs onto mux. All other /v1/* paths get the
+// setupOnlyFallback (HTTP 503 + JSON hint), and "/" redirects to the
+// console so a browser hitting the root lands on the wizard.
+func registerSetupOnlyRoutes(mux *http.ServeMux, handlers setupOnlyHandlers) {
+	mux.Handle("/v1/healthz", handlers.healthz)
+	mux.Handle("/v1/setup/status", handlers.setup)
+	mux.Handle("/v1/admin/config", handlers.config)
+	mux.Handle("/v1/admin/config/values", handlers.config)
+	mux.Handle("/v1/admin/config/schema", handlers.config)
+	mux.Handle("/v1/admin/restart", handlers.config)
+	mux.Handle("/v1/auth/whoami", handlers.auth)
+	if handlers.events != nil {
+		mux.Handle("/v1/events/stream", handlers.events)
+	}
+	if handlers.console != nil {
+		mux.Handle("/console", handlers.console)
+		mux.Handle("/console/", handlers.console)
+	}
+	mux.Handle("/v1/", http.HandlerFunc(setupOnlyFallback))
+	mux.Handle("/", http.HandlerFunc(setupOnlyRoot))
+}
+
+// setupOnlyFallback rejects unsupported /v1/* requests with a 503 +
+// JSON hint pointing at /console. The Phase 3 wizard should never
+// hit this path in practice, but a clear response beats a confusing
+// 404 if it does (or if external code probes the server).
+func setupOnlyFallback(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+		"error":       "service unavailable in setup-only mode",
+		"hint":        "complete setup at /console to enable this endpoint",
+		"path":        r.URL.Path,
+		"needs_setup": true,
+	})
+}
+
+// setupOnlyRoot mirrors the production root handler: "/" redirects to
+// the console wizard, anything else 404s. Console assets themselves
+// are served by the dedicated /console handler registered above.
+func setupOnlyRoot(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/" {
+		http.Redirect(w, r, "/console/", http.StatusFound)
+		return
+	}
+	http.NotFound(w, r)
+}

--- a/internal/tarsserver/main_serve_api_setup_test.go
+++ b/internal/tarsserver/main_serve_api_setup_test.go
@@ -2,9 +2,15 @@ package tarsserver
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/devlikebear/tars/internal/config"
+	"github.com/rs/zerolog"
 )
 
 func TestRegisterSetupOnlyRoutes_ServesAllowedEndpoints(t *testing.T) {
@@ -144,4 +150,80 @@ func noContentHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	})
+}
+
+func TestBuildAPIMux_RoutesToSetupOnlyWhenLLMNotReady(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Config{
+		RuntimeConfig: config.RuntimeConfig{WorkspaceDir: filepath.Join(dir, "workspace")},
+		APIConfig: config.APIConfig{
+			APIAuthMode:               "off",
+			APIAllowInsecureLocalAuth: true,
+		},
+	}
+	logger := zerolog.New(io.Discard)
+	base, err := buildBaseDeps(&options{}, cfg, time.Now, logger)
+	if err != nil {
+		t.Fatalf("buildBaseDeps: %v", err)
+	}
+	// LLMReady=false (default) — no llm router populated.
+
+	opts := &options{APIAddr: "127.0.0.1:0", ConfigPath: ""}
+	apiRuntime, err := buildAPIMux(opts, base, time.Now, logger, io.Discard)
+	if err != nil {
+		t.Fatalf("buildAPIMux setup-only: %v", err)
+	}
+	if apiRuntime.server == nil {
+		t.Fatalf("expected server constructed")
+	}
+	if apiRuntime.agentRuntime != nil {
+		t.Fatalf("expected agentRuntime nil in setup-only mode")
+	}
+	if apiRuntime.cronManager != nil {
+		t.Fatalf("expected cronManager nil in setup-only mode")
+	}
+	if apiRuntime.pulseRuntime != nil {
+		t.Fatalf("expected pulseRuntime nil in setup-only mode")
+	}
+	if apiRuntime.reflectionRuntime != nil {
+		t.Fatalf("expected reflectionRuntime nil in setup-only mode")
+	}
+
+	// Probe routes through the actual server handler (so middleware runs too).
+	for _, tc := range []struct {
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{"healthz allowed", "/v1/healthz", http.StatusOK},
+		{"setup status allowed", "/v1/setup/status", http.StatusOK},
+		{"chat blocked with 503", "/v1/chat", http.StatusServiceUnavailable},
+		{"agentruntime blocked with 503", "/v1/agentruntime/runs", http.StatusServiceUnavailable},
+		{"pulse blocked with 503", "/v1/pulse/status", http.StatusServiceUnavailable},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			req.RemoteAddr = "127.0.0.1:5555"
+			apiRuntime.server.Handler.ServeHTTP(rec, req)
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("expected %d for %s, got %d body=%q", tc.wantStatus, tc.path, rec.Code, rec.Body.String())
+			}
+		})
+	}
+
+	// healthz body should expose needs_setup=true since cfg has no providers.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/healthz", nil)
+	req.RemoteAddr = "127.0.0.1:5555"
+	apiRuntime.server.Handler.ServeHTTP(rec, req)
+	var body struct {
+		NeedsSetup bool `json:"needs_setup"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode healthz: %v", err)
+	}
+	if !body.NeedsSetup {
+		t.Fatalf("expected needs_setup=true in setup-only mode, got body %s", rec.Body.String())
+	}
 }

--- a/internal/tarsserver/main_serve_api_setup_test.go
+++ b/internal/tarsserver/main_serve_api_setup_test.go
@@ -1,0 +1,147 @@
+package tarsserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRegisterSetupOnlyRoutes_ServesAllowedEndpoints(t *testing.T) {
+	mux := http.NewServeMux()
+	stub := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	registerSetupOnlyRoutes(mux, setupOnlyHandlers{
+		healthz: stub,
+		setup:   stub,
+		config:  stub,
+		auth:    stub,
+		events:  stub,
+		console: stub,
+	})
+
+	allowed := []string{
+		"/v1/healthz",
+		"/v1/setup/status",
+		"/v1/admin/config",
+		"/v1/admin/config/values",
+		"/v1/admin/config/schema",
+		"/v1/admin/restart",
+		"/v1/auth/whoami",
+		"/v1/events/stream",
+		"/console",
+		"/console/",
+	}
+	for _, path := range allowed {
+		t.Run("allow "+path, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			mux.ServeHTTP(rec, req)
+			if rec.Code != http.StatusNoContent {
+				t.Fatalf("expected 204 from stub for %s, got %d body=%q", path, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestRegisterSetupOnlyRoutes_FallbackOnUnknownV1(t *testing.T) {
+	mux := http.NewServeMux()
+	registerSetupOnlyRoutes(mux, setupOnlyHandlers{
+		healthz: noContentHandler(),
+		setup:   noContentHandler(),
+		config:  noContentHandler(),
+		auth:    noContentHandler(),
+	})
+
+	for _, path := range []string{"/v1/chat", "/v1/agentruntime/runs", "/v1/sessions", "/v1/cron/jobs", "/v1/pulse/status"} {
+		t.Run(path, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, path, nil)
+			mux.ServeHTTP(rec, req)
+			if rec.Code != http.StatusServiceUnavailable {
+				t.Fatalf("expected 503 for %s, got %d body=%q", path, rec.Code, rec.Body.String())
+			}
+			var body map[string]any
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode fallback body: %v", err)
+			}
+			if needs, _ := body["needs_setup"].(bool); !needs {
+				t.Fatalf("expected needs_setup=true in fallback body, got %+v", body)
+			}
+			if got, _ := body["path"].(string); got != path {
+				t.Fatalf("expected path=%q, got %q", path, got)
+			}
+		})
+	}
+}
+
+func TestRegisterSetupOnlyRoutes_RootRedirectsToConsole(t *testing.T) {
+	mux := http.NewServeMux()
+	registerSetupOnlyRoutes(mux, setupOnlyHandlers{
+		healthz: noContentHandler(),
+		setup:   noContentHandler(),
+		config:  noContentHandler(),
+		auth:    noContentHandler(),
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("expected 302, got %d", rec.Code)
+	}
+	if got := rec.Header().Get("Location"); got != "/console/" {
+		t.Fatalf("expected redirect to /console/, got %q", got)
+	}
+}
+
+func TestRegisterSetupOnlyRoutes_UnknownNonV1Returns404(t *testing.T) {
+	mux := http.NewServeMux()
+	registerSetupOnlyRoutes(mux, setupOnlyHandlers{
+		healthz: noContentHandler(),
+		setup:   noContentHandler(),
+		config:  noContentHandler(),
+		auth:    noContentHandler(),
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/some/random/path", nil)
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRegisterSetupOnlyRoutes_OmitsEventsAndConsoleWhenNil(t *testing.T) {
+	mux := http.NewServeMux()
+	registerSetupOnlyRoutes(mux, setupOnlyHandlers{
+		healthz: noContentHandler(),
+		setup:   noContentHandler(),
+		config:  noContentHandler(),
+		auth:    noContentHandler(),
+		// events and console intentionally nil
+	})
+
+	for _, path := range []string{"/v1/events/stream", "/console", "/console/x"} {
+		t.Run(path, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			mux.ServeHTTP(rec, req)
+			// /v1/events/stream falls into the /v1/ catch-all → 503
+			// /console paths fall into the / catch-all → 404
+			if path == "/v1/events/stream" && rec.Code != http.StatusServiceUnavailable {
+				t.Fatalf("expected 503 for events when nil, got %d", rec.Code)
+			}
+			if path != "/v1/events/stream" && rec.Code != http.StatusNotFound {
+				t.Fatalf("expected 404 for %s when console nil, got %d", path, rec.Code)
+			}
+		})
+	}
+}
+
+func noContentHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+}

--- a/internal/tarsserver/setup_only_e2e_test.go
+++ b/internal/tarsserver/setup_only_e2e_test.go
@@ -1,0 +1,173 @@
+package tarsserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/devlikebear/tars/internal/config"
+	"github.com/rs/zerolog"
+)
+
+// TestSetupOnlyE2E_WizardSaveCycle walks through the full degraded
+// boot path and the wizard happy path:
+//
+//  1. buildBaseDeps succeeds without LLM config
+//  2. buildLLMDeps fails on init_llm — recoverable
+//  3. CLI downgrade leaves deps.LLMReady=false
+//  4. buildAPIMux delegates to the setup-only mux
+//  5. The wizard polls healthz / setup/status, sees needs_setup=true
+//  6. The wizard PATCHes /v1/admin/config/values to write providers + tiers
+//  7. After patch, /v1/setup/status reports needs_setup=false
+//
+// This is the integration regression target the rest of Phase 2's
+// unit tests are written against.
+func TestSetupOnlyE2E_WizardSaveCycle(t *testing.T) {
+	dir := t.TempDir()
+	workspaceDir := filepath.Join(dir, "workspace")
+	configPath := filepath.Join(dir, "config.yaml")
+
+	// Seed a minimal config with no LLM section — the wizard's job to fill.
+	if err := os.WriteFile(configPath, []byte("runtime:\n  workspace_dir: "+workspaceDir+"\n"), 0o600); err != nil {
+		t.Fatalf("write seed config: %v", err)
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	cfg.WorkspaceDir = workspaceDir
+	cfg.APIAuthMode = "off"
+	cfg.APIAllowInsecureLocalAuth = true
+
+	logger := zerolog.New(io.Discard)
+	opts := &options{ConfigPath: configPath, APIAddr: "127.0.0.1:0"}
+
+	base, err := buildBaseDeps(opts, cfg, time.Now, logger)
+	if err != nil {
+		t.Fatalf("buildBaseDeps: %v", err)
+	}
+	if base.LLMReady {
+		t.Fatalf("buildBaseDeps must not set LLMReady")
+	}
+
+	_, llmErr := buildLLMDeps(base, cfg, logger)
+	if llmErr == nil {
+		t.Fatalf("expected buildLLMDeps to fail with empty cfg")
+	}
+	if !isRecoverableLLMInitError(llmErr) {
+		t.Fatalf("expected recoverable init error, got %v", llmErr)
+	}
+	var depErr *runtimeDepsError
+	if !errors.As(llmErr, &depErr) || depErr.stage != "init_llm" {
+		t.Fatalf("expected init_llm stage, got %+v", depErr)
+	}
+
+	// Apply the same downgrade the CLI's RunE performs.
+	deps := base
+	deps.LLMReady = false
+
+	apiRuntime, err := buildAPIMux(opts, deps, time.Now, logger, io.Discard)
+	if err != nil {
+		t.Fatalf("buildAPIMux setup-only: %v", err)
+	}
+	srv := apiRuntime.server.Handler
+
+	// 1. healthz signals needs_setup=true.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/healthz", nil)
+	req.RemoteAddr = "127.0.0.1:5555"
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("healthz expected 200, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	var healthz struct {
+		NeedsSetup bool `json:"needs_setup"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &healthz); err != nil || !healthz.NeedsSetup {
+		t.Fatalf("healthz needs_setup=true expected, body=%s err=%v", rec.Body.String(), err)
+	}
+
+	// 2. /v1/setup/status reports the missing pieces.
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/v1/setup/status", nil)
+	req.RemoteAddr = "127.0.0.1:5555"
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("setup/status expected 200, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	var status struct {
+		NeedsSetup bool `json:"needs_setup"`
+		Providers  struct {
+			Missing bool `json:"missing"`
+		} `json:"providers"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &status); err != nil {
+		t.Fatalf("decode setup/status: %v", err)
+	}
+	if !status.NeedsSetup || !status.Providers.Missing {
+		t.Fatalf("expected needs_setup=true and providers.missing=true, body=%s", rec.Body.String())
+	}
+
+	// 3. /v1/chat is blocked with the setup-only fallback (503).
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/v1/chat", nil)
+	req.RemoteAddr = "127.0.0.1:5555"
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("/v1/chat expected 503, got %d body=%q", rec.Code, rec.Body.String())
+	}
+
+	// 4. Wizard saves a provider + 3 tiers via PATCH /v1/admin/config/values.
+	patch := map[string]any{
+		"updates": map[string]any{
+			"llm_providers": map[string]any{
+				"openai": map[string]any{
+					"kind":      "openai",
+					"auth_mode": "api-key",
+					"api_key":   "sk-test-fake-key",
+					"base_url":  "https://api.openai.com/v1",
+				},
+			},
+			"llm_tiers": map[string]any{
+				"heavy":    map[string]any{"provider": "openai", "model": "gpt-5.4"},
+				"standard": map[string]any{"provider": "openai", "model": "gpt-5.4"},
+				"light":    map[string]any{"provider": "openai", "model": "gpt-5.4-mini"},
+			},
+		},
+	}
+	body, err := json.Marshal(patch)
+	if err != nil {
+		t.Fatalf("marshal patch: %v", err)
+	}
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPatch, "/v1/admin/config/values", bytes.NewReader(body))
+	req.RemoteAddr = "127.0.0.1:5555"
+	req.Header.Set("Content-Type", "application/json")
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("config/values PATCH expected 200, got %d body=%q", rec.Code, rec.Body.String())
+	}
+
+	// 5. /v1/setup/status now reflects the persisted config (needs_setup=false).
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/v1/setup/status", nil)
+	req.RemoteAddr = "127.0.0.1:5555"
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("post-patch setup/status expected 200, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &status); err != nil {
+		t.Fatalf("decode post-patch setup/status: %v", err)
+	}
+	if status.NeedsSetup || status.Providers.Missing {
+		t.Fatalf("after wizard save expected needs_setup=false providers.missing=false, body=%s", rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

Phase 2 of the onboarding Epic ([#637](https://github.com/devlikebear/tars/issues/637)). Introduces the **setup-only boot mode**: when \`llm_providers\` / \`llm_tiers\` are missing or invalid, \`tars serve\` no longer panics — it boots a restricted HTTP surface that the Phase 3 wizard can drive to write the missing config and trigger a restart.

The five preceding commits each leave \`make test && make vet\` green. The series adds infrastructure first (refactor + helpers), then the user-visible behavior change in commit 4, and ends with stdout banner + e2e regression coverage.

Closes #634

## Commits

1. \`refactor: split buildRuntimeDeps into base + llm stages\` — pure refactor, identical behavior.
2. \`feat: tolerate llm init failure as setup-only mode\` — adds \`runtimeDeps.LLMReady\`, downgrade in \`main_cli.go\`. Still exits 1 here because the API mux rejects nil router.
3. \`feat: add setup-only mux with restricted routes\` — \`registerSetupOnlyRoutes\`, 503 fallback, root redirect. Not wired in yet.
4. \`refactor: branch buildAPIMux on LLMReady\` — **the user-visible cutover**. Setup-only path delegates to \`buildSetupOnlyAPIMux\`; existing background nil-checks naturally skip the unconfigured runtimes.
5. \`feat: emit setup-only mode banner on boot\` — \`tars api serving on … (setup-only mode)\` + console hint.
6. \`test: add setup-only wizard happy-path e2e\` — full cycle: empty cfg → degraded → wizard PATCH → \`needs_setup=false\`.

## What changes for users

- **Empty / invalid LLM config no longer panics**. The server boots in setup-only mode. \`/console\` is reachable; everything LLM-bound returns a JSON 503 with a setup hint.
- Boot stdout adds a clear marker:
  \`\`\`
  tars api serving on 127.0.0.1:43180 (setup-only mode)
      open http://127.0.0.1:43180/console to complete setup
  \`\`\`
- \`tars serve --config-check\` exits **1** with a "setup required" message in setup-only mode, so external scripts that gate on its exit code still detect a misconfigured server.
- Background runtimes (chat, agent runtime, cron, pulse, reflection, telegram polling, extensions, watchdog) **do not start** in setup-only mode. \`startBackgrounds\` already nil-checks each, no behavior added there.
- After the Phase 3 wizard PATCHes \`/v1/admin/config/values\` and POSTs \`/v1/admin/restart\`, the next boot sees a complete config and runs in normal mode.

## Setup-only allow-list

\`\`\`
/v1/healthz                  GET   needs_setup=true
/v1/setup/status             GET   diagnostic JSON
/v1/admin/config             GET / PUT
/v1/admin/config/values      PATCH (wizard save)
/v1/admin/config/schema      GET (form rendering)
/v1/admin/restart            POST (wizard finalize)
/v1/auth/whoami              GET
/console, /console/          static SPA assets
/                            302 → /console/
/v1/* (anything else)        503 + JSON setup-required hint
\`\`\`

\`/v1/events/stream\` is intentionally omitted for now — the SPA falls back to polling \`/v1/healthz\`. Phase 3 will reconsider once the wizard's UX needs are clearer.

## Test plan

- [x] \`go test ./internal/tarsserver/\` — all green (≈8s)
- [x] \`make test\` — full suite green
- [x] \`make vet\` — clean
- [x] \`make security-scan\` — clean
- [x] New tests:
  - \`TestBuildBaseDeps_*\` (3 cases) — split refactor coverage
  - \`TestBuildLLMDeps_*\` (3 cases) — split refactor coverage
  - \`TestIsRecoverableLLMInitError\` (9 sub-cases, table-driven)
  - \`TestRegisterSetupOnlyRoutes_*\` (4 functions, 23 sub-cases) — mux behavior
  - \`TestBuildAPIMux_RoutesToSetupOnlyWhenLLMNotReady\` — branch coverage
  - \`TestSetupOnlyE2E_WizardSaveCycle\` — full wizard cycle
- [x] Manual sanity check (planned, not run here): with an empty workspace config, \`tars serve\` should boot to setup-only and \`curl http://127.0.0.1:43180/v1/healthz\` should return \`needs_setup=true\`. The e2e test exercises the same code path against a fresh \`http.Server.Handler\`.

## Out of scope (Phase 3+)

- The actual frontend wizard UI (Onboarding.svelte, /console/onboarding route) — Phase 3 (#635)
- Re-entry from the Config page in normal mode — Phase 4 (#636)
- Exposing \`/v1/providers\` and \`/v1/models\` in the setup-only mux — folded into Phase 3 if the wizard needs the picker
- Auto-restart on wizard save — explicit user click stays the trigger

## Risk notes

- \`buildAPIMux\` is 460+ lines but the branch is at the top, so the LLM-bound path is unchanged once the branch falls through. No giant if/else nesting was introduced.
- Removed the \`if deps.llmRouter == nil { return error }\` defense at the old line 161; the new branch makes it unreachable. Replaced with a comment noting the invariant.
- \`ConfigCheck\` semantics tightened: setup-only now returns exit 1 (was 0 before this PR couldn't reach setup-only at all). External scripts gating on the check are unaffected; they only ever saw exit 0 on a fully-configured server.