### PR TITLE
feat(onboarding) Phase 4: re-entry UX + polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,9 +162,17 @@ git fetch origin && git switch main && git pull --rebase
 ## Config
 
 - `config/default.yaml` — checked-in default config. Ships a minimal provider pool + 3 tier bindings; new users get a working baseline after setting their provider API key. `config/tars.config.example.yaml` is the annotated reference covering every field.
-- `workspace/config/tars.config.yaml` — local override (gitignored). Must define at least one entry under `llm_providers` and the three `llm_tiers` bindings (heavy/standard/light) or startup errors.
+- `workspace/config/tars.config.yaml` — local override (gitignored). Should define at least one entry under `llm_providers` and the three `llm_tiers` bindings (heavy/standard/light); when missing or invalid, the server boots in **setup-only mode** so the wizard can repair it (see Onboarding below).
 - Environment variables override YAML: `TARS_API_AUTH_MODE`, `TARS_LLM_PROVIDERS_JSON`, `TARS_LLM_TIERS_JSON`, etc. Nested pool/tier maps are overridden as a single JSON blob.
 - Config field mapping: `internal/config/config_input_fields.go`. LLM pool parsers: `internal/config/llm_providers_field.go`. Resolver: `internal/config/llm_resolve.go`.
+
+## Onboarding (degraded mode + console wizard)
+
+When `llm_providers` or any of `llm_tiers.{heavy,standard,light}` is missing/empty, `tars serve` boots in **setup-only mode** instead of panicking. Detection lives in `config.NeedsSetup` (single source of truth shared by `/v1/healthz`, `/v1/setup/status`, and the boot path). The CLI's RunE downgrades on the recoverable stages `init_llm` / `init_memory_backend` / `init_semantic_memory` (see `isRecoverableLLMInitError`); other failures stay fatal.
+
+Setup-only mux (`buildSetupOnlyAPIMux` in `internal/tarsserver/main_serve_api_setup.go`) only registers the wizard surface — `/v1/healthz`, `/v1/setup/status`, `/v1/admin/config{,/values,/schema}`, `/v1/admin/restart`, `/v1/auth/whoami`, and `/console/*`. Every other `/v1/*` returns a JSON 503 with a "complete setup at /console" hint. Background runtimes (chat, agent runtime, cron, pulse, reflection, telegram, extensions, watchdog) stay nil so `startBackgrounds` skips them.
+
+Frontend wizard (`frontend/console/src/components/Onboarding.svelte`, `lib/onboarding.ts`) is a 4-step Svelte 5 component: Provider → Tiers → Review → Restarting. `App.svelte` calls `/v1/healthz` on mount and force-pushes `/console/onboarding` when `needs_setup=true`. Saving runs PATCH `/v1/admin/config/values` → POST `/v1/admin/restart` → polls healthz for up to 30 s. Re-entry from the Settings page (`?reentry=1`) prefills the form via `formFromConfigValues`, masks the api_key with a "Keep existing" pin, and exposes [Save only] alongside [Save & Restart] so users in normal mode can defer the restart. `--config-check` returns exit 1 in setup-only mode so external scripts that gate on it still detect a misconfigured server.
 
 ## CI
 

--- a/README.md
+++ b/README.md
@@ -191,27 +191,25 @@ curl -fsSL https://raw.githubusercontent.com/devlikebear/tars/main/install.sh | 
 # Initialize workspace and config
 tars init
 
-# Set your provider credentials
-export ANTHROPIC_API_KEY="your-key"
-# Or: export OPENAI_API_KEY="your-key"
-# Then edit ~/.tars/config/config.yaml under llm.providers / llm.tiers if needed
-
-# Validate setup
-tars doctor --fix
-
-# Validate server bootstrap without binding the API
-tars serve --config-check
-
-# Start the server
+# Start the server (it boots in setup-only mode if no LLM is configured yet)
 tars serve
 
-# Open the web console
+# Open the web console — the onboarding wizard runs automatically when needed
 tars
 ```
 
-On macOS, `tars service install && tars service start` manages `tars serve` as a LaunchAgent. Once a plist exists, `tars service start`, `stop`, and `status` keep working from the plist and `launchctl` state even if the config needs repair.
+On first run, if `~/.tars/config/config.yaml` has no `llm_providers` / `llm_tiers`, the server boots in **setup-only mode**: only the wizard endpoints + `/console` are active and `tars api serving on … (setup-only mode)` is printed to stdout. Open `http://127.0.0.1:43180/console`, the SPA detects `needs_setup=true` from `/v1/healthz`, and walks you through three steps: pick a provider (kind + alias + api_key), bind heavy/standard/light tiers to a model, then save & restart. The wizard is also re-runnable later from the Settings page (`/console/config` → "설정 마법사 다시 실행 →") if you need to swap providers or tweak tier bindings.
 
-Open `http://127.0.0.1:43180/console` and start chatting.
+To skip the wizard and edit by hand, set credentials directly and validate:
+
+```bash
+export ANTHROPIC_API_KEY="your-key"   # or OPENAI_API_KEY, etc.
+# Edit ~/.tars/config/config.yaml under llm.providers / llm.tiers
+tars doctor --fix
+tars serve --config-check              # exits 1 in setup-only mode
+```
+
+On macOS, `tars service install && tars service start` manages `tars serve` as a LaunchAgent. Once a plist exists, `tars service start`, `stop`, and `status` keep working from the plist and `launchctl` state even if the config needs repair.
 
 When TARS is exposed behind a reverse proxy path, pass that base path in `--server-url`; CLI API calls and the console opener resolve `/v1/*` and `/console` from the same base.
 

--- a/frontend/console/src/App.svelte
+++ b/frontend/console/src/App.svelte
@@ -108,7 +108,7 @@
   onUnreadChange={(count) => { unreadCount = count }}
 >
   {#if route.view === 'onboarding'}
-    <Onboarding onComplete={handleOnboardingComplete} />
+    <Onboarding onComplete={handleOnboardingComplete} reentry={route.reentry === true} />
   {:else if route.view === 'home'}
     <Home onNavigate={navigate} />
   {:else if route.view === 'chat'}

--- a/frontend/console/src/App.svelte
+++ b/frontend/console/src/App.svelte
@@ -134,7 +134,7 @@
   {:else if route.view === 'analytics'}
     <Analytics />
   {:else if route.view === 'config'}
-    <Config />
+    <Config onNavigate={navigate} />
   {:else if route.view === 'pulse'}
     <Pulse onNavigate={navigate} />
   {:else if route.view === 'reflection'}

--- a/frontend/console/src/components/Config.svelte
+++ b/frontend/console/src/components/Config.svelte
@@ -31,6 +31,11 @@
 
   type ViewMode = 'quick' | 'form' | 'yaml'
 
+  interface Props {
+    onNavigate?: (path: string) => void
+  }
+  let { onNavigate }: Props = $props()
+
   let configPath = $state('')
   let schemaUpdatedAt = $state('')
   let schema: ConfigFieldMeta[] = $state([])
@@ -742,6 +747,20 @@
     </div>
   </div>
 
+  {#if onNavigate}
+    <div class="wizard-entry-card" role="region" aria-label="Onboarding wizard entry">
+      <div>
+        <span class="wizard-entry-kicker">Setup wizard</span>
+        <p class="wizard-entry-text">Provider 또는 tier 바인딩을 빠르게 재구성하려면 마법사를 다시 실행하세요. 기존 값이 prefill됩니다.</p>
+      </div>
+      <button
+        type="button"
+        class="btn btn-primary btn-sm"
+        onclick={() => onNavigate?.('/console/onboarding?reentry=1')}
+      >설정 마법사 다시 실행 →</button>
+    </div>
+  {/if}
+
   {#if loading}
     <div class="loading">Loading configuration...</div>
   {:else if !configPath}
@@ -1342,6 +1361,33 @@
     justify-content: space-between;
     gap: var(--space-3);
     flex-wrap: wrap;
+  }
+
+  .wizard-entry-card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+    padding: var(--space-3) var(--space-4);
+    border: 1px solid var(--border-soft);
+    border-radius: 8px;
+    background: var(--surface-2);
+  }
+  .wizard-entry-kicker {
+    display: inline-block;
+    padding: 2px 8px;
+    background: rgba(224, 145, 69, 0.12);
+    border: 1px solid var(--primary);
+    color: var(--primary);
+    border-radius: 999px;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  .wizard-entry-text {
+    margin: var(--space-2) 0 0;
+    color: var(--text-muted);
+    font-size: 13px;
   }
 
   .page-header-left {

--- a/frontend/console/src/components/Onboarding.svelte
+++ b/frontend/console/src/components/Onboarding.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte'
   import {
+    getConfigSchema,
     getHealthz,
     getSetupStatus,
     patchConfigValues,
@@ -10,6 +11,7 @@
     buildConfigPayload,
     defaultBaseURLForKind,
     emptyOnboardingForm,
+    formFromConfigValues,
     providerKinds,
     suggestedAuthModeForKind,
     validateForm,
@@ -23,10 +25,11 @@
 
   interface Props {
     onComplete?: () => void
+    reentry?: boolean
   }
-  let { onComplete }: Props = $props()
+  let { onComplete, reentry = false }: Props = $props()
 
-  type StepId = 'provider' | 'tiers' | 'review' | 'restarting'
+  type StepId = 'provider' | 'tiers' | 'review' | 'restarting' | 'saved'
 
   let step = $state<StepId>('provider')
   let form = $state<OnboardingFormState>(emptyOnboardingForm())
@@ -43,6 +46,14 @@
       // status fetch is optional — wizard still works on empty fields
       console.warn('setup status fetch failed', err)
     }
+    if (reentry) {
+      try {
+        const schema = await getConfigSchema()
+        form = formFromConfigValues(schema.values || {})
+      } catch (err) {
+        console.warn('reentry prefill failed', err)
+      }
+    }
   })
 
   const stepOrder: StepId[] = ['provider', 'tiers', 'review', 'restarting']
@@ -51,10 +62,21 @@
     tiers: 'Tiers',
     review: 'Review',
     restarting: 'Restart',
+    saved: 'Saved',
   }
 
   function progressIndex(current: StepId): number {
+    if (current === 'saved') return stepOrder.length - 1
     return stepOrder.indexOf(current)
+  }
+
+  function handleApiKeyInput(value: string) {
+    form.provider.api_key = value
+    if (value.trim() !== '') {
+      // user typed a fresh value — drop the keep-existing pin so the
+      // payload includes the new key
+      form.provider.keepExistingApiKey = false
+    }
   }
 
   function handleKindChange(value: string) {
@@ -100,7 +122,7 @@
     step = target
   }
 
-  async function handleSave() {
+  async function handleSave(restart: boolean) {
     const formErrors = validateForm(form)
     if (formErrors.length > 0) {
       stepErrors = formErrors
@@ -118,6 +140,11 @@
       step = 'review'
       return
     }
+    if (!restart) {
+      restartPhase = 'idle'
+      step = 'saved'
+      return
+    }
     restartPhase = 'restarting'
     try {
       await restartServer()
@@ -125,6 +152,23 @@
       saveError = (err as Error).message || 'failed to trigger restart'
       restartPhase = 'idle'
       step = 'review'
+      return
+    }
+    restartPhase = 'polling'
+    pollDeadline = Date.now() + 30_000
+    pollUntilReady()
+  }
+
+  async function handleManualRestart() {
+    saveError = ''
+    step = 'restarting'
+    restartPhase = 'restarting'
+    try {
+      await restartServer()
+    } catch (err) {
+      saveError = (err as Error).message || 'failed to trigger restart'
+      restartPhase = 'idle'
+      step = 'saved'
       return
     }
     restartPhase = 'polling'
@@ -159,9 +203,13 @@
 
 <section class="onboarding">
   <header class="onboarding-header">
-    <span class="onboarding-kicker">First-run setup</span>
+    <span class="onboarding-kicker">{reentry ? 'Reconfigure' : 'First-run setup'}</span>
     <h1>TARS 설정 마법사</h1>
-    <p>최소 LLM provider 1개와 3개 tier(heavy/standard/light) 바인딩만 입력하면 콘솔이 활성화됩니다.</p>
+    {#if reentry}
+      <p>이미 설정된 값이 prefill되어 있습니다. 변경하지 않은 항목은 그대로 유지됩니다.</p>
+    {:else}
+      <p>최소 LLM provider 1개와 3개 tier(heavy/standard/light) 바인딩만 입력하면 콘솔이 활성화됩니다.</p>
+    {/if}
   </header>
 
   <ol class="onboarding-progress">
@@ -215,8 +263,14 @@
 
         {#if form.provider.auth_mode === 'api-key'}
           <label class="onboarding-field">
-            <span>API Key</span>
-            <input type="password" bind:value={form.provider.api_key} autocomplete="new-password" placeholder="sk-…" />
+            <span>API Key {#if form.provider.keepExistingApiKey}<em>변경하지 않으면 기존 값 유지</em>{/if}</span>
+            <input
+              type="password"
+              value={form.provider.keepExistingApiKey ? '' : form.provider.api_key}
+              oninput={(e) => handleApiKeyInput((e.currentTarget as HTMLInputElement).value)}
+              autocomplete="new-password"
+              placeholder={form.provider.keepExistingApiKey ? '••••••• (현재 값 유지)' : 'sk-…'}
+            />
           </label>
         {/if}
 
@@ -296,7 +350,16 @@
             <div><dt>Kind</dt><dd>{form.provider.kind}</dd></div>
             <div><dt>Auth mode</dt><dd>{form.provider.auth_mode}</dd></div>
             {#if form.provider.auth_mode === 'api-key'}
-              <div><dt>API Key</dt><dd><code>{maskedKey(form.provider.api_key)}</code></dd></div>
+              <div>
+                <dt>API Key</dt>
+                <dd>
+                  {#if form.provider.keepExistingApiKey}
+                    <code>(현재 값 유지)</code>
+                  {:else}
+                    <code>{maskedKey(form.provider.api_key)}</code>
+                  {/if}
+                </dd>
+              </div>
             {/if}
             <div><dt>Base URL</dt><dd>{form.provider.base_url || defaultBaseURLForKind(form.provider.kind) || '(none)'}</dd></div>
           </dl>
@@ -322,7 +385,24 @@
 
       <div class="onboarding-actions">
         <button class="btn btn-ghost" type="button" onclick={() => goBack('tiers')}>← 이전</button>
-        <button class="btn btn-primary" type="button" onclick={handleSave}>저장하고 재시작</button>
+        {#if reentry}
+          <button class="btn btn-ghost" type="button" onclick={() => handleSave(false)}>저장만 (재시작 없이)</button>
+          <button class="btn btn-primary" type="button" onclick={() => handleSave(true)}>저장하고 재시작</button>
+        {:else}
+          <button class="btn btn-primary" type="button" onclick={() => handleSave(true)}>저장하고 재시작</button>
+        {/if}
+      </div>
+    </section>
+  {:else if step === 'saved'}
+    <section class="card onboarding-restart">
+      <h2>저장 완료</h2>
+      <p>변경사항이 config 파일에 기록되었습니다. 적용하려면 서버를 재시작해주세요.</p>
+      {#if saveError}
+        <div class="onboarding-errors"><strong>재시작 실패</strong><div>{saveError}</div></div>
+      {/if}
+      <div class="onboarding-actions onboarding-saved-actions">
+        <button class="btn btn-ghost" type="button" onclick={() => onComplete && onComplete()}>나중에 (콘솔로 이동)</button>
+        <button class="btn btn-primary" type="button" onclick={handleManualRestart}>지금 재시작</button>
       </div>
     </section>
   {:else}
@@ -550,6 +630,10 @@
   .onboarding-restart {
     text-align: center;
     padding: var(--space-6);
+  }
+  .onboarding-saved-actions {
+    justify-content: center;
+    margin-top: var(--space-5);
   }
   .onboarding-spinner {
     width: 40px;

--- a/frontend/console/src/lib/onboarding.ts
+++ b/frontend/console/src/lib/onboarding.ts
@@ -33,6 +33,11 @@ export type OnboardingProvider = {
   api_key: string
   base_url: string
   oauth_provider?: string
+  // keepExistingApiKey is true on the re-entry path when the wizard
+  // has prefilled a masked api_key from the server. Saving with this
+  // flag set drops api_key from the patch payload so the existing
+  // value on disk is preserved.
+  keepExistingApiKey?: boolean
 }
 
 export type OnboardingTierBinding = {
@@ -87,7 +92,7 @@ export function validateProviderStep(form: OnboardingFormState): string[] {
   if (form.provider.kind === '') {
     errs.push('Pick a provider kind.')
   }
-  if (form.provider.auth_mode === 'api-key' && form.provider.api_key.trim() === '') {
+  if (form.provider.auth_mode === 'api-key' && !form.provider.keepExistingApiKey && form.provider.api_key.trim() === '') {
     errs.push('API key is required for api-key auth mode.')
   }
   return errs
@@ -133,7 +138,10 @@ export function buildConfigPayload(form: OnboardingFormState): Record<string, un
     kind: form.provider.kind,
     auth_mode: form.provider.auth_mode,
   }
-  if (form.provider.api_key.trim() !== '') {
+  // Skip api_key when the user opted to keep the existing value on
+  // disk (re-entry path with masked prefill). PatchYAML preserves the
+  // original key when the field is absent from the updates map.
+  if (!form.provider.keepExistingApiKey && form.provider.api_key.trim() !== '') {
     provider.api_key = form.provider.api_key.trim()
   }
   if (form.provider.base_url.trim() !== '') {
@@ -200,4 +208,49 @@ export function suggestedAuthModeForKind(kind: ProviderKind | ''): AuthMode {
     default:
       return 'api-key'
   }
+}
+
+// formFromConfigValues maps a config schema's values map into the
+// wizard's form shape. Used by the re-entry path so the wizard opens
+// with the existing provider + tier bindings prefilled.
+//
+// Picks the FIRST provider alias as the active edit target. The
+// wizard does not yet support editing multiple providers from the
+// same screen — that lands as a separate enhancement.
+//
+// API keys arrive masked from the schema endpoint; the form sets
+// keepExistingApiKey=true so saving without typing a new value
+// leaves the on-disk credential untouched.
+export function formFromConfigValues(values: Record<string, unknown>): OnboardingFormState {
+  const form = emptyOnboardingForm()
+  const providers = (values?.llm_providers ?? {}) as Record<string, Record<string, unknown>>
+  const aliases = Object.keys(providers).sort()
+  if (aliases.length > 0) {
+    const alias = aliases[0]
+    const entry = providers[alias] || {}
+    const kind = String(entry.kind ?? '') as ProviderKind | ''
+    form.provider.alias = alias
+    form.provider.kind = kind
+    form.provider.auth_mode = (String(entry.auth_mode ?? 'api-key') as AuthMode) || 'api-key'
+    form.provider.api_key = String(entry.api_key ?? '')
+    form.provider.base_url = String(entry.base_url ?? '')
+    if (entry.oauth_provider) {
+      form.provider.oauth_provider = String(entry.oauth_provider)
+    }
+    // The schema endpoint masks api_key; treat any non-empty masked
+    // value as "keep existing" until the user types a new key.
+    if (form.provider.api_key.trim() !== '') {
+      form.provider.keepExistingApiKey = true
+    }
+  }
+
+  const tiers = (values?.llm_tiers ?? {}) as Record<string, Record<string, unknown>>
+  for (const tier of requiredTiers) {
+    const binding = tiers[tier] || {}
+    if (binding.provider) form.tiers[tier].provider = String(binding.provider)
+    if (binding.model) form.tiers[tier].model = String(binding.model)
+    if (binding.reasoning_effort) form.tiers[tier].reasoning_effort = String(binding.reasoning_effort)
+  }
+
+  return form
 }

--- a/frontend/console/src/lib/router.ts
+++ b/frontend/console/src/lib/router.ts
@@ -18,15 +18,18 @@ export type Route =
   | { view: 'pulse' }
   | { view: 'reflection' }
   | { view: 'channels' }
-  | { view: 'onboarding' }
+  | { view: 'onboarding'; reentry?: boolean }
 
 export function resolveRoute(pathname: string): Route {
   let path = pathname.trim()
   let sessionQuery = ''
+  let reentryQuery = false
   try {
     const url = new URL(path, 'http://tars.local')
     path = url.pathname
     sessionQuery = url.searchParams.get('session')?.trim() ?? ''
+    const reentryRaw = url.searchParams.get('reentry')?.trim().toLowerCase() ?? ''
+    reentryQuery = reentryRaw === '1' || reentryRaw === 'true' || reentryRaw === 'yes'
   } catch {
     path = pathname.trim()
   }
@@ -115,7 +118,7 @@ export function resolveRoute(pathname: string): Route {
   }
 
   if (path.startsWith(`${consoleBase}/onboarding`)) {
-    return { view: 'onboarding' }
+    return reentryQuery ? { view: 'onboarding', reentry: true } : { view: 'onboarding' }
   }
 
   return { view: 'home' }

--- a/frontend/console/tests/onboarding.test.ts
+++ b/frontend/console/tests/onboarding.test.ts
@@ -5,6 +5,7 @@ import {
   buildConfigPayload,
   defaultBaseURLForKind,
   emptyOnboardingForm,
+  formFromConfigValues,
   suggestedAuthModeForKind,
   validateForm,
   validateProviderStep,
@@ -151,4 +152,80 @@ test('suggestedAuthModeForKind defaults oauth for codex/claude-code-cli, api-key
   assert.equal(suggestedAuthModeForKind('claude-code-cli'), 'oauth')
   assert.equal(suggestedAuthModeForKind('openai'), 'api-key')
   assert.equal(suggestedAuthModeForKind('anthropic'), 'api-key')
+})
+
+test('formFromConfigValues prefills the first provider and 3 tiers', () => {
+  const values = {
+    llm_providers: {
+      openai: {
+        kind: 'openai',
+        auth_mode: 'api-key',
+        api_key: 'sk-t****ast4',
+        base_url: 'https://api.openai.com/v1',
+      },
+    },
+    llm_tiers: {
+      heavy: { provider: 'openai', model: 'gpt-5.4', reasoning_effort: 'high' },
+      standard: { provider: 'openai', model: 'gpt-5.4' },
+      light: { provider: 'openai', model: 'gpt-5.4-mini' },
+    },
+  }
+  const form = formFromConfigValues(values)
+  assert.equal(form.provider.alias, 'openai')
+  assert.equal(form.provider.kind, 'openai')
+  assert.equal(form.provider.auth_mode, 'api-key')
+  assert.equal(form.provider.base_url, 'https://api.openai.com/v1')
+  assert.equal(form.provider.keepExistingApiKey, true, 'masked api_key should set keepExisting=true')
+  assert.equal(form.tiers.heavy.model, 'gpt-5.4')
+  assert.equal(form.tiers.heavy.reasoning_effort, 'high')
+  assert.equal(form.tiers.standard.provider, 'openai')
+  assert.equal(form.tiers.light.model, 'gpt-5.4-mini')
+})
+
+test('formFromConfigValues handles empty values gracefully', () => {
+  const form = formFromConfigValues({})
+  assert.equal(form.provider.alias, '')
+  assert.equal(form.tiers.heavy.provider, '')
+})
+
+test('buildConfigPayload omits api_key when keepExistingApiKey is set', () => {
+  const form = emptyOnboardingForm()
+  form.provider.alias = 'openai'
+  form.provider.kind = 'openai'
+  form.provider.api_key = '****abcd'
+  form.provider.keepExistingApiKey = true
+  for (const tier of ['heavy', 'standard', 'light'] as const) {
+    form.tiers[tier].provider = 'openai'
+    form.tiers[tier].model = 'gpt-5.4'
+  }
+  const payload = buildConfigPayload(form) as {
+    llm_providers: { openai: Record<string, unknown> }
+  }
+  assert.equal('api_key' in payload.llm_providers.openai, false, 'masked key must not be patched back')
+})
+
+test('buildConfigPayload includes api_key when user supplies a fresh value', () => {
+  const form = emptyOnboardingForm()
+  form.provider.alias = 'openai'
+  form.provider.kind = 'openai'
+  form.provider.api_key = 'sk-fresh-replacement'
+  form.provider.keepExistingApiKey = false
+  for (const tier of ['heavy', 'standard', 'light'] as const) {
+    form.tiers[tier].provider = 'openai'
+    form.tiers[tier].model = 'gpt-5.4'
+  }
+  const payload = buildConfigPayload(form) as {
+    llm_providers: { openai: Record<string, unknown> }
+  }
+  assert.equal(payload.llm_providers.openai.api_key, 'sk-fresh-replacement')
+})
+
+test('validateProviderStep accepts api-key mode without typed key when keepExisting=true', () => {
+  const form = emptyOnboardingForm()
+  form.provider.alias = 'openai'
+  form.provider.kind = 'openai'
+  form.provider.auth_mode = 'api-key'
+  form.provider.api_key = '' // user did not type anything
+  form.provider.keepExistingApiKey = true
+  assert.equal(validateProviderStep(form).length, 0)
 })


### PR DESCRIPTION
## Summary

Final phase of the onboarding Epic ([#637](https://github.com/devlikebear/tars/issues/637)). Now that the wizard works end-to-end on first run (Phase 1 + 2 + 3), users can reach the same wizard from a normal-mode console to swap providers or change tier bindings — without losing the existing API key on disk.

Closes #636

## Commits

1. \`feat: parse ?reentry query on the onboarding route\` — router accepts \`?reentry=1|true|yes\` and reflects it on Route.
2. \`feat: support reentry prefill + Keep existing for masked api_key\` — \`formFromConfigValues\`, \`keepExistingApiKey\` flag, validation + payload builder updates, 5 new unit tests.
3. \`feat: support reentry mode in Onboarding wizard\` — \`reentry\` prop, schema-driven prefill on mount, "(현재 값 유지)" hint on the api_key input, \`[Save only]\` vs \`[Save & Restart]\` split on the review step, new "saved" terminal step with [지금 재시작] / [나중에] exits.
4. \`feat: add Run setup wizard card to the Config page\` — small entry card at the top of /console/config that pushes \`/console/onboarding?reentry=1\`.
5. \`docs: document onboarding flow in CLAUDE.md and README\` — new "Onboarding" section in CLAUDE.md, README Quick Start leads with the wizard happy path.

## What changes for users

- **Re-running the wizard** from a fully configured server: \`/console/config\` → "설정 마법사 다시 실행 →" card opens \`/console/onboarding?reentry=1\` with the existing provider + tiers prefilled.
- **API key preservation**: the masked api_key from the schema endpoint is shown as \`(현재 값 유지)\`. Saving without typing a new key omits \`api_key\` from the PATCH payload, so PatchYAML keeps the on-disk credential intact. Typing a new value flips off the keep-existing pin.
- **Save without restart**: in re-entry mode, the review step exposes \`[저장만 (재시작 없이)]\` alongside \`[저장하고 재시작]\`. Save-only ends on a "Saved" screen with \`[나중에]\` (back to console) and \`[지금 재시작]\` (kicks off the same restart + healthz polling cycle as the first-run path).
- **Header copy switches** to "Reconfigure" / "이미 설정된 값이 prefill되어 있습니다…" when the wizard is re-entered, so it's clear that blank fields will not overwrite anything.

## What stayed the same

- First-run path (\`/console/onboarding\` without query) still mounts with a blank form, single \`[저장하고 재시작]\` button, and the existing 4-step UX.
- Phase 2 setup-only mux is unchanged. \`?reentry=1\` only matters in normal mode where \`needs_setup=false\`.
- Backend has zero changes — all wizard mutations still go through the existing \`PATCH /v1/admin/config/values\` + \`POST /v1/admin/restart\` endpoints.

## Test plan

- [x] \`npm test\` — 188 frontend tests pass (5 new for prefill / Keep-existing / payload omission).
- [x] \`npm run check\` — 480 files, 0 errors / 0 warnings.
- [x] \`make test\` — full Go suite green.
- [x] \`make vet\` — clean.
- [x] \`make security-scan\` — clean.
- [ ] Manual smoke (planned, not executed in this PR): live console run of the re-entry happy path.

## Out of scope (separate follow-up issues if wanted)

- **QuickStart shortcut** (one-click recommended defaults).
- **Provider live validation** (probe LLM endpoint with the entered key).
- **Multi-provider editor** (currently the wizard edits the first alias only — additional providers must be added through the YAML editor or the Settings field surface).
- **role_defaults UI** (still managed through the regular Config page).
- **i18n full English** for wizard labels (Korean-first with English glossary terms inline).

This closes the onboarding Epic. The Phase 1-4 series ships a complete browser-driven setup loop: empty config → degraded boot → wizard → normal mode → re-entry from Settings.