### PR TITLE
feat(onboarding) Phase 3: frontend onboarding wizard

### DIFF
--- a/frontend/console/src/App.svelte
+++ b/frontend/console/src/App.svelte
@@ -16,13 +16,15 @@
   import Pulse from './components/Pulse.svelte'
   import Reflection from './components/Reflection.svelte'
   import Channels from './components/Channels.svelte'
+  import Onboarding from './components/Onboarding.svelte'
   import AgentRuntimeRunView from './components/AgentRuntimeRunView.svelte'
   import { resolveRoute, type Route } from './lib/router'
-  import { getEventsHistory, streamEvents } from './lib/api'
+  import { getEventsHistory, getHealthz, streamEvents } from './lib/api'
 
   let currentPath = $state('/console')
   let route = $state<Route>({ view: 'home' })
   let serverHealth = $state('connecting')
+  let needsSetup = $state(false)
   let unreadCount = $state(0)
   let aiPrompt = $state('')
   let stopGlobalStream: (() => void) | null = null
@@ -59,10 +61,29 @@
     )
   }
 
+  async function checkSetupAndMaybeRedirect() {
+    try {
+      const health = await getHealthz()
+      needsSetup = !!health.needs_setup
+      if (needsSetup && route.view !== 'onboarding') {
+        navigate('/console/onboarding')
+      }
+    } catch {
+      // healthz fetch failed — let the SSE stream surface the disconnect
+    }
+  }
+
+  function handleOnboardingComplete() {
+    needsSetup = false
+    navigate('/console')
+  }
+
   onMount(() => {
     syncFromBrowser()
     const onPopState = () => syncFromBrowser()
     window.addEventListener('popstate', onPopState)
+
+    void checkSetupAndMaybeRedirect()
 
     getEventsHistory(1)
       .then((h) => { unreadCount = h.unread_count ?? 0 })
@@ -82,10 +103,13 @@
   {currentPath}
   {serverHealth}
   {unreadCount}
+  {needsSetup}
   onNavigate={navigate}
   onUnreadChange={(count) => { unreadCount = count }}
 >
-  {#if route.view === 'home'}
+  {#if route.view === 'onboarding'}
+    <Onboarding onComplete={handleOnboardingComplete} />
+  {:else if route.view === 'home'}
     <Home onNavigate={navigate} />
   {:else if route.view === 'chat'}
     {#key aiPrompt}

--- a/frontend/console/src/components/Onboarding.svelte
+++ b/frontend/console/src/components/Onboarding.svelte
@@ -1,0 +1,566 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import {
+    getHealthz,
+    getSetupStatus,
+    patchConfigValues,
+    restartServer,
+  } from '../lib/api'
+  import {
+    buildConfigPayload,
+    defaultBaseURLForKind,
+    emptyOnboardingForm,
+    providerKinds,
+    suggestedAuthModeForKind,
+    validateForm,
+    validateProviderStep,
+    validateTiersStep,
+    type AuthMode,
+    type OnboardingFormState,
+    type ProviderKind,
+  } from '../lib/onboarding'
+  import type { SetupStatusResponse } from '../lib/types'
+
+  interface Props {
+    onComplete?: () => void
+  }
+  let { onComplete }: Props = $props()
+
+  type StepId = 'provider' | 'tiers' | 'review' | 'restarting'
+
+  let step = $state<StepId>('provider')
+  let form = $state<OnboardingFormState>(emptyOnboardingForm())
+  let setupStatus = $state<SetupStatusResponse | null>(null)
+  let stepErrors = $state<string[]>([])
+  let saveError = $state<string>('')
+  let restartPhase = $state<'idle' | 'patching' | 'restarting' | 'polling' | 'ready' | 'timeout'>('idle')
+  let pollDeadline = $state<number>(0)
+
+  onMount(async () => {
+    try {
+      setupStatus = await getSetupStatus()
+    } catch (err) {
+      // status fetch is optional — wizard still works on empty fields
+      console.warn('setup status fetch failed', err)
+    }
+  })
+
+  const stepOrder: StepId[] = ['provider', 'tiers', 'review', 'restarting']
+  const stepLabels: Record<StepId, string> = {
+    provider: 'Provider',
+    tiers: 'Tiers',
+    review: 'Review',
+    restarting: 'Restart',
+  }
+
+  function progressIndex(current: StepId): number {
+    return stepOrder.indexOf(current)
+  }
+
+  function handleKindChange(value: string) {
+    const kind = value as ProviderKind | ''
+    form.provider.kind = kind
+    if (form.provider.base_url.trim() === '') {
+      form.provider.base_url = defaultBaseURLForKind(kind)
+    }
+    form.provider.auth_mode = suggestedAuthModeForKind(kind) as AuthMode
+    if (form.provider.alias.trim() === '' && kind !== '') {
+      form.provider.alias = kind
+    }
+  }
+
+  function syncTiersToWizardAlias() {
+    const alias = form.provider.alias.trim()
+    if (alias === '') return
+    for (const tier of ['heavy', 'standard', 'light'] as const) {
+      if (form.tiers[tier].provider.trim() === '') {
+        form.tiers[tier].provider = alias
+      }
+    }
+  }
+
+  function goToTiers() {
+    stepErrors = validateProviderStep(form)
+    if (stepErrors.length === 0) {
+      syncTiersToWizardAlias()
+      step = 'tiers'
+    }
+  }
+
+  function goToReview() {
+    stepErrors = validateTiersStep(form)
+    if (stepErrors.length === 0) {
+      step = 'review'
+    }
+  }
+
+  function goBack(target: StepId) {
+    stepErrors = []
+    saveError = ''
+    step = target
+  }
+
+  async function handleSave() {
+    const formErrors = validateForm(form)
+    if (formErrors.length > 0) {
+      stepErrors = formErrors
+      return
+    }
+    stepErrors = []
+    saveError = ''
+    step = 'restarting'
+    restartPhase = 'patching'
+    try {
+      await patchConfigValues(buildConfigPayload(form))
+    } catch (err) {
+      saveError = (err as Error).message || 'failed to save config'
+      restartPhase = 'idle'
+      step = 'review'
+      return
+    }
+    restartPhase = 'restarting'
+    try {
+      await restartServer()
+    } catch (err) {
+      saveError = (err as Error).message || 'failed to trigger restart'
+      restartPhase = 'idle'
+      step = 'review'
+      return
+    }
+    restartPhase = 'polling'
+    pollDeadline = Date.now() + 30_000
+    pollUntilReady()
+  }
+
+  async function pollUntilReady() {
+    while (Date.now() < pollDeadline) {
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+      try {
+        const health = await getHealthz()
+        if (!health.needs_setup) {
+          restartPhase = 'ready'
+          if (onComplete) onComplete()
+          return
+        }
+      } catch {
+        // server is restarting — connection refused is expected
+      }
+    }
+    restartPhase = 'timeout'
+  }
+
+  function maskedKey(key: string): string {
+    const trimmed = key.trim()
+    if (trimmed.length === 0) return '(none)'
+    if (trimmed.length <= 8) return '*'.repeat(trimmed.length)
+    return trimmed.slice(0, 4) + '*'.repeat(trimmed.length - 8) + trimmed.slice(-4)
+  }
+</script>
+
+<section class="onboarding">
+  <header class="onboarding-header">
+    <span class="onboarding-kicker">First-run setup</span>
+    <h1>TARS 설정 마법사</h1>
+    <p>최소 LLM provider 1개와 3개 tier(heavy/standard/light) 바인딩만 입력하면 콘솔이 활성화됩니다.</p>
+  </header>
+
+  <ol class="onboarding-progress">
+    {#each stepOrder as stepKey, idx}
+      <li class:active={step === stepKey} class:done={idx < progressIndex(step)}>
+        <span class="onboarding-progress-dot">{idx + 1}</span>
+        <span class="onboarding-progress-label">{stepLabels[stepKey]}</span>
+      </li>
+    {/each}
+  </ol>
+
+  {#if stepErrors.length > 0 && step !== 'restarting'}
+    <div class="onboarding-errors">
+      <strong>입력을 확인해주세요</strong>
+      <ul>
+        {#each stepErrors as err}
+          <li>{err}</li>
+        {/each}
+      </ul>
+    </div>
+  {/if}
+
+  {#if step === 'provider'}
+    <section class="card">
+      <div class="card-header">
+        <span class="card-title">Step 1 · Provider 등록</span>
+      </div>
+      <div class="onboarding-grid">
+        <label class="onboarding-field">
+          <span>Provider 종류 <em>Kind</em></span>
+          <select value={form.provider.kind} onchange={(e) => handleKindChange((e.currentTarget as HTMLSelectElement).value)}>
+            <option value="">선택하세요…</option>
+            {#each providerKinds as kind}
+              <option value={kind}>{kind}</option>
+            {/each}
+          </select>
+        </label>
+
+        <label class="onboarding-field">
+          <span>Alias <em>llm_providers의 키</em></span>
+          <input type="text" bind:value={form.provider.alias} placeholder="openai, codex, kimi 등" />
+        </label>
+
+        <label class="onboarding-field">
+          <span>인증 모드 <em>auth_mode</em></span>
+          <select bind:value={form.provider.auth_mode}>
+            <option value="api-key">api-key</option>
+            <option value="oauth">oauth</option>
+          </select>
+        </label>
+
+        {#if form.provider.auth_mode === 'api-key'}
+          <label class="onboarding-field">
+            <span>API Key</span>
+            <input type="password" bind:value={form.provider.api_key} autocomplete="new-password" placeholder="sk-…" />
+          </label>
+        {/if}
+
+        <label class="onboarding-field">
+          <span>Base URL <em>비우면 kind 기본값 사용</em></span>
+          <input type="url" bind:value={form.provider.base_url} placeholder={defaultBaseURLForKind(form.provider.kind)} />
+        </label>
+
+        {#if form.provider.auth_mode === 'oauth'}
+          <label class="onboarding-field">
+            <span>OAuth Provider <em>선택</em></span>
+            <input type="text" bind:value={form.provider.oauth_provider} placeholder="openai-codex" />
+          </label>
+        {/if}
+      </div>
+
+      <div class="onboarding-actions">
+        <span class="onboarding-spacer"></span>
+        <button class="btn btn-primary" type="button" onclick={goToTiers}>다음: Tier 설정 →</button>
+      </div>
+    </section>
+  {:else if step === 'tiers'}
+    <section class="card">
+      <div class="card-header">
+        <span class="card-title">Step 2 · Tier 바인딩</span>
+        <span class="card-meta">heavy / standard / light 모두 모델을 지정해야 합니다.</span>
+      </div>
+      <div class="onboarding-tier-grid">
+        {#each ['heavy', 'standard', 'light'] as const as tier}
+          <fieldset class="onboarding-tier">
+            <legend>{tier}</legend>
+            <label class="onboarding-field">
+              <span>Provider alias</span>
+              <input type="text" bind:value={form.tiers[tier].provider} />
+            </label>
+            <label class="onboarding-field">
+              <span>Model</span>
+              <input type="text" bind:value={form.tiers[tier].model} placeholder={tier === 'light' ? 'e.g. gpt-5.4-mini' : 'e.g. gpt-5.4'} />
+            </label>
+            <label class="onboarding-field">
+              <span>Reasoning effort <em>선택</em></span>
+              <select bind:value={form.tiers[tier].reasoning_effort}>
+                <option value="">기본값</option>
+                <option value="minimal">minimal</option>
+                <option value="low">low</option>
+                <option value="medium">medium</option>
+                <option value="high">high</option>
+              </select>
+            </label>
+          </fieldset>
+        {/each}
+      </div>
+
+      <div class="onboarding-actions">
+        <button class="btn btn-ghost" type="button" onclick={() => goBack('provider')}>← 이전</button>
+        <button class="btn btn-primary" type="button" onclick={goToReview}>다음: 검토 →</button>
+      </div>
+    </section>
+  {:else if step === 'review'}
+    <section class="card">
+      <div class="card-header">
+        <span class="card-title">Step 3 · 검토 및 저장</span>
+        {#if setupStatus?.config_path}
+          <span class="card-meta">저장 위치: <code>{setupStatus.config_path}</code></span>
+        {/if}
+      </div>
+
+      {#if saveError}
+        <div class="onboarding-errors"><strong>저장 실패</strong><div>{saveError}</div></div>
+      {/if}
+
+      <div class="onboarding-review">
+        <div class="onboarding-review-section">
+          <h3>Provider</h3>
+          <dl>
+            <div><dt>Alias</dt><dd>{form.provider.alias}</dd></div>
+            <div><dt>Kind</dt><dd>{form.provider.kind}</dd></div>
+            <div><dt>Auth mode</dt><dd>{form.provider.auth_mode}</dd></div>
+            {#if form.provider.auth_mode === 'api-key'}
+              <div><dt>API Key</dt><dd><code>{maskedKey(form.provider.api_key)}</code></dd></div>
+            {/if}
+            <div><dt>Base URL</dt><dd>{form.provider.base_url || defaultBaseURLForKind(form.provider.kind) || '(none)'}</dd></div>
+          </dl>
+        </div>
+
+        <div class="onboarding-review-section">
+          <h3>Tier 바인딩</h3>
+          <table>
+            <thead><tr><th>Tier</th><th>Provider</th><th>Model</th><th>Reasoning</th></tr></thead>
+            <tbody>
+              {#each ['heavy', 'standard', 'light'] as const as tier}
+                <tr>
+                  <td><strong>{tier}</strong></td>
+                  <td>{form.tiers[tier].provider}</td>
+                  <td>{form.tiers[tier].model}</td>
+                  <td>{form.tiers[tier].reasoning_effort || '(default)'}</td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="onboarding-actions">
+        <button class="btn btn-ghost" type="button" onclick={() => goBack('tiers')}>← 이전</button>
+        <button class="btn btn-primary" type="button" onclick={handleSave}>저장하고 재시작</button>
+      </div>
+    </section>
+  {:else}
+    <section class="card onboarding-restart">
+      {#if restartPhase === 'patching'}
+        <h2>설정 저장 중…</h2>
+        <p>입력한 provider와 tier 바인딩을 config 파일에 기록하고 있습니다.</p>
+      {:else if restartPhase === 'restarting'}
+        <h2>서버 재시작 요청…</h2>
+        <p>잠시 후 healthz를 확인합니다.</p>
+      {:else if restartPhase === 'polling'}
+        <h2>서버 응답 대기 중…</h2>
+        <p>최대 30초까지 healthz를 폴링합니다. 정상 모드 진입이 확인되면 자동으로 콘솔 홈으로 이동합니다.</p>
+        <div class="onboarding-spinner" aria-hidden="true"></div>
+      {:else if restartPhase === 'ready'}
+        <h2>완료</h2>
+        <p>정상 모드로 진입했습니다. 잠시 후 콘솔 홈으로 이동합니다.</p>
+      {:else if restartPhase === 'timeout'}
+        <h2>응답 지연</h2>
+        <p>30초 이내에 정상 모드 진입을 확인하지 못했습니다. 페이지를 새로고침해 상태를 다시 확인해주세요.</p>
+        <button class="btn btn-primary" type="button" onclick={() => window.location.reload()}>새로고침</button>
+      {/if}
+    </section>
+  {/if}
+</section>
+
+<style>
+  .onboarding {
+    max-width: 760px;
+    margin: 0 auto;
+    padding: var(--space-6) var(--space-4);
+    color: var(--text-primary);
+  }
+  .onboarding-header {
+    margin-bottom: var(--space-5);
+  }
+  .onboarding-kicker {
+    display: inline-block;
+    padding: 2px 8px;
+    background: var(--surface-2);
+    border: 1px solid var(--border-soft);
+    border-radius: 999px;
+    font-size: 12px;
+    color: var(--primary);
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+  .onboarding-header h1 {
+    margin: var(--space-2) 0 var(--space-2);
+    color: var(--text-primary);
+  }
+  .onboarding-header p {
+    color: var(--text-muted);
+    margin: 0;
+  }
+  .onboarding-progress {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 var(--space-5);
+    display: flex;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+  }
+  .onboarding-progress li {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    color: var(--text-muted);
+  }
+  .onboarding-progress-dot {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: var(--surface-2);
+    border: 1px solid var(--border-soft);
+    color: var(--text-muted);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+  }
+  .onboarding-progress li.active .onboarding-progress-dot {
+    background: var(--primary);
+    color: var(--surface-base);
+    border-color: var(--primary);
+  }
+  .onboarding-progress li.active .onboarding-progress-label {
+    color: var(--text-primary);
+    font-weight: 600;
+  }
+  .onboarding-progress li.done .onboarding-progress-dot {
+    background: var(--surface-3);
+    border-color: var(--primary);
+    color: var(--primary);
+  }
+  .onboarding-errors {
+    margin-bottom: var(--space-4);
+    padding: var(--space-3) var(--space-4);
+    border-radius: 8px;
+    border: 1px solid var(--border-error, #6c2a2a);
+    background: rgba(204, 64, 64, 0.08);
+    color: var(--text-primary);
+  }
+  .onboarding-errors strong {
+    display: block;
+    margin-bottom: var(--space-2);
+    color: var(--accent-error, #d36b6b);
+  }
+  .onboarding-errors ul {
+    margin: 0;
+    padding-left: 1.2em;
+  }
+  .onboarding-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-3) var(--space-4);
+  }
+  .onboarding-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    font-size: 14px;
+  }
+  .onboarding-field span {
+    color: var(--text-muted);
+    font-weight: 500;
+  }
+  .onboarding-field span em {
+    color: var(--text-muted);
+    font-weight: 400;
+    font-style: normal;
+    margin-left: 4px;
+    font-size: 12px;
+  }
+  .onboarding-field input,
+  .onboarding-field select {
+    padding: 8px 10px;
+    border: 1px solid var(--border-soft);
+    border-radius: 6px;
+    background: var(--surface-1);
+    color: var(--text-primary);
+    font-family: inherit;
+    font-size: 14px;
+  }
+  .onboarding-field input:focus,
+  .onboarding-field select:focus {
+    outline: 2px solid var(--primary);
+    outline-offset: 1px;
+  }
+  .onboarding-tier-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: var(--space-4);
+  }
+  .onboarding-tier {
+    border: 1px solid var(--border-soft);
+    border-radius: 8px;
+    padding: var(--space-3);
+    background: var(--surface-1);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+  }
+  .onboarding-tier legend {
+    padding: 0 6px;
+    color: var(--primary);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-size: 12px;
+  }
+  .onboarding-actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--space-3);
+    margin-top: var(--space-4);
+  }
+  .onboarding-spacer { flex: 1; }
+  .onboarding-review {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+  }
+  .onboarding-review-section h3 {
+    margin: 0 0 var(--space-2);
+    color: var(--text-primary);
+  }
+  .onboarding-review dl {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: var(--space-2) var(--space-4);
+    margin: 0;
+  }
+  .onboarding-review dt {
+    color: var(--text-muted);
+    font-size: 13px;
+  }
+  .onboarding-review dd { margin: 0; color: var(--text-primary); font-size: 14px; }
+  .onboarding-review code {
+    background: var(--surface-2);
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 12px;
+  }
+  .onboarding-review table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 14px;
+  }
+  .onboarding-review thead th {
+    text-align: left;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border-soft);
+    padding: 6px 8px;
+    font-weight: 500;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .onboarding-review tbody td {
+    padding: 8px;
+    border-bottom: 1px dashed var(--border-soft);
+  }
+  .onboarding-restart {
+    text-align: center;
+    padding: var(--space-6);
+  }
+  .onboarding-spinner {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    border: 3px solid var(--border-soft);
+    border-top-color: var(--primary);
+    margin: var(--space-4) auto 0;
+    animation: onboarding-spin 1s linear infinite;
+  }
+  @keyframes onboarding-spin {
+    to { transform: rotate(360deg); }
+  }
+</style>

--- a/frontend/console/src/components/Shell.svelte
+++ b/frontend/console/src/components/Shell.svelte
@@ -7,6 +7,7 @@
     currentPath: string
     serverHealth?: string
     unreadCount?: number
+    needsSetup?: boolean
     onNavigate: (path: string) => void
     onUnreadChange?: (count: number) => void
     children: Snippet
@@ -16,16 +17,25 @@
     currentPath,
     serverHealth = 'ok',
     unreadCount = 0,
+    needsSetup = false,
     onNavigate,
     onUnreadChange,
     children,
   }: Props = $props()
 </script>
 
-<div class="shell">
-  <Nav {currentPath} {onNavigate} />
-  <div class="shell-main">
+<div class="shell" class:setup-only={needsSetup}>
+  {#if !needsSetup}
+    <Nav {currentPath} {onNavigate} />
+  {/if}
+  <div class="shell-main" class:no-nav={needsSetup}>
     <Header {serverHealth} {unreadCount} {onUnreadChange} {onNavigate} />
+    {#if needsSetup}
+      <div class="setup-only-banner" role="alert">
+        <strong>Setup-only mode</strong>
+        <span>LLM 설정이 완료되지 않아 콘솔 기능이 제한됩니다. 마법사를 완료하면 정상 모드로 전환됩니다.</span>
+      </div>
+    {/if}
     <main class="shell-content">
       {@render children()}
     </main>
@@ -44,6 +54,27 @@
     display: flex;
     flex-direction: column;
     margin-left: var(--nav-width);
+  }
+
+  .shell-main.no-nav {
+    margin-left: 0;
+  }
+
+  .setup-only-banner {
+    background: rgba(224, 145, 69, 0.12);
+    border-bottom: 1px solid var(--primary);
+    color: var(--text-primary);
+    padding: var(--space-2) var(--space-4);
+    font-size: 13px;
+    display: flex;
+    gap: var(--space-3);
+    align-items: center;
+  }
+  .setup-only-banner strong {
+    color: var(--primary);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: 11px;
   }
 
   .shell-content {

--- a/frontend/console/src/lib/api.ts
+++ b/frontend/console/src/lib/api.ts
@@ -9,7 +9,9 @@ import type {
   CleanupPlan,
   ConfigFile,
   ConfigSchema,
+  HealthzResponse,
   ProviderModelsInfo,
+  SetupStatusResponse,
   HubInstallResponse,
   HubInstalled,
   AgentRuntimeRun,
@@ -189,6 +191,16 @@ function normalizeGlobalPlans(data: Partial<GlobalPlansResponse> | null | undefi
 }
 
 // --- Server status ---
+
+// --- Onboarding signals ---
+
+export async function getHealthz(): Promise<HealthzResponse> {
+  return requestJSON<HealthzResponse>('/v1/healthz')
+}
+
+export async function getSetupStatus(): Promise<SetupStatusResponse> {
+  return requestJSON<SetupStatusResponse>('/v1/setup/status')
+}
 
 export async function getServerStatus(): Promise<{ version: string }> {
   return requestJSON<{ version: string }>('/v1/status')

--- a/frontend/console/src/lib/onboarding.ts
+++ b/frontend/console/src/lib/onboarding.ts
@@ -1,0 +1,203 @@
+// Onboarding wizard state + helpers.
+//
+// The Phase 3 SPA collects a single LLM provider + 3 tier bindings
+// (heavy / standard / light) and POSTs them to the existing
+// /v1/admin/config/values endpoint. Validation and payload shaping
+// live here so the wizard component can stay declarative.
+
+export type ProviderKind =
+  | 'anthropic'
+  | 'openai'
+  | 'openai-codex'
+  | 'gemini'
+  | 'gemini-native'
+  | 'kimi'
+  | 'claude-code-cli'
+
+export const providerKinds: ProviderKind[] = [
+  'anthropic',
+  'openai',
+  'openai-codex',
+  'gemini',
+  'gemini-native',
+  'kimi',
+  'claude-code-cli',
+]
+
+export type AuthMode = 'api-key' | 'oauth'
+
+export type OnboardingProvider = {
+  alias: string
+  kind: ProviderKind | ''
+  auth_mode: AuthMode
+  api_key: string
+  base_url: string
+  oauth_provider?: string
+}
+
+export type OnboardingTierBinding = {
+  provider: string
+  model: string
+  reasoning_effort?: string
+}
+
+export type OnboardingFormState = {
+  provider: OnboardingProvider
+  tiers: {
+    heavy: OnboardingTierBinding
+    standard: OnboardingTierBinding
+    light: OnboardingTierBinding
+  }
+}
+
+export const requiredTiers = ['heavy', 'standard', 'light'] as const
+export type RequiredTier = (typeof requiredTiers)[number]
+
+export function emptyOnboardingForm(): OnboardingFormState {
+  return {
+    provider: {
+      alias: '',
+      kind: '',
+      auth_mode: 'api-key',
+      api_key: '',
+      base_url: '',
+    },
+    tiers: {
+      heavy: { provider: '', model: '' },
+      standard: { provider: '', model: '' },
+      light: { provider: '', model: '' },
+    },
+  }
+}
+
+// validateProviderStep returns user-facing error messages for the
+// provider step. Empty array means the step is ready to advance.
+//
+// api_key is required only when auth_mode is "api-key" — oauth flows
+// inherit credentials from the launcher (e.g. claude-code-cli), so an
+// empty key is legal.
+export function validateProviderStep(form: OnboardingFormState): string[] {
+  const errs: string[] = []
+  const alias = form.provider.alias.trim()
+  if (alias === '') {
+    errs.push('Provider alias is required.')
+  } else if (!/^[a-z0-9][a-z0-9_-]*$/i.test(alias)) {
+    errs.push('Provider alias must be alphanumeric (with optional - or _).')
+  }
+  if (form.provider.kind === '') {
+    errs.push('Pick a provider kind.')
+  }
+  if (form.provider.auth_mode === 'api-key' && form.provider.api_key.trim() === '') {
+    errs.push('API key is required for api-key auth mode.')
+  }
+  return errs
+}
+
+// validateTiersStep returns user-facing error messages for the tier
+// bindings step. All three tiers must point at a non-empty provider
+// alias and a non-empty model. The provider alias should match the
+// one configured on the previous step (or another tier's provider).
+export function validateTiersStep(form: OnboardingFormState): string[] {
+  const errs: string[] = []
+  const knownAliases = new Set<string>()
+  if (form.provider.alias.trim() !== '') {
+    knownAliases.add(form.provider.alias.trim())
+  }
+  for (const tier of requiredTiers) {
+    const binding = form.tiers[tier]
+    const provider = binding.provider.trim()
+    const model = binding.model.trim()
+    if (provider === '') {
+      errs.push(`${tier}: provider is required.`)
+    } else if (knownAliases.size > 0 && !knownAliases.has(provider)) {
+      errs.push(`${tier}: provider "${provider}" is not configured in this wizard.`)
+    }
+    if (model === '') {
+      errs.push(`${tier}: model is required.`)
+    }
+  }
+  return errs
+}
+
+// validateForm returns the union of provider + tier errors. The
+// review step uses this to gate the Save button.
+export function validateForm(form: OnboardingFormState): string[] {
+  return [...validateProviderStep(form), ...validateTiersStep(form)]
+}
+
+// buildConfigPayload converts the form into the `updates` map shape
+// that PATCH /v1/admin/config/values expects. Empty optional fields
+// are omitted so the resulting YAML stays clean.
+export function buildConfigPayload(form: OnboardingFormState): Record<string, unknown> {
+  const provider: Record<string, unknown> = {
+    kind: form.provider.kind,
+    auth_mode: form.provider.auth_mode,
+  }
+  if (form.provider.api_key.trim() !== '') {
+    provider.api_key = form.provider.api_key.trim()
+  }
+  if (form.provider.base_url.trim() !== '') {
+    provider.base_url = form.provider.base_url.trim()
+  }
+  if (form.provider.auth_mode === 'oauth' && form.provider.oauth_provider) {
+    const op = form.provider.oauth_provider.trim()
+    if (op !== '') provider.oauth_provider = op
+  }
+
+  const tiers: Record<string, Record<string, unknown>> = {}
+  for (const tier of requiredTiers) {
+    const binding = form.tiers[tier]
+    const entry: Record<string, unknown> = {
+      provider: binding.provider.trim(),
+      model: binding.model.trim(),
+    }
+    if (binding.reasoning_effort && binding.reasoning_effort.trim() !== '') {
+      entry.reasoning_effort = binding.reasoning_effort.trim()
+    }
+    tiers[tier] = entry
+  }
+
+  return {
+    llm_providers: { [form.provider.alias.trim()]: provider },
+    llm_tiers: tiers,
+  }
+}
+
+// defaultBaseURLForKind returns the canonical base URL for a provider
+// kind so the wizard can prefill base_url when the user picks a kind.
+// Returning empty string means "no canonical default" — the user must
+// fill it in manually (claude-code-cli is local, openai-codex is
+// resolved by oauth handshake, etc.).
+export function defaultBaseURLForKind(kind: ProviderKind | ''): string {
+  switch (kind) {
+    case 'anthropic':
+      return 'https://api.anthropic.com'
+    case 'openai':
+      return 'https://api.openai.com/v1'
+    case 'gemini':
+      return 'https://generativelanguage.googleapis.com'
+    case 'gemini-native':
+      return 'https://generativelanguage.googleapis.com'
+    case 'kimi':
+      return 'https://api.moonshot.ai/v1'
+    case 'openai-codex':
+      return 'https://chatgpt.com/backend-api'
+    case 'claude-code-cli':
+      return ''
+    default:
+      return ''
+  }
+}
+
+// suggestedAuthModeForKind picks the natural default auth mode per
+// provider kind. The wizard calls this when the user changes kind so
+// the form switches between api-key and oauth flows automatically.
+export function suggestedAuthModeForKind(kind: ProviderKind | ''): AuthMode {
+  switch (kind) {
+    case 'openai-codex':
+    case 'claude-code-cli':
+      return 'oauth'
+    default:
+      return 'api-key'
+  }
+}

--- a/frontend/console/src/lib/router.ts
+++ b/frontend/console/src/lib/router.ts
@@ -18,6 +18,7 @@ export type Route =
   | { view: 'pulse' }
   | { view: 'reflection' }
   | { view: 'channels' }
+  | { view: 'onboarding' }
 
 export function resolveRoute(pathname: string): Route {
   let path = pathname.trim()
@@ -111,6 +112,10 @@ export function resolveRoute(pathname: string): Route {
 
   if (path.startsWith(`${consoleBase}/channels`)) {
     return { view: 'channels' }
+  }
+
+  if (path.startsWith(`${consoleBase}/onboarding`)) {
+    return { view: 'onboarding' }
   }
 
   return { view: 'home' }

--- a/frontend/console/src/lib/types.ts
+++ b/frontend/console/src/lib/types.ts
@@ -1240,6 +1240,40 @@ export type ProviderModelsInfo = {
   warning?: string
 }
 
+// --- Onboarding (Phase 1+2 backend, Phase 3 wizard) ---
+
+export type HealthzResponse = {
+  ok: boolean
+  component: string
+  time: string
+  needs_setup: boolean
+  dashboard_auth?: Record<string, unknown>
+}
+
+export type SetupTierStatus = {
+  configured: boolean
+  provider?: string
+  model?: string
+}
+
+export type SetupCheck = {
+  id: string
+  ok: boolean
+  message: string
+}
+
+export type SetupStatusResponse = {
+  needs_setup: boolean
+  config_path?: string
+  config_exists: boolean
+  providers: {
+    configured: string[]
+    missing: boolean
+  }
+  tiers: Record<string, SetupTierStatus>
+  checks: SetupCheck[]
+}
+
 export type PlanStatus =
   | 'drafting'
   | 'proposed'

--- a/frontend/console/tests/onboarding.test.ts
+++ b/frontend/console/tests/onboarding.test.ts
@@ -1,0 +1,154 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  buildConfigPayload,
+  defaultBaseURLForKind,
+  emptyOnboardingForm,
+  suggestedAuthModeForKind,
+  validateForm,
+  validateProviderStep,
+  validateTiersStep,
+} from '../src/lib/onboarding.ts'
+
+test('emptyOnboardingForm returns blank state with all 3 tier slots', () => {
+  const form = emptyOnboardingForm()
+  assert.equal(form.provider.alias, '')
+  assert.equal(form.provider.kind, '')
+  assert.equal(form.provider.auth_mode, 'api-key')
+  assert.deepEqual(Object.keys(form.tiers).sort(), ['heavy', 'light', 'standard'])
+})
+
+test('validateProviderStep flags missing alias / kind / api_key', () => {
+  const form = emptyOnboardingForm()
+  const errs = validateProviderStep(form)
+  assert.ok(errs.some((e) => /alias is required/i.test(e)))
+  assert.ok(errs.some((e) => /provider kind/i.test(e)))
+  assert.ok(errs.some((e) => /api key is required/i.test(e)))
+})
+
+test('validateProviderStep rejects non-alphanumeric alias', () => {
+  const form = emptyOnboardingForm()
+  form.provider.alias = 'has space'
+  form.provider.kind = 'openai'
+  form.provider.api_key = 'sk-test'
+  const errs = validateProviderStep(form)
+  assert.ok(errs.some((e) => /alphanumeric/i.test(e)))
+})
+
+test('validateProviderStep allows oauth without api_key', () => {
+  const form = emptyOnboardingForm()
+  form.provider.alias = 'codex'
+  form.provider.kind = 'openai-codex'
+  form.provider.auth_mode = 'oauth'
+  const errs = validateProviderStep(form)
+  assert.equal(errs.length, 0)
+})
+
+test('validateTiersStep requires provider+model on every tier', () => {
+  const form = emptyOnboardingForm()
+  form.provider.alias = 'openai'
+  form.provider.kind = 'openai'
+  form.provider.api_key = 'sk-test'
+  const errs = validateTiersStep(form)
+  // 3 tiers * 2 fields (provider + model) = 6 errors
+  assert.equal(errs.length, 6, errs.join(' | '))
+})
+
+test('validateTiersStep rejects tier provider that does not match wizard alias', () => {
+  const form = emptyOnboardingForm()
+  form.provider.alias = 'openai'
+  form.provider.kind = 'openai'
+  form.provider.api_key = 'sk-test'
+  for (const tier of ['heavy', 'standard', 'light'] as const) {
+    form.tiers[tier].provider = 'not-the-alias'
+    form.tiers[tier].model = 'gpt-x'
+  }
+  const errs = validateTiersStep(form)
+  assert.ok(errs.length >= 3, 'expected one error per mismatching tier')
+  assert.ok(errs.every((e) => /not configured/i.test(e)))
+})
+
+test('validateTiersStep accepts complete bindings', () => {
+  const form = emptyOnboardingForm()
+  form.provider.alias = 'openai'
+  form.provider.kind = 'openai'
+  form.provider.api_key = 'sk-test'
+  for (const tier of ['heavy', 'standard', 'light'] as const) {
+    form.tiers[tier].provider = 'openai'
+    form.tiers[tier].model = 'gpt-5.4'
+  }
+  assert.equal(validateTiersStep(form).length, 0)
+})
+
+test('validateForm aggregates provider + tiers errors', () => {
+  const form = emptyOnboardingForm()
+  const errs = validateForm(form)
+  // provider step: 3 errors, tiers step: 6 errors = 9 total
+  assert.equal(errs.length, 9, errs.join(' | '))
+})
+
+test('buildConfigPayload shapes a clean PATCH updates map', () => {
+  const form = emptyOnboardingForm()
+  form.provider.alias = 'openai'
+  form.provider.kind = 'openai'
+  form.provider.api_key = 'sk-test'
+  form.provider.base_url = 'https://api.openai.com/v1'
+  for (const tier of ['heavy', 'standard', 'light'] as const) {
+    form.tiers[tier].provider = 'openai'
+    form.tiers[tier].model = tier === 'light' ? 'gpt-5.4-mini' : 'gpt-5.4'
+  }
+  form.tiers.heavy.reasoning_effort = 'high'
+
+  const payload = buildConfigPayload(form)
+  assert.deepEqual(payload, {
+    llm_providers: {
+      openai: {
+        kind: 'openai',
+        auth_mode: 'api-key',
+        api_key: 'sk-test',
+        base_url: 'https://api.openai.com/v1',
+      },
+    },
+    llm_tiers: {
+      heavy: { provider: 'openai', model: 'gpt-5.4', reasoning_effort: 'high' },
+      standard: { provider: 'openai', model: 'gpt-5.4' },
+      light: { provider: 'openai', model: 'gpt-5.4-mini' },
+    },
+  })
+})
+
+test('buildConfigPayload omits empty optional fields', () => {
+  const form = emptyOnboardingForm()
+  form.provider.alias = 'codex'
+  form.provider.kind = 'openai-codex'
+  form.provider.auth_mode = 'oauth'
+  // No api_key, no base_url, no reasoning_effort
+  for (const tier of ['heavy', 'standard', 'light'] as const) {
+    form.tiers[tier].provider = 'codex'
+    form.tiers[tier].model = 'gpt-5.4'
+  }
+  const payload = buildConfigPayload(form) as {
+    llm_providers: { codex: Record<string, unknown> }
+    llm_tiers: Record<string, Record<string, unknown>>
+  }
+  assert.equal(payload.llm_providers.codex.kind, 'openai-codex')
+  assert.equal(payload.llm_providers.codex.auth_mode, 'oauth')
+  assert.equal('api_key' in payload.llm_providers.codex, false)
+  assert.equal('base_url' in payload.llm_providers.codex, false)
+  assert.equal('reasoning_effort' in payload.llm_tiers.heavy, false)
+})
+
+test('defaultBaseURLForKind returns canonical URLs and empty for local', () => {
+  assert.equal(defaultBaseURLForKind('anthropic'), 'https://api.anthropic.com')
+  assert.equal(defaultBaseURLForKind('openai'), 'https://api.openai.com/v1')
+  assert.equal(defaultBaseURLForKind('claude-code-cli'), '')
+  assert.equal(defaultBaseURLForKind(''), '')
+})
+
+test('suggestedAuthModeForKind defaults oauth for codex/claude-code-cli, api-key elsewhere', () => {
+  assert.equal(suggestedAuthModeForKind('openai-codex'), 'oauth')
+  assert.equal(suggestedAuthModeForKind('claude-code-cli'), 'oauth')
+  assert.equal(suggestedAuthModeForKind('openai'), 'api-key')
+  assert.equal(suggestedAuthModeForKind('anthropic'), 'api-key')
+})


### PR DESCRIPTION
## Summary

Phase 3 of the onboarding Epic ([#637](https://github.com/devlikebear/tars/issues/637)). Builds the actual wizard UI on top of the Phase 1 + 2 backend so a brand-new install with an empty config can be set up entirely from the browser:

> open \`/console\` → wizard auto-loads → 3 steps + restart → normal mode.

Closes #635

## Commits

1. \`feat: add api client wrappers for setup status + healthz\` — \`getHealthz()\`, \`getSetupStatus()\`, response types.
2. \`feat: add onboarding form state + validation + payload builder\` — \`lib/onboarding.ts\` + 12 unit tests.
3. \`feat: add Onboarding wizard component (4 steps)\` — single-file Svelte 5, no over-componentization.
4. \`feat: wire onboarding route + auto-redirect on degraded boot\` — router, App.svelte healthz redirect, Shell Nav hidden + degraded banner.

## What changes for users

Boot \`tars serve\` with empty \`llm_providers\` / \`llm_tiers\`:
1. Phase 2 puts the server in setup-only mode.
2. Open http://127.0.0.1:43180/console — App.svelte calls \`/v1/healthz\`, sees \`needs_setup=true\`, pushes \`/console/onboarding\`.
3. Wizard renders the side Nav hidden + a banner: "Setup-only mode … 마법사를 완료하면 정상 모드로 전환됩니다."
4. Step 1: pick provider kind / alias / auth_mode / api_key (or oauth) / base_url. Picking the kind autofills base_url and the natural auth_mode.
5. Step 2: bind heavy / standard / light to the configured alias + a model name. Tier-provider mismatch errors surface inline.
6. Step 3: review (api_key masked), see the destination \`config_path\` from \`/v1/setup/status\`, click "저장하고 재시작".
7. Step 4: PATCH \`/v1/admin/config/values\` → POST \`/v1/admin/restart\` → poll \`/v1/healthz\` for up to 30 s. As soon as \`needs_setup=false\` flips, the wizard navigates to \`/console\`.

If PATCH or restart fails, the wizard bounces back to the review screen with the error visible. If the 30 s poll deadline passes, a "새로고침" button is offered.

## Design

- Single-file \`Onboarding.svelte\` (~570 lines incl. style) — keeps form state local, no prop drilling across 4 child components for a transient wizard.
- All visuals reuse existing DESIGN.md tokens (\`--surface-*\`, \`--primary\`, \`--text-*\`) and existing classes (\`.card\`, \`.badge\`, \`.btn-primary\`, \`.btn-ghost\`). No new color or component primitives added.
- API key inputs use \`autocomplete=new-password\` so browsers do not autofill.
- Shell hides the side Nav and adds a dismissable-feeling top banner during \`needs_setup=true\` so users do not click into broken surfaces (chat / agent / cron / pulse all 503 in setup-only).

## Test plan

- [x] \`make console-build\` — green
- [x] \`npm run check\` — 480 files, 0 errors
- [x] \`npm test\` — 183 frontend tests pass (12 new tests for \`lib/onboarding\`)
- [x] \`make test\` — full Go suite green
- [x] \`make vet\` — clean
- [x] \`make security-scan\` — clean
- [ ] Manual smoke (planned): \`make dev-console\` with empty workspace config → browser \`/console\` → wizard completes → home view loads. Could not run in this PR; the e2e test in #641 covers the equivalent backend cycle.

## Out of scope (deferred)

- **Re-entry from Config page** (\`?reentry=1\`, prefill from current config, "Keep existing" for masked api_key) — Phase 4, #636.
- **Live model picker** in step 2 — wizard uses plain text for the model name. The setup-only mux does not yet expose \`/v1/providers\` and \`/v1/models\`; will land alongside picker UI in Phase 4 if needed.
- **QuickStart shortcut** (one-click recommended defaults) — separate issue after Phase 4 stabilizes.
- **Provider live validation** (probe the LLM endpoint with the entered key) — separate issue.
- **i18n full English translation** — Step labels and inline help are Korean-first with English glossary terms (Provider, Tier, alias, kind, etc.) inline. Future PR can switch on existing i18n infra.