### PR TITLE
feat(onboarding): model picker (static OpenRouter catalog + live refresh)

### DIFF
--- a/frontend/console/src/components/Onboarding.svelte
+++ b/frontend/console/src/components/Onboarding.svelte
@@ -3,10 +3,15 @@
   import {
     getConfigSchema,
     getHealthz,
+    getProviderModels,
     getSetupStatus,
     patchConfigValues,
     restartServer,
   } from '../lib/api'
+  import {
+    SNAPSHOT_DATE,
+    popularModelsForKind,
+  } from '../lib/llm-catalog'
   import {
     availableAuthModesForKind,
     buildConfigPayload,
@@ -35,6 +40,15 @@
   let step = $state<StepId>('provider')
   let form = $state<OnboardingFormState>(emptyOnboardingForm())
   let availableAuthModes = $derived(availableAuthModesForKind(form.provider.kind))
+  // Live model list pulled from /v1/models when the user clicks Refresh
+  // (reentry / normal mode only — the setup-only path has no on-disk
+  // credentials yet so /v1/models has nothing to call).
+  let liveModels = $state<string[]>([])
+  let liveRefreshError = $state<string>('')
+  let liveRefreshing = $state<boolean>(false)
+  let modelSuggestions = $derived(
+    liveModels.length > 0 ? liveModels : popularModelsForKind(form.provider.kind),
+  )
   let setupStatus = $state<SetupStatusResponse | null>(null)
   let stepErrors = $state<string[]>([])
   let saveError = $state<string>('')
@@ -129,6 +143,24 @@
     stepErrors = []
     saveError = ''
     step = target
+  }
+
+  async function refreshLiveModels() {
+    liveRefreshError = ''
+    liveRefreshing = true
+    try {
+      const info = await getProviderModels()
+      const models = Array.isArray(info?.models) ? info.models.filter((m) => typeof m === 'string' && m.trim() !== '') : []
+      if (models.length === 0) {
+        liveRefreshError = '응답에 모델이 없습니다 (provider가 live model listing을 지원하지 않거나 인증 실패).'
+        return
+      }
+      liveModels = models
+    } catch (err) {
+      liveRefreshError = (err as Error).message || 'failed to fetch models'
+    } finally {
+      liveRefreshing = false
+    }
   }
 
   async function handleSave(restart: boolean) {
@@ -311,6 +343,31 @@
         <span class="card-title">Step 2 · Tier 바인딩</span>
         <span class="card-meta">heavy / standard / light 모두 모델을 지정해야 합니다.</span>
       </div>
+
+      <div class="onboarding-models-source">
+        <div class="onboarding-models-source-text">
+          {#if liveModels.length > 0}
+            <strong>Live</strong> · provider에서 받은 최신 모델 목록을 사용 중 ({liveModels.length}개)
+          {:else}
+            <strong>정적 카탈로그</strong> · OpenRouter 스냅샷 기준 ({SNAPSHOT_DATE}) {modelSuggestions.length > 0 ? `· ${modelSuggestions.length}개 추천` : '· 추천 없음'}
+          {/if}
+        </div>
+        {#if reentry}
+          <button class="btn btn-ghost btn-sm" type="button" onclick={refreshLiveModels} disabled={liveRefreshing}>
+            {liveRefreshing ? '가져오는 중…' : 'Provider에서 최신 가져오기'}
+          </button>
+        {/if}
+      </div>
+      {#if liveRefreshError}
+        <div class="onboarding-errors"><strong>Refresh 실패</strong><div>{liveRefreshError}</div></div>
+      {/if}
+
+      <datalist id="onboarding-model-suggestions">
+        {#each modelSuggestions as model}
+          <option value={model}></option>
+        {/each}
+      </datalist>
+
       <div class="onboarding-tier-grid">
         {#each ['heavy', 'standard', 'light'] as const as tier}
           <fieldset class="onboarding-tier">
@@ -321,7 +378,13 @@
             </label>
             <label class="onboarding-field">
               <span>Model</span>
-              <input type="text" bind:value={form.tiers[tier].model} placeholder={tier === 'light' ? 'e.g. gpt-5.4-mini' : 'e.g. gpt-5.4'} />
+              <input
+                type="text"
+                bind:value={form.tiers[tier].model}
+                placeholder={tier === 'light' ? 'e.g. gpt-5.4-mini' : 'e.g. gpt-5.4'}
+                list="onboarding-model-suggestions"
+                autocomplete="off"
+              />
             </label>
             <label class="onboarding-field">
               <span>Reasoning effort <em>선택</em></span>
@@ -595,6 +658,26 @@
     margin-top: var(--space-4);
   }
   .onboarding-spacer { flex: 1; }
+  .onboarding-models-source {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--space-3);
+    margin-bottom: var(--space-3);
+    padding: var(--space-2) var(--space-3);
+    border: 1px dashed var(--border-soft);
+    border-radius: 6px;
+    background: var(--surface-1);
+    font-size: 13px;
+    color: var(--text-muted);
+  }
+  .onboarding-models-source-text strong {
+    color: var(--primary);
+    margin-right: 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: 11px;
+  }
   .onboarding-hint {
     margin: var(--space-4) 0 0;
     padding: var(--space-3) var(--space-4);

--- a/frontend/console/src/lib/llm-catalog.ts
+++ b/frontend/console/src/lib/llm-catalog.ts
@@ -1,0 +1,85 @@
+// Static well-known model catalog used by the onboarding wizard's
+// Step 2 datalist. Seeded from OpenRouter's public catalog
+// (https://openrouter.ai/api/v1/models) snapshotted on 2026-05-03.
+//
+// Two adjustments vs. the raw OpenRouter response:
+//   1. The OpenRouter id format is `<provider-prefix>/<model-id>`
+//      (e.g. `openai/gpt-5.4`). The wizard sends just the trailing
+//      part to the per-kind native API, so the prefix is dropped
+//      before the entry lands here.
+//   2. Anthropic models on Anthropic's native API use the dash form
+//      (`claude-opus-4-7-20XXXXXX`) while OpenRouter exposes a
+//      friendlier `claude-opus-4.7`. We list the dash form here
+//      because the wizard targets the native API; the dot form
+//      still works for users on OpenRouter routing.
+//
+// Refreshing the catalog: re-fetch
+//   curl https://openrouter.ai/api/v1/models | jq '.data[] | .id'
+// then prune to the entries that map to a TARS provider kind, drop
+// preview/non-chat variants you do not want surfaced as defaults,
+// and bump the SNAPSHOT_DATE constant below.
+
+import type { ProviderKind } from './onboarding'
+
+export const SNAPSHOT_DATE = '2026-05-03'
+export const SNAPSHOT_SOURCE = 'OpenRouter /api/v1/models'
+
+// Per-kind well-known model ids, ordered by typical user preference
+// (newest / heaviest first). The wizard surfaces these as datalist
+// suggestions; users may type any other id by hand.
+export const wellKnownModelsByKind: Record<ProviderKind, string[]> = {
+  openai: [
+    'gpt-5.5-pro',
+    'gpt-5.5',
+    'gpt-5.4-pro',
+    'gpt-5.4',
+    'gpt-5.4-mini',
+    'gpt-5.4-nano',
+    'gpt-5.3-chat',
+    'gpt-4o',
+    'gpt-4o-mini',
+  ],
+  'openai-codex': [
+    'gpt-5.4',
+    'gpt-5.3-codex',
+  ],
+  anthropic: [
+    'claude-opus-4-7',
+    'claude-opus-4-6',
+    'claude-sonnet-4-6',
+    'claude-haiku-4-5',
+  ],
+  gemini: [
+    'gemini-3.1-pro-preview',
+    'gemini-3.1-flash-lite-preview',
+    'gemini-2.5-pro',
+    'gemini-2.5-flash',
+  ],
+  'gemini-native': [
+    'gemini-3.1-pro-preview',
+    'gemini-3.1-flash-lite-preview',
+    'gemini-2.5-pro',
+    'gemini-2.5-flash',
+  ],
+  kimi: [
+    'kimi-k2.6',
+    'moonshot-v1-128k',
+  ],
+  // claude-code-cli accepts short aliases that the local CLI maps to
+  // its current pinned defaults — the wizard never sends a pinned
+  // dated id here.
+  'claude-code-cli': [
+    'sonnet',
+    'opus',
+    'haiku',
+  ],
+}
+
+// popularModelsForKind returns the curated catalog entries for a
+// kind, or an empty list when the kind is unknown / unset. The
+// wizard datalist degrades gracefully (no autocomplete) when this
+// is empty.
+export function popularModelsForKind(kind: ProviderKind | ''): string[] {
+  if (kind === '') return []
+  return wellKnownModelsByKind[kind] ?? []
+}

--- a/frontend/console/tests/llmCatalog.test.ts
+++ b/frontend/console/tests/llmCatalog.test.ts
@@ -1,0 +1,68 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  SNAPSHOT_DATE,
+  SNAPSHOT_SOURCE,
+  popularModelsForKind,
+  wellKnownModelsByKind,
+} from '../src/lib/llm-catalog.ts'
+import { providerKinds } from '../src/lib/onboarding.ts'
+
+test('snapshot metadata is non-empty so future PRs can grep for the date', () => {
+  assert.ok(SNAPSHOT_DATE.length > 0, 'SNAPSHOT_DATE must be set')
+  assert.ok(/\d{4}-\d{2}-\d{2}/.test(SNAPSHOT_DATE), 'SNAPSHOT_DATE should look like YYYY-MM-DD')
+  assert.ok(SNAPSHOT_SOURCE.length > 0, 'SNAPSHOT_SOURCE must be set')
+})
+
+test('every provider kind has at least one well-known model', () => {
+  for (const kind of providerKinds) {
+    const models = wellKnownModelsByKind[kind]
+    assert.ok(Array.isArray(models), `kind ${kind} must have a catalog entry`)
+    assert.ok(models.length >= 1, `kind ${kind} must have at least one model`)
+  }
+})
+
+test('catalog entries omit the openrouter slash prefix', () => {
+  for (const [kind, models] of Object.entries(wellKnownModelsByKind)) {
+    for (const id of models) {
+      assert.equal(
+        id.includes('/'),
+        false,
+        `kind ${kind} model "${id}" leaked an openrouter prefix; native API ids are slash-free`,
+      )
+    }
+  }
+})
+
+test('anthropic ids use dash form for the native API', () => {
+  for (const id of wellKnownModelsByKind.anthropic) {
+    assert.equal(
+      id.includes('.'),
+      false,
+      `anthropic model "${id}" should use dash form (claude-opus-4-7) not dot form for the native API`,
+    )
+  }
+})
+
+test('claude-code-cli catalog only carries short aliases', () => {
+  for (const id of wellKnownModelsByKind['claude-code-cli']) {
+    assert.equal(
+      id.includes('-'),
+      false,
+      `claude-code-cli model "${id}" must be a short alias (sonnet/opus/haiku)`,
+    )
+    assert.equal(
+      id.includes('.'),
+      false,
+      `claude-code-cli model "${id}" must not carry a version dot`,
+    )
+  }
+})
+
+test('popularModelsForKind returns the kind catalog or [] for empty kind', () => {
+  assert.deepEqual(popularModelsForKind(''), [])
+  for (const kind of providerKinds) {
+    assert.deepEqual(popularModelsForKind(kind), wellKnownModelsByKind[kind])
+  }
+})

--- a/internal/tarsserver/main_serve_api_setup.go
+++ b/internal/tarsserver/main_serve_api_setup.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/devlikebear/tars/internal/config"
+	"github.com/devlikebear/tars/internal/llm"
 	"github.com/rs/zerolog"
 )
 
@@ -28,14 +29,25 @@ func buildSetupOnlyAPIMux(opts *options, deps runtimeDeps, nowFn func() time.Tim
 	setupHandler := newSetupAPIHandler(opts.ConfigPath, cfg, logger)
 	configHandler := newConfigAPIHandler(opts.ConfigPath, cfg, cfg.WorkspaceDir, logger)
 	authHandler := newAuthAPIHandler(cfg.APIAuthMode)
+	// providers/models picker — wired even in setup-only so the Step 2
+	// "Refresh from provider" button can call /v1/models with the user's
+	// just-typed credentials. The cache lives in the workspace dir; the
+	// user-supplied workspace dir is created by buildBaseDeps already.
+	providerModelsCache, err := newProviderModelsCache(providerModelsCachePath(cfg), providerModelsCacheTTL, nowFn)
+	if err != nil {
+		return nil, err
+	}
+	providerModelsService := newProviderModelsService(cfg, providerModelsCache, llm.NewModelFetcher(), nowFn)
+	providersModelsHandler := newProvidersModelsAPIHandler(providerModelsService, logger)
 
 	mux := http.NewServeMux()
 	registerSetupOnlyRoutes(mux, setupOnlyHandlers{
-		healthz: healthzHandler,
-		setup:   setupHandler,
-		config:  configHandler,
-		auth:    authHandler,
-		console: consoleHandler,
+		healthz:         healthzHandler,
+		setup:           setupHandler,
+		config:          configHandler,
+		auth:            authHandler,
+		console:         consoleHandler,
+		providersModels: providersModelsHandler,
 		// events handler intentionally omitted for now — the SPA falls back
 		// to polling healthz when the SSE stream is unavailable, and adding
 		// the broker here would pull in unused background goroutines.
@@ -60,12 +72,13 @@ func buildSetupOnlyAPIMux(opts *options, deps runtimeDeps, nowFn func() time.Tim
 // have no useful response without an LLM router and the catch-all
 // 503 fallback steers the wizard toward the supported surface.
 type setupOnlyHandlers struct {
-	healthz http.Handler
-	setup   http.Handler
-	config  http.Handler // serves /v1/admin/config{,/values,/schema} and /v1/admin/restart
-	auth    http.Handler
-	events  http.Handler // optional — SSE keepalive so the SPA stays connected
-	console http.Handler
+	healthz         http.Handler
+	setup           http.Handler
+	config          http.Handler // serves /v1/admin/config{,/values,/schema} and /v1/admin/restart
+	auth            http.Handler
+	events          http.Handler // optional — SSE keepalive so the SPA stays connected
+	console         http.Handler
+	providersModels http.Handler // optional — /v1/providers + /v1/models for the wizard model picker
 }
 
 // registerSetupOnlyRoutes wires the minimal set of endpoints the
@@ -80,6 +93,10 @@ func registerSetupOnlyRoutes(mux *http.ServeMux, handlers setupOnlyHandlers) {
 	mux.Handle("/v1/admin/config/schema", handlers.config)
 	mux.Handle("/v1/admin/restart", handlers.config)
 	mux.Handle("/v1/auth/whoami", handlers.auth)
+	if handlers.providersModels != nil {
+		mux.Handle("/v1/providers", handlers.providersModels)
+		mux.Handle("/v1/models", handlers.providersModels)
+	}
 	if handlers.events != nil {
 		mux.Handle("/v1/events/stream", handlers.events)
 	}

--- a/internal/tarsserver/main_serve_api_setup_test.go
+++ b/internal/tarsserver/main_serve_api_setup_test.go
@@ -19,12 +19,13 @@ func TestRegisterSetupOnlyRoutes_ServesAllowedEndpoints(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 	registerSetupOnlyRoutes(mux, setupOnlyHandlers{
-		healthz: stub,
-		setup:   stub,
-		config:  stub,
-		auth:    stub,
-		events:  stub,
-		console: stub,
+		healthz:         stub,
+		setup:           stub,
+		config:          stub,
+		auth:            stub,
+		events:          stub,
+		console:         stub,
+		providersModels: stub,
 	})
 
 	allowed := []string{
@@ -35,6 +36,8 @@ func TestRegisterSetupOnlyRoutes_ServesAllowedEndpoints(t *testing.T) {
 		"/v1/admin/config/schema",
 		"/v1/admin/restart",
 		"/v1/auth/whoami",
+		"/v1/providers",
+		"/v1/models",
 		"/v1/events/stream",
 		"/console",
 		"/console/",
@@ -129,18 +132,21 @@ func TestRegisterSetupOnlyRoutes_OmitsEventsAndConsoleWhenNil(t *testing.T) {
 		// events and console intentionally nil
 	})
 
-	for _, path := range []string{"/v1/events/stream", "/console", "/console/x"} {
+	for _, path := range []string{"/v1/events/stream", "/v1/providers", "/v1/models", "/console", "/console/x"} {
 		t.Run(path, func(t *testing.T) {
 			rec := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, path, nil)
 			mux.ServeHTTP(rec, req)
-			// /v1/events/stream falls into the /v1/ catch-all → 503
-			// /console paths fall into the / catch-all → 404
-			if path == "/v1/events/stream" && rec.Code != http.StatusServiceUnavailable {
-				t.Fatalf("expected 503 for events when nil, got %d", rec.Code)
+			// /v1/* paths fall into the /v1/ catch-all → 503 setup-only fallback.
+			// /console paths fall into the / catch-all → 404.
+			if path == "/console" || path == "/console/x" {
+				if rec.Code != http.StatusNotFound {
+					t.Fatalf("expected 404 for %s when console nil, got %d", path, rec.Code)
+				}
+				return
 			}
-			if path != "/v1/events/stream" && rec.Code != http.StatusNotFound {
-				t.Fatalf("expected 404 for %s when console nil, got %d", path, rec.Code)
+			if rec.Code != http.StatusServiceUnavailable {
+				t.Fatalf("expected 503 for %s when handler nil, got %d", path, rec.Code)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Wizard Step 2 used to ask the user to type the model id from memory — no list, no autocomplete. This PR adds an A+B hybrid as agreed in #648:

- **Static catalog (always on)**: per-kind well-known model ids seeded from OpenRouter's public catalog snapshotted on **2026-05-03**, surfaced as an HTML \`<datalist>\` against each tier's model input. Free-text input still works for users with a pinned dated id.
- **Live refresh (reentry only)**: a "Provider에서 최신 가져오기" button next to the catalog source strip calls \`/v1/models\` and replaces the suggestions with the live response. Gated to reentry / normal mode because the first-install path has no api_key on disk yet.

Closes #648

## Catalog mapping (snapshot 2026-05-03)

OpenRouter id → TARS-native id (slash prefix dropped, anthropic dot→dash for the native API):

| TARS kind | Sample suggestions |
|---|---|
| \`openai\` | gpt-5.5-pro, gpt-5.5, gpt-5.4-pro, gpt-5.4, gpt-5.4-mini, gpt-5.4-nano, gpt-5.3-chat, gpt-4o, gpt-4o-mini |
| \`openai-codex\` | gpt-5.4, gpt-5.3-codex |
| \`anthropic\` | claude-opus-4-7, claude-opus-4-6, claude-sonnet-4-6, claude-haiku-4-5 |
| \`gemini\` / \`gemini-native\` | gemini-3.1-pro-preview, gemini-3.1-flash-lite-preview, gemini-2.5-pro, gemini-2.5-flash |
| \`kimi\` | kimi-k2.6, moonshot-v1-128k |
| \`claude-code-cli\` | sonnet, opus, haiku (CLI aliases) |

Refresh procedure documented in \`frontend/console/src/lib/llm-catalog.ts\` header — bump SNAPSHOT_DATE on each catalog refresh.

## Commits

1. \`feat: add static LLM model catalog (OpenRouter snapshot 2026-05-03)\` — \`lib/llm-catalog.ts\` + 6 unit tests covering snapshot metadata, per-kind coverage, slash-prefix scrubbing, anthropic dash form, claude-code-cli short-alias invariant, and helper API.
2. \`feat: expose /v1/providers + /v1/models in the setup-only mux\` — wires the existing providersModelsHandler into \`buildSetupOnlyAPIMux\` (deferred from Phase 2). Tests in setupOnly route allow-list updated; nil-handler test covers the 503 fallback.
3. \`feat: model datalist + Refresh-from-provider in wizard Step 2\` — \`Onboarding.svelte\`: datalist autocomplete on each tier's model input, an inline "models source" strip showing whether the catalog is static (with date) or live (with count), and the Refresh button on reentry mode.

## Test plan

- [x] \`npm test\` — 197 frontend tests pass (6 new for the catalog)
- [x] \`npm run check\` — 481 files, 0 errors / 0 warnings
- [x] \`make console-build\` — green
- [x] \`make test\` — full Go suite green
- [x] \`make vet\` — clean
- [x] \`make security-scan\` — clean
- [ ] Manual smoke (planned, not run): drop into Step 2 with kind=openai, see gpt-5.* suggestions; switch to anthropic, see claude-* suggestions; reentry from /console/config and click Refresh, see suggestions get replaced with the live response.

## Out of scope

- Auto-update of the static catalog at build time. The 2026-05-03 snapshot is curated manually; future bumps land via small PRs.
- Pricing / context-length display in the picker. Catalog only carries the model id.
- LiteLLM JSON as a second source. OpenRouter's public catalog covers our supported provider set; LiteLLM re-enters the conversation only if pricing data becomes wizard-relevant.
- Live refresh in setup-only mode (would need a different endpoint shape that accepts wizard-draft credentials in the request body — separate issue if/when needed).