### PR TITLE
fix(onboarding): missing-config fallback applies env-var overrides

### DIFF
--- a/internal/tarsserver/main_bootstrap.go
+++ b/internal/tarsserver/main_bootstrap.go
@@ -77,10 +77,15 @@ func loadConfigForServe(opts *options) (config.Config, error) {
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			// First-run case: the operator (or `tars init`) hasn't
-			// written a file yet. Boot with defaults; the wizard will
-			// land its PATCH at resolvedPath (or the fixed default if
-			// none was given).
-			cfg = config.Default()
+			// written a file yet. Boot with defaults but route through
+			// config.Load("") so env-var overrides (TARS_API_AUTH_MODE
+			// etc.) and the schema defaults still apply — otherwise
+			// admin paths reject the wizard's first PATCH because the
+			// loopback / off-mode posture only arrives via env vars.
+			cfg, err = config.Load("")
+			if err != nil {
+				return config.Config{}, &runtimeDepsError{stage: "load_config", err: err}
+			}
 		} else {
 			return config.Config{}, &runtimeDepsError{stage: "load_config", err: err}
 		}

--- a/internal/tarsserver/main_bootstrap_missing_config_test.go
+++ b/internal/tarsserver/main_bootstrap_missing_config_test.go
@@ -69,3 +69,31 @@ func TestLoadConfigForServe_WorkspaceDirOverrideAppliesEvenWhenFileMissing(t *te
 		t.Fatalf("expected workspace_dir override %q, got %q", override, cfg.WorkspaceDir)
 	}
 }
+
+func TestLoadConfigForServe_MissingFileAppliesEnvOverrides(t *testing.T) {
+	// Regression for #650: when the config file does not exist yet,
+	// the fall-through must still run applyEnv so TARS_API_AUTH_MODE
+	// (and friends) reach the cfg the middleware sees. Without this
+	// the wizard's first PATCH /v1/admin/config/values returns 401.
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "does-not-exist.yaml")
+
+	t.Setenv("TARS_API_AUTH_MODE", "off")
+	t.Setenv("TARS_API_ALLOW_INSECURE_LOCAL_AUTH", "true")
+	t.Setenv("TARS_DASHBOARD_AUTH_MODE", "off")
+
+	opts := &options{ConfigPath: missing}
+	cfg, err := loadConfigForServe(opts)
+	if err != nil {
+		t.Fatalf("loadConfigForServe with envs: %v", err)
+	}
+	if cfg.APIAuthMode != "off" {
+		t.Fatalf("expected APIAuthMode=off from env, got %q", cfg.APIAuthMode)
+	}
+	if !cfg.APIAllowInsecureLocalAuth {
+		t.Fatalf("expected APIAllowInsecureLocalAuth=true from env, got false")
+	}
+	if cfg.DashboardAuthMode != "off" {
+		t.Fatalf("expected DashboardAuthMode=off from env, got %q", cfg.DashboardAuthMode)
+	}
+}


### PR DESCRIPTION
## Summary

Wizard reproduces a 401 on its first PATCH save against \`/v1/admin/config/values\`, exactly under the first-install scenario the rest of the onboarding series targets. Root cause: PR #645's missing-file fall-through skipped \`applyEnv\`, so the cfg the middleware sees ignores \`TARS_API_AUTH_MODE=off\` (and friends) that \`make dev-console\` installs as the local-dev posture.

Closes #650

## Repro

```bash
TEST_DIR=$(mktemp -d /tmp/tars-onboarding-test.XXXXXX)
mkdir -p "$TEST_DIR/workspace"
TARS_CONFIG="$TEST_DIR/workspace/config/tars.config.yaml" \
  WORKSPACE_DIR="$TEST_DIR/workspace" \
  API_ADDR="127.0.0.1:43181" \
  make dev-console
# wizard → 저장하고 재시작 → "저장 실패: unauthorized"
```

## Fix

Route the \`fs.ErrNotExist\` branch through \`config.Load("")\` instead of \`config.Default()\`. \`Load("")\` was already the canonical "no file but apply env + defaults" entry; using it keeps the missing-file path identical to "operator explicitly empty" which is the same operator intent.

```go
if errors.Is(err, fs.ErrNotExist) {
    cfg, err = config.Load("") // applies env + defaults
    if err != nil { return ... }
}
```

Adds \`TestLoadConfigForServe_MissingFileAppliesEnvOverrides\` — sets \`TARS_API_AUTH_MODE\` / \`DASHBOARD_AUTH_MODE\` / \`API_ALLOW_INSECURE_LOCAL_AUTH\` and asserts the env values reach the returned cfg.

## Test plan

- [x] \`go test ./internal/tarsserver/ -run TestLoadConfigForServe\` — 4 cases, all pass
- [x] \`make test\` — full suite green
- [x] \`make vet\` — clean
- [x] \`make security-scan\` — clean
- [ ] Manual smoke (planned, not executed): re-run the dev-console scenario above and confirm the wizard PATCH returns 200.