### PR TITLE
fix(onboarding): wizard derives auth_mode + oauth_provider from kind

### DIFF
--- a/frontend/console/src/components/Onboarding.svelte
+++ b/frontend/console/src/components/Onboarding.svelte
@@ -8,6 +8,7 @@
     restartServer,
   } from '../lib/api'
   import {
+    availableAuthModesForKind,
     buildConfigPayload,
     defaultBaseURLForKind,
     emptyOnboardingForm,
@@ -33,6 +34,7 @@
 
   let step = $state<StepId>('provider')
   let form = $state<OnboardingFormState>(emptyOnboardingForm())
+  let availableAuthModes = $derived(availableAuthModesForKind(form.provider.kind))
   let setupStatus = $state<SetupStatusResponse | null>(null)
   let stepErrors = $state<string[]>([])
   let saveError = $state<string>('')
@@ -85,7 +87,14 @@
     if (form.provider.base_url.trim() === '') {
       form.provider.base_url = defaultBaseURLForKind(kind)
     }
-    form.provider.auth_mode = suggestedAuthModeForKind(kind) as AuthMode
+    // Reset auth_mode to a value valid for the picked kind. If the
+    // user had selected api-key for an api-key kind and switches to
+    // claude-code-cli (cli-only), keeping the stale value would let
+    // them advance with an invalid combo.
+    const valid = availableAuthModesForKind(kind)
+    if (!valid.includes(form.provider.auth_mode)) {
+      form.provider.auth_mode = suggestedAuthModeForKind(kind)
+    }
     if (form.provider.alias.trim() === '' && kind !== '') {
       form.provider.alias = kind
     }
@@ -255,9 +264,10 @@
 
         <label class="onboarding-field">
           <span>인증 모드 <em>auth_mode</em></span>
-          <select bind:value={form.provider.auth_mode}>
-            <option value="api-key">api-key</option>
-            <option value="oauth">oauth</option>
+          <select bind:value={form.provider.auth_mode} disabled={availableAuthModes.length <= 1 && form.provider.kind !== ''}>
+            {#each availableAuthModes as mode}
+              <option value={mode}>{mode}</option>
+            {/each}
           </select>
         </label>
 
@@ -278,14 +288,17 @@
           <span>Base URL <em>비우면 kind 기본값 사용</em></span>
           <input type="url" bind:value={form.provider.base_url} placeholder={defaultBaseURLForKind(form.provider.kind)} />
         </label>
-
-        {#if form.provider.auth_mode === 'oauth'}
-          <label class="onboarding-field">
-            <span>OAuth Provider <em>선택</em></span>
-            <input type="text" bind:value={form.provider.oauth_provider} placeholder="openai-codex" />
-          </label>
-        {/if}
       </div>
+
+      {#if form.provider.auth_mode === 'oauth'}
+        <p class="onboarding-hint">
+          <strong>OAuth 인증</strong> · 환경변수 또는 OAuth 핸드셰이크에서 자동으로 토큰을 받습니다. 선택한 kind에 맞는 OAuth provider가 자동 적용됩니다 (별도 입력 불필요).
+        </p>
+      {:else if form.provider.auth_mode === 'cli'}
+        <p class="onboarding-hint">
+          <strong>CLI 인증</strong> · 로컬에 설치된 <code>claude-code</code> CLI를 통해 인증합니다. 추가 키 입력 없이도 동작합니다 (CLI 자체 로그인 상태가 사용됩니다).
+        </p>
+      {/if}
 
       <div class="onboarding-actions">
         <span class="onboarding-spacer"></span>
@@ -582,6 +595,27 @@
     margin-top: var(--space-4);
   }
   .onboarding-spacer { flex: 1; }
+  .onboarding-hint {
+    margin: var(--space-4) 0 0;
+    padding: var(--space-3) var(--space-4);
+    border: 1px solid var(--border-soft);
+    border-left: 3px solid var(--primary);
+    border-radius: 6px;
+    background: var(--surface-1);
+    color: var(--text-muted);
+    font-size: 13px;
+    line-height: 1.55;
+  }
+  .onboarding-hint strong {
+    color: var(--text-primary);
+    margin-right: 4px;
+  }
+  .onboarding-hint code {
+    background: var(--surface-2);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 12px;
+  }
   .onboarding-review {
     display: flex;
     flex-direction: column;

--- a/frontend/console/src/lib/onboarding.ts
+++ b/frontend/console/src/lib/onboarding.ts
@@ -24,7 +24,7 @@ export const providerKinds: ProviderKind[] = [
   'claude-code-cli',
 ]
 
-export type AuthMode = 'api-key' | 'oauth'
+export type AuthMode = 'api-key' | 'oauth' | 'cli'
 
 export type OnboardingProvider = {
   alias: string
@@ -147,10 +147,12 @@ export function buildConfigPayload(form: OnboardingFormState): Record<string, un
   if (form.provider.base_url.trim() !== '') {
     provider.base_url = form.provider.base_url.trim()
   }
-  if (form.provider.auth_mode === 'oauth' && form.provider.oauth_provider) {
-    const op = form.provider.oauth_provider.trim()
-    if (op !== '') provider.oauth_provider = op
-  }
+  // oauth_provider is intentionally omitted from the payload. The
+  // backend's providerAuthConfig (internal/llm/provider.go) auto-fills
+  // it from the per-kind defaults in internal/llmdefaults/. Asking the
+  // user a second time made the kind selection feel redundant; if a
+  // pre-existing oauth_provider value is on disk PatchYAML preserves
+  // it because we never write the key.
 
   const tiers: Record<string, Record<string, unknown>> = {}
   for (const tier of requiredTiers) {
@@ -197,17 +199,35 @@ export function defaultBaseURLForKind(kind: ProviderKind | ''): string {
   }
 }
 
-// suggestedAuthModeForKind picks the natural default auth mode per
-// provider kind. The wizard calls this when the user changes kind so
-// the form switches between api-key and oauth flows automatically.
-export function suggestedAuthModeForKind(kind: ProviderKind | ''): AuthMode {
+// availableAuthModesForKind returns the closed set of auth_mode
+// values that are valid for a given provider kind. Mirrors the
+// per-kind defaults in internal/llmdefaults/defaults.go: most kinds
+// authenticate with an API key, openai-codex uses an OAuth handshake,
+// and claude-code-cli delegates to the local `claude-code` CLI.
+//
+// The wizard uses this to populate the auth_mode select with only
+// the modes that make sense for the picked kind, instead of letting
+// the user pick a structurally-invalid combination like
+// claude-code-cli + api-key.
+export function availableAuthModesForKind(kind: ProviderKind | ''): AuthMode[] {
   switch (kind) {
     case 'openai-codex':
+      return ['oauth']
     case 'claude-code-cli':
-      return 'oauth'
+      return ['cli']
+    case 'anthropic':
+      return ['api-key', 'oauth']
+    case '':
+      return ['api-key', 'oauth', 'cli']
     default:
-      return 'api-key'
+      return ['api-key']
   }
+}
+
+// suggestedAuthModeForKind picks the natural default auth mode per
+// provider kind — the first entry of availableAuthModesForKind.
+export function suggestedAuthModeForKind(kind: ProviderKind | ''): AuthMode {
+  return availableAuthModesForKind(kind)[0]
 }
 
 // formFromConfigValues maps a config schema's values map into the

--- a/frontend/console/tests/onboarding.test.ts
+++ b/frontend/console/tests/onboarding.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 
 import {
+  availableAuthModesForKind,
   buildConfigPayload,
   defaultBaseURLForKind,
   emptyOnboardingForm,
@@ -147,11 +148,48 @@ test('defaultBaseURLForKind returns canonical URLs and empty for local', () => {
   assert.equal(defaultBaseURLForKind(''), '')
 })
 
-test('suggestedAuthModeForKind defaults oauth for codex/claude-code-cli, api-key elsewhere', () => {
+test('availableAuthModesForKind narrows the auth_mode select per kind', () => {
+  assert.deepEqual(availableAuthModesForKind('openai-codex'), ['oauth'])
+  assert.deepEqual(availableAuthModesForKind('claude-code-cli'), ['cli'])
+  assert.deepEqual(availableAuthModesForKind('anthropic'), ['api-key', 'oauth'])
+  assert.deepEqual(availableAuthModesForKind('openai'), ['api-key'])
+  assert.deepEqual(availableAuthModesForKind('kimi'), ['api-key'])
+  assert.deepEqual(availableAuthModesForKind('gemini'), ['api-key'])
+  assert.deepEqual(availableAuthModesForKind('gemini-native'), ['api-key'])
+  // Empty kind: every mode is offered until the user picks one.
+  assert.deepEqual(availableAuthModesForKind(''), ['api-key', 'oauth', 'cli'])
+})
+
+test('suggestedAuthModeForKind matches the head of availableAuthModesForKind', () => {
   assert.equal(suggestedAuthModeForKind('openai-codex'), 'oauth')
-  assert.equal(suggestedAuthModeForKind('claude-code-cli'), 'oauth')
+  assert.equal(suggestedAuthModeForKind('claude-code-cli'), 'cli', 'cli kinds must default to cli, not oauth')
   assert.equal(suggestedAuthModeForKind('openai'), 'api-key')
   assert.equal(suggestedAuthModeForKind('anthropic'), 'api-key')
+})
+
+test('buildConfigPayload never emits oauth_provider — backend infers from kind', () => {
+  const form = emptyOnboardingForm()
+  form.provider.alias = 'codex'
+  form.provider.kind = 'openai-codex'
+  form.provider.auth_mode = 'oauth'
+  form.provider.oauth_provider = 'should-be-ignored-by-payload'
+  for (const tier of ['heavy', 'standard', 'light'] as const) {
+    form.tiers[tier].provider = 'codex'
+    form.tiers[tier].model = 'gpt-5.4'
+  }
+  const payload = buildConfigPayload(form) as {
+    llm_providers: { codex: Record<string, unknown> }
+  }
+  assert.equal('oauth_provider' in payload.llm_providers.codex, false)
+})
+
+test('validateProviderStep accepts cli auth_mode without api_key', () => {
+  const form = emptyOnboardingForm()
+  form.provider.alias = 'claude'
+  form.provider.kind = 'claude-code-cli'
+  form.provider.auth_mode = 'cli'
+  form.provider.api_key = ''
+  assert.equal(validateProviderStep(form).length, 0)
 })
 
 test('formFromConfigValues prefills the first provider and 3 tiers', () => {


### PR DESCRIPTION
## Summary

Closes the two related Provider-step issues raised in #646 — both reproduce on the screenshot: \`claude-code-cli + oauth + manually re-typed openai-codex\` is structurally invalid, but the wizard let the user assemble it.

Closes #646

## What changed

1. **\`AuthMode\` union** now includes \`'cli'\` so claude-code-cli has a real wizard path.
2. **\`availableAuthModesForKind(kind)\`** returns the closed list of valid modes per kind, mirroring \`internal/llmdefaults/defaults.go\`. The wizard select renders only those entries; the option list disables when only one mode applies.
3. **\`suggestedAuthModeForKind\`** is now the head of \`availableAuthModesForKind\` — claude-code-cli defaults to \`cli\` (was \`oauth\`, which was wrong from day one).
4. **OAuth Provider input is gone.** The backend's \`providerAuthConfig\` (\`internal/llm/provider.go:289-295\`) already auto-fills it from the per-kind defaults, so asking the user a second time was pure noise. \`buildConfigPayload\` now omits the field; PatchYAML preserves any pre-existing on-disk value because we never write the key.
5. **Inline hints** replace the OAuth Provider input: one for \`oauth\` ("환경변수 또는 OAuth 핸드셰이크에서 자동으로 토큰을 받습니다…"), one for \`cli\` ("로컬에 설치된 claude-code CLI를 통해 인증합니다").
6. **\`handleKindChange\`** resets auth_mode only when the previous selection becomes invalid for the new kind — switching openai → kimi keeps \`api-key\` untouched.

## Per-kind matrix the wizard now offers

| Kind | Modes shown | Default | Hint |
|---|---|---|---|
| (none picked) | api-key / oauth / cli | api-key | — |
| \`openai\`, \`kimi\`, \`gemini\`, \`gemini-native\` | api-key | api-key | API Key 입력 |
| \`anthropic\` | api-key, oauth | api-key | API Key 또는 OAuth |
| \`openai-codex\` | oauth | oauth | OAuth 자동 |
| \`claude-code-cli\` | cli | cli | claude-code CLI 위임 |

## Test plan

- [x] \`npm test\` — 191 frontend tests pass (5 new for the narrowing / cli default / payload omission / cli validation)
- [x] \`npm run check\` — 480 files, 0 errors / 0 warnings
- [x] \`make console-build\` — green
- [x] \`make test\` — full Go suite green
- [x] \`make vet\` — clean
- [x] \`make security-scan\` — clean
- [ ] Manual smoke (planned, not run): re-run wizard with \`claude-code-cli\`, confirm only \`cli\` shows in the auth_mode select and the OAuth Provider input is gone.

## Out of scope

- Multi-provider editor (the wizard still edits the first alias only).
- Reentering a hand-edited \`oauth_provider\` that differs from the canonical default. The wizard preserves it on disk (via the omit-from-payload semantics) but does not surface it for editing — operators with that need use the YAML editor.
- Surfacing per-kind API key env vars in the hint (e.g. "or set OPENAI_API_KEY"). Possible follow-up.