### PR TITLE
feat: provider-specific model listing for LLM tiers

### DIFF
--- a/frontend/console/src/components/Config.svelte
+++ b/frontend/console/src/components/Config.svelte
@@ -1,6 +1,15 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { getConfig, getConfigSchema, getProviderModels, saveConfig, patchConfigValues, resetWorkspace, restartServer } from '../lib/api'
+  import {
+    getConfig,
+    getConfigSchema,
+    getProviderModels,
+    getProviders,
+    saveConfig,
+    patchConfigValues,
+    resetWorkspace,
+    restartServer,
+  } from '../lib/api'
   import { buildConfigImpactPreview } from '../lib/configImpact'
   import { buildConfigMetaBadges } from '../lib/configMetaBadges'
   import { buildQuickStartItems, quickStartProgress } from '../lib/quickStartFields'
@@ -26,7 +35,7 @@
     type LLMTierDraftErrors,
     type LLMTierDraftField,
   } from '../lib/configStructured'
-  import type { ConfigFieldMeta, ConfigSchema } from '../lib/types'
+  import type { ConfigFieldMeta, ConfigSchema, ProvidersAPIInfo } from '../lib/types'
   import ConfigPendingChanges from './ConfigPendingChanges.svelte'
   import { t } from '../i18n'
 
@@ -69,6 +78,11 @@
   let providerEditorErrors: LLMProviderDraftErrors = $state({})
   let providerDraftSeq = 0
   let providerSecretReveal: Record<string, boolean> = $state({})
+  let tierModelOptionsByProvider: Record<string, string[]> = $state({})
+  let tierModelLoadingByProvider: Record<string, boolean> = $state({})
+  let tierModelLoadErrorByProvider: Record<string, string> = $state({})
+  let tierModelSupportsByAlias: Record<string, boolean> = $state({})
+  let providersMetadataRequest: Promise<ProvidersAPIInfo | null> | null = $state(null)
   let llmTestBusy = $state(false)
   let llmTestResult = $state('')
   let llmTestKind: 'success' | 'error' | '' = $state('')
@@ -76,6 +90,7 @@
   let hasDirtyFields = $derived(Object.keys(dirtyFields).length > 0)
   let quickStartItems = $derived(buildQuickStartItems(schema, values, dirtyFields))
   let quickStartStats = $derived(quickStartProgress(quickStartItems))
+  let shouldShowFieldActions = $derived(viewMode === 'quick' || viewMode === 'form')
 
   // -- Diff popup --
   let showDiff = $state(false)
@@ -378,7 +393,7 @@
     if ((e.metaKey || e.ctrlKey) && e.key === 's') {
       e.preventDefault()
       if (viewMode === 'yaml' && isYamlDirty && !saving) handleSaveYaml()
-      if (viewMode === 'form' && hasDirtyFields && !fieldSaving) handleSaveFields()
+      if ((viewMode === 'form' || viewMode === 'quick') && hasDirtyFields && !fieldSaving) handleSaveFields()
     }
   }
 
@@ -474,6 +489,10 @@
     tierDrafts = drafts.length > 0 ? drafts : [createTierDraft('standard')]
     tierEditorField = field
     tierEditorErrors = {}
+    tierModelOptionsByProvider = {}
+    tierModelLoadingByProvider = {}
+    tierModelLoadErrorByProvider = {}
+    void preloadTierModelOptions(drafts)
   }
 
   function openProviderEditor(field: ConfigFieldMeta) {
@@ -608,6 +627,9 @@
     tierDrafts = []
     tierEditorErrors = {}
     tierProviderOptions = []
+    tierModelOptionsByProvider = {}
+    tierModelLoadingByProvider = {}
+    tierModelLoadErrorByProvider = {}
   }
 
   function resetTierEditor() {
@@ -615,10 +637,18 @@
     const drafts = makeLLMTierDrafts(values[tierEditorField.key])
     tierDrafts = drafts.length > 0 ? drafts : [createTierDraft('standard')]
     tierEditorErrors = {}
+    tierModelOptionsByProvider = {}
+    tierModelLoadingByProvider = {}
+    tierModelLoadErrorByProvider = {}
+    void preloadTierModelOptions(drafts)
   }
 
   function addTierDraft() {
-    tierDrafts = [...tierDrafts, createTierDraft(nextTierName())]
+    const draft = createTierDraft(nextTierName())
+    tierDrafts = [...tierDrafts, draft]
+    if (draft?.provider.trim()) {
+      void ensureTierModelOptionsForProvider(draft.provider)
+    }
   }
 
   function removeTierDraft(id: string) {
@@ -628,8 +658,150 @@
     tierEditorErrors = remaining
   }
 
+  function normalizeProviderAlias(alias: string): string {
+    return alias.trim()
+  }
+
+  function setTierProviderModelSupport(providerAlias: string, supportsLiveModels: boolean) {
+    const alias = normalizeProviderAlias(providerAlias)
+    if (!alias) return
+    tierModelSupportsByAlias = { ...tierModelSupportsByAlias, [alias]: supportsLiveModels }
+  }
+
+  function getTierProviderSupportsLiveModels(alias: string): boolean | undefined {
+    const providerAlias = normalizeProviderAlias(alias)
+    if (!providerAlias || !Object.prototype.hasOwnProperty.call(tierModelSupportsByAlias, providerAlias)) return undefined
+    return tierModelSupportsByAlias[providerAlias]
+  }
+
+  function getProviderKindFromPool(metadata: Pick<ProvidersAPIInfo, 'pool'>, alias: string): string | null {
+    const target = normalizeProviderAlias(alias).toLowerCase()
+    const entry = metadata.pool.find((item) => normalizeProviderAlias(item.alias).toLowerCase() === target)
+    return entry?.kind?.trim().toLowerCase() || null
+  }
+
+  async function preloadProviderModelsMetadata(): Promise<ProvidersAPIInfo | null> {
+    if (providersMetadataRequest) {
+      try {
+        return await providersMetadataRequest
+      } catch {
+        providersMetadataRequest = null
+        return null
+      }
+    }
+
+    providersMetadataRequest = getProviders()
+    try {
+      return await providersMetadataRequest
+    } catch {
+      providersMetadataRequest = null
+      return null
+    }
+  }
+
+  async function providerSupportsLiveModels(alias: string): Promise<boolean> {
+    const normalizedAlias = normalizeProviderAlias(alias)
+    if (!normalizedAlias) return false
+    const cached = getTierProviderSupportsLiveModels(normalizedAlias)
+    if (cached !== undefined) return cached
+
+    const metadata = await preloadProviderModelsMetadata()
+    if (!metadata) {
+      setTierProviderModelSupport(normalizedAlias, true)
+      return true
+    }
+
+    const kind = getProviderKindFromPool(metadata, normalizedAlias)
+    if (!kind) {
+      setTierProviderModelSupport(normalizedAlias, true)
+      return true
+    }
+
+    const provider = metadata.providers.find((entry) => entry.id.toLowerCase() === kind)
+    const supports = provider ? provider.supports_live_models : true
+    setTierProviderModelSupport(normalizedAlias, supports)
+    return supports
+  }
+
+  function preloadTierModelOptions(drafts: LLMTierDraft[]) {
+    const providers = new Set<string>()
+    for (const draft of drafts) {
+      const provider = normalizeProviderAlias(draft.provider)
+      if (provider) providers.add(provider)
+    }
+    providers.forEach((provider) => {
+      void ensureTierModelOptionsForProvider(provider)
+    })
+  }
+
+  async function ensureTierModelOptionsForProvider(providerAlias: string) {
+    const alias = normalizeProviderAlias(providerAlias)
+    if (!alias) return
+    if (tierModelLoadingByProvider[alias] || Object.prototype.hasOwnProperty.call(tierModelOptionsByProvider, alias)) {
+      return
+    }
+    tierModelLoadingByProvider = { ...tierModelLoadingByProvider, [alias]: true }
+    tierModelLoadErrorByProvider = { ...tierModelLoadErrorByProvider, [alias]: '' }
+
+    try {
+      const supportsLiveModels = await providerSupportsLiveModels(alias)
+      if (!supportsLiveModels) {
+        tierModelOptionsByProvider = { ...tierModelOptionsByProvider, [alias]: [] }
+        tierModelLoadErrorByProvider = { ...tierModelLoadErrorByProvider, [alias]: 'Live model listing is unavailable for this provider' }
+        return
+      }
+
+      const info = await getProviderModels(alias)
+      const warning = typeof info.warning === 'string' ? info.warning.trim() : ''
+      const models = Array.isArray(info.models) ? info.models : []
+      const deduped = [...new Set(models.map((model) => String(model).trim()).filter(Boolean))].sort()
+      tierModelOptionsByProvider = { ...tierModelOptionsByProvider, [alias]: deduped }
+      tierModelLoadErrorByProvider = { ...tierModelLoadErrorByProvider, [alias]: warning }
+    } catch (error) {
+      tierModelLoadErrorByProvider = { ...tierModelLoadErrorByProvider, [alias]: error instanceof Error ? error.message : 'Failed to load models' }
+      tierModelOptionsByProvider = { ...tierModelOptionsByProvider, [alias]: [] }
+    } finally {
+      tierModelLoadingByProvider = { ...tierModelLoadingByProvider, [alias]: false }
+    }
+  }
+
+  function tierModelOptionsForProvider(alias: string): string[] {
+    const provider = normalizeProviderAlias(alias)
+    return provider && tierModelOptionsByProvider[provider] ? tierModelOptionsByProvider[provider] : []
+  }
+
+  function tierModelLoadingForProvider(alias: string): boolean {
+    const provider = normalizeProviderAlias(alias)
+    return !!tierModelLoadingByProvider[provider]
+  }
+
+  function tierModelLoadErrorForProvider(alias: string): string {
+    const provider = normalizeProviderAlias(alias)
+    return tierModelLoadErrorByProvider[provider] || ''
+  }
+
+  function tierModelOptionsForDraft(draft: LLMTierDraft): string[] {
+    const provider = normalizeProviderAlias(draft.provider)
+    if (!provider) return []
+    const options = tierModelOptionsForProvider(provider)
+    const current = normalizeProviderAlias(draft.model)
+    if (!current) return options
+    if (options.includes(current)) return options
+    return [current, ...options]
+  }
+
   function updateTierDraft(id: string, field: LLMTierDraftField, value: string) {
-    tierDrafts = tierDrafts.map((draft) => draft.id === id ? { ...draft, [field]: value } : draft)
+    tierDrafts = tierDrafts.map((draft) => {
+      if (draft.id !== id) return draft
+      const updated = { ...draft, [field]: value }
+      if (field === 'provider') {
+        updated.model = ''
+        if (normalizeProviderAlias(value)) {
+          void ensureTierModelOptionsForProvider(value)
+        }
+      }
+      return updated
+    })
     const rowErrors = tierEditorErrors[id]
     if (!rowErrors?.[field]) return
     const nextRowErrors = { ...rowErrors }
@@ -733,7 +905,7 @@
       {/if}
     </div>
     <div class="page-header-right">
-      {#if viewMode === 'form' && hasDirtyFields}
+      {#if shouldShowFieldActions && hasDirtyFields}
         <button class="badge badge-warning diff-badge" onclick={() => { showDiff = !showDiff }} title="View changes">{Object.keys(dirtyFields).length} changed</button>
         <button class="btn btn-ghost btn-sm" onclick={handleDiscardFields}>Discard</button>
         <button class="btn btn-primary btn-sm" disabled={fieldSaving} onclick={handleSaveFields}>
@@ -1214,11 +1386,32 @@
                 </label>
                 <label class="tier-field tier-field-model">
                   <span>Model</span>
-                  <input
-                    class:error={!!tierError(draft.id, 'model')}
-                    value={draft.model}
-                    oninput={(event) => updateTierDraft(draft.id, 'model', inputValue(event))}
-                  />
+                  {#if tierModelLoadingForProvider(draft.provider.trim())}
+                    <select class="tier-model-loading" disabled>
+                      <option value="">Loading models...</option>
+                    </select>
+                  {:else if tierModelOptionsForDraft(draft).length > 0}
+                      <select
+                        class:error={!!tierError(draft.id, 'model')}
+                        value={draft.model}
+                        onchange={(event) => updateTierDraft(draft.id, 'model', inputValue(event))}
+                      >
+                      <option value="">Select</option>
+                      {#each tierModelOptionsForDraft(draft) as model}
+                        <option value={model}>{model}</option>
+                      {/each}
+                    </select>
+                  {:else}
+                    <input
+                      class:error={!!tierError(draft.id, 'model')}
+                      value={draft.model}
+                      oninput={(event) => updateTierDraft(draft.id, 'model', inputValue(event))}
+                      placeholder="No model list available"
+                    />
+                  {/if}
+                  {#if tierModelLoadErrorForProvider(draft.provider.trim())}
+                    <small>{tierModelLoadErrorForProvider(draft.provider.trim())}</small>
+                  {/if}
                   {#if tierError(draft.id, 'model')}
                     <small>{tierError(draft.id, 'model')}</small>
                   {/if}

--- a/frontend/console/src/lib/api.ts
+++ b/frontend/console/src/lib/api.ts
@@ -10,6 +10,7 @@ import type {
   ConfigFile,
   ConfigSchema,
   HealthzResponse,
+  ProvidersAPIInfo,
   ProviderModelsInfo,
   SetupStatusResponse,
   HubInstallResponse,
@@ -931,8 +932,17 @@ export async function getConfigSchema(): Promise<ConfigSchema> {
   return requestJSON<ConfigSchema>('/v1/admin/config/schema')
 }
 
-export async function getProviderModels(): Promise<ProviderModelsInfo> {
-  return requestJSON<ProviderModelsInfo>('/v1/models')
+export async function getProviderModels(providerAlias = ''): Promise<ProviderModelsInfo> {
+  const params = new URLSearchParams()
+  if (providerAlias.trim()) {
+    params.set('provider_alias', providerAlias.trim())
+  }
+  const suffix = params.toString()
+  return requestJSON<ProviderModelsInfo>(`/v1/models${suffix ? `?${suffix}` : ''}`)
+}
+
+export async function getProviders(): Promise<ProvidersAPIInfo> {
+  return requestJSON<ProvidersAPIInfo>('/v1/providers')
 }
 
 export async function saveConfig(content: string): Promise<void> {

--- a/frontend/console/src/lib/types.ts
+++ b/frontend/console/src/lib/types.ts
@@ -1240,6 +1240,24 @@ export type ProviderModelsInfo = {
   warning?: string
 }
 
+export type ProviderAPIStatus = {
+  id: string
+  supports_live_models: boolean
+}
+
+export type ProviderPoolEntry = {
+  alias: string
+  kind: string
+}
+
+export type ProvidersAPIInfo = {
+  current_provider: string
+  current_model: string
+  auth_mode: string
+  providers: ProviderAPIStatus[]
+  pool: ProviderPoolEntry[]
+}
+
 // --- Onboarding (Phase 1+2 backend, Phase 3 wizard) ---
 
 export type HealthzResponse = {

--- a/internal/tarsserver/handler_chat.go
+++ b/internal/tarsserver/handler_chat.go
@@ -237,19 +237,130 @@ func buildLLMMessages(systemPrompt string, history []session.Message, userMessag
 func buildLLMMessagesWithBlocks(systemPrompt string, history []session.Message, userMessage string, contentBlocks []llm.ContentBlock) []llm.ChatMessage {
 	llmMessages := make([]llm.ChatMessage, 0, len(history)+2)
 	llmMessages = append(llmMessages, llm.ChatMessage{Role: "system", Content: systemPrompt})
+	llmMessages = append(llmMessages, buildLLMMessageHistory(history)...)
+	msg := llm.ChatMessage{Role: "user", Content: userMessage, ContentBlocks: contentBlocks}
+	llmMessages = append(llmMessages, msg)
+	return llmMessages
+}
+
+type toolReplayRecord struct {
+	id      string
+	name    string
+	args    string
+	content string
+}
+
+func buildLLMMessageHistory(history []session.Message) []llm.ChatMessage {
+	llmMessages := make([]llm.ChatMessage, 0, len(history)+1)
+	pendingByID := map[string]toolReplayRecord{}
+	pendingOrder := make([]string, 0, 4)
+
+	appendToolOutput := func(toolCallIDs []string) {
+		if len(toolCallIDs) == 0 {
+			return
+		}
+		for _, id := range toolCallIDs {
+			if strings.TrimSpace(id) == "" {
+				continue
+			}
+			record := pendingByID[id]
+			if strings.TrimSpace(record.id) == "" {
+				continue
+			}
+			llmMessages = append(llmMessages, llm.ChatMessage{
+				Role:       "tool",
+				Content:    record.content,
+				ToolCallID: record.id,
+			})
+		}
+		pendingByID = map[string]toolReplayRecord{}
+		pendingOrder = pendingOrder[:0]
+	}
+
+	discardToolOutput := func() {
+		pendingByID = map[string]toolReplayRecord{}
+		pendingOrder = pendingOrder[:0]
+	}
+
+	appendAssistantWithPendingTools := func(m session.Message) {
+		if len(pendingOrder) == 0 {
+			llmMessages = append(llmMessages, llm.ChatMessage{
+				Role:       strings.TrimSpace(m.Role),
+				Content:    m.Content,
+				ToolCallID: strings.TrimSpace(m.ToolCallID),
+			})
+			return
+		}
+
+		toolCalls := make([]llm.ToolCall, 0, len(pendingOrder))
+		outputOrder := make([]string, 0, len(pendingOrder))
+		for _, id := range pendingOrder {
+			record := pendingByID[id]
+			name := strings.TrimSpace(record.name)
+			if name == "" {
+				continue
+			}
+			toolCalls = append(toolCalls, llm.ToolCall{
+				ID:        id,
+				Name:      name,
+				Arguments: strings.TrimSpace(record.args),
+			})
+			outputOrder = append(outputOrder, id)
+		}
+		if len(toolCalls) == 0 {
+			llmMessages = append(llmMessages, llm.ChatMessage{
+				Role:       "assistant",
+				Content:    m.Content,
+				ToolCallID: strings.TrimSpace(m.ToolCallID),
+			})
+			discardToolOutput()
+			return
+		}
+
+		llmMessages = append(llmMessages, llm.ChatMessage{
+			Role:       "assistant",
+			Content:    m.Content,
+			ToolCalls:  toolCalls,
+			ToolCallID: strings.TrimSpace(m.ToolCallID),
+		})
+		appendToolOutput(outputOrder)
+	}
+
 	for _, m := range history {
 		role := strings.TrimSpace(m.Role)
-		if role == "tool" && strings.TrimSpace(m.ToolCallID) == "" {
+		if role == "" {
 			continue
 		}
+		if role == "tool" {
+			callID := strings.TrimSpace(m.ToolCallID)
+			if callID == "" {
+				continue
+			}
+			if _, ok := pendingByID[callID]; !ok {
+				pendingOrder = append(pendingOrder, callID)
+			}
+			pendingByID[callID] = toolReplayRecord{
+				id:      callID,
+				name:    m.ToolName,
+				args:    m.ToolArgs,
+				content: m.Content,
+			}
+			continue
+		}
+		if role == "assistant" {
+			appendAssistantWithPendingTools(m)
+			continue
+		}
+
+		discardToolOutput()
 		llmMessages = append(llmMessages, llm.ChatMessage{
 			Role:       role,
 			Content:    m.Content,
-			ToolCallID: m.ToolCallID,
+			ToolCallID: strings.TrimSpace(m.ToolCallID),
 		})
 	}
-	msg := llm.ChatMessage{Role: "user", Content: userMessage, ContentBlocks: contentBlocks}
-	llmMessages = append(llmMessages, msg)
+	discardToolOutput()
+
 	return llmMessages
 }
 

--- a/internal/tarsserver/handler_chat_test.go
+++ b/internal/tarsserver/handler_chat_test.go
@@ -7,31 +7,45 @@ import (
 	"github.com/devlikebear/tars/internal/session"
 )
 
-func TestBuildLLMMessagesWithBlocks_PropagatesToolCallIDFromHistory(t *testing.T) {
+func TestBuildLLMMessagesWithBlocks_PropagatesToolCallMetadataFromHistory(t *testing.T) {
 	msgs := buildLLMMessagesWithBlocks("system prompt", []session.Message{
 		{
-			Role:       "assistant",
-			Content:    "I need to check files",
-			ToolCallID: "",
+			Role:    "user",
+			Content: "read the file",
 		},
 		{
 			Role:       "tool",
 			Content:    `{"count":1}`,
 			ToolCallID: "call_123",
+			ToolName:   "read_file",
+			ToolArgs:   `{"path":"README.md"}`,
+		},
+		{
+			Role:    "assistant",
+			Content: "I reviewed that file",
 		},
 	}, "what now", nil)
 
-	if len(msgs) != 4 {
-		t.Fatalf("expected 4 messages, got %d", len(msgs))
+	if len(msgs) != 5 {
+		t.Fatalf("expected 5 messages, got %d", len(msgs))
 	}
-	if msgs[1].Role != "assistant" {
-		t.Fatalf("expected assistant at index 1, got %q", msgs[1].Role)
+	if msgs[2].Role != "assistant" {
+		t.Fatalf("expected assistant at index 2, got %q", msgs[2].Role)
 	}
-	if msgs[2].Role != "tool" {
-		t.Fatalf("expected tool at index 2, got %q", msgs[2].Role)
+	if len(msgs[2].ToolCalls) != 1 {
+		t.Fatalf("expected one tool call, got %+v", msgs[2].ToolCalls)
 	}
-	if msgs[2].ToolCallID != "call_123" {
-		t.Fatalf("expected tool_call_id call_123, got %q", msgs[2].ToolCallID)
+	if msgs[2].ToolCalls[0].ID != "call_123" {
+		t.Fatalf("expected tool call id call_123, got %q", msgs[2].ToolCalls[0].ID)
+	}
+	if msgs[2].ToolCalls[0].Name != "read_file" {
+		t.Fatalf("expected tool name read_file, got %q", msgs[2].ToolCalls[0].Name)
+	}
+	if msgs[3].Role != "tool" {
+		t.Fatalf("expected tool at index 3, got %q", msgs[3].Role)
+	}
+	if msgs[3].ToolCallID != "call_123" {
+		t.Fatalf("expected tool_call_id call_123, got %q", msgs[3].ToolCallID)
 	}
 }
 
@@ -40,6 +54,25 @@ func TestBuildLLMMessagesWithBlocks_SkipsToolMessagesWithoutToolCallID(t *testin
 		{
 			Role:    "tool",
 			Content: `{"count":1}`,
+		},
+	}, "what now", nil)
+
+	if len(msgs) != 2 { // system + current user
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
+	}
+	if msgs[1].Role != "user" {
+		t.Fatalf("expected user message to be second, got %q", msgs[1].Role)
+	}
+}
+
+func TestBuildLLMMessagesWithBlocks_DropsTrailingToolWithoutMatchingAssistant(t *testing.T) {
+	msgs := buildLLMMessagesWithBlocks("system prompt", []session.Message{
+		{
+			Role:      "tool",
+			Content:   `{"count":1}`,
+			ToolName:  "read_file",
+			ToolArgs:  `{"path":"README.md"}`,
+			ToolCallID: "call_123",
 		},
 	}, "what now", nil)
 

--- a/internal/tarsserver/handler_providers_models.go
+++ b/internal/tarsserver/handler_providers_models.go
@@ -14,6 +14,14 @@ import (
 	"github.com/rs/zerolog"
 )
 
+func providerModelsWarnMessage(err error) string {
+	msg := strings.TrimSpace(err.Error())
+	if msg == "" {
+		return ""
+	}
+	return msg
+}
+
 var supportedLiveModelProviders = []string{
 	"openai",
 	"openai-codex",
@@ -135,16 +143,16 @@ func (s *providerModelsService) providers() providersAPIInfo {
 	}
 }
 
-func (s *providerModelsService) models(ctx context.Context) (modelsAPIInfo, error) {
+func (s *providerModelsService) models(ctx context.Context, providerAlias string) (modelsAPIInfo, error) {
 	if s == nil {
 		return modelsAPIInfo{}, fmt.Errorf("provider models service is not configured")
 	}
 	if s.cache == nil {
 		return modelsAPIInfo{}, fmt.Errorf("provider models cache is not configured")
 	}
-	resolved, ok := s.defaultResolved()
-	if !ok {
-		return modelsAPIInfo{}, fmt.Errorf("default tier not resolvable — check llm_providers and llm_tiers config")
+	resolved, err := s.resolveProvider(providerAlias)
+	if err != nil {
+		return modelsAPIInfo{}, err
 	}
 	provider := normalizeProviderValue(resolved.Kind)
 	if !s.supportsProvider(provider) {
@@ -188,6 +196,24 @@ func (s *providerModelsService) models(ctx context.Context) (modelsAPIInfo, erro
 		}, nil
 	}
 
+	if providerErr, ok := err.(*llm.ProviderError); ok && (providerErr.StatusCode == http.StatusUnauthorized || providerErr.StatusCode == http.StatusForbidden) {
+		warn := providerModelsWarnMessage(err)
+		if warn == "" {
+			warn = fmt.Sprintf("provider models unavailable for %s", provider)
+		}
+		if hasCached {
+			return s.responseFromCacheEntry(cached, currentModel, true, warn, now), nil
+		}
+		return modelsAPIInfo{
+			Provider:     provider,
+			CurrentModel: "",
+			Source:       "provider_models_unavailable",
+			Stale:        false,
+			Models:       []string{},
+			Warning:      warn,
+		}, nil
+	}
+
 	if hasCached {
 		return s.responseFromCacheEntry(cached, currentModel, true, err.Error(), now), nil
 	}
@@ -213,13 +239,67 @@ func (s *providerModelsService) responseFromCacheEntry(entry providerModelsCache
 	}
 }
 
+func (s *providerModelsService) resolveProvider(providerAlias string) (config.ResolvedLLMTier, error) {
+	alias := strings.TrimSpace(providerAlias)
+	if alias == "" {
+		resolved, ok := s.defaultResolved()
+		if !ok {
+			return config.ResolvedLLMTier{}, fmt.Errorf("default tier not resolvable — check llm_providers and llm_tiers config")
+		}
+		return resolved, nil
+	}
+
+	provider, ok := s.cfg.LLMProviders[alias]
+	if !ok {
+		return config.ResolvedLLMTier{}, fmt.Errorf("provider alias %q not found", alias)
+	}
+	kind := strings.ToLower(strings.TrimSpace(provider.Kind))
+	if kind == "" {
+		return config.ResolvedLLMTier{}, fmt.Errorf("provider %q has empty kind", alias)
+	}
+
+	return config.ResolvedLLMTier{
+		Kind:          kind,
+		AuthMode:      normalizeAuthMode(provider.AuthMode),
+		OAuthProvider: strings.TrimSpace(provider.OAuthProvider),
+		BaseURL:       normalizeBaseURL(provider.BaseURL),
+		APIKey:        strings.TrimSpace(provider.APIKey),
+		Model:         strings.TrimSpace(s.currentModelForProviderAlias(alias)),
+		ServiceTier:   strings.TrimSpace(provider.ServiceTier),
+		ProviderAlias: alias,
+	}, nil
+}
+
+func (s *providerModelsService) currentModelForProviderAlias(providerAlias string) string {
+	alias := strings.TrimSpace(providerAlias)
+	for _, tier := range sortedTierKeys(s.cfg.LLMTiers) {
+		binding := s.cfg.LLMTiers[tier]
+		if strings.TrimSpace(binding.Provider) != alias {
+			continue
+		}
+		if model := strings.TrimSpace(binding.Model); model != "" {
+			return model
+		}
+	}
+	return ""
+}
+
+func sortedTierKeys(tiers map[string]config.LLMTierBinding) []string {
+	keys := make([]string, 0, len(tiers))
+	for name := range tiers {
+		keys = append(keys, name)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
 func (s *providerModelsService) supportsProvider(provider string) bool {
 	return slices.Contains(supportedLiveModelProviders, normalizeProviderValue(provider))
 }
 
 func providerSupportsLiveModels(provider string) bool {
 	switch normalizeProviderValue(provider) {
-	case "openai-codex", "claude-code-cli":
+	case "claude-code-cli":
 		return false
 	default:
 		return true
@@ -273,9 +353,14 @@ func newProvidersModelsAPIHandler(service *providerModelsService, logger zerolog
 			writeError(w, http.StatusInternalServerError, "models_unavailable", "provider models service is not configured")
 			return
 		}
-		models, err := service.models(r.Context())
+		providerAlias := strings.TrimSpace(r.URL.Query().Get("provider_alias"))
+		if providerAlias == "" {
+			providerAlias = strings.TrimSpace(r.URL.Query().Get("provider"))
+		}
+
+		models, err := service.models(r.Context(), providerAlias)
 		if err != nil {
-			if strings.Contains(strings.ToLower(err.Error()), "unsupported for llm provider") {
+			if strings.Contains(strings.ToLower(err.Error()), "unsupported for llm provider") || strings.Contains(strings.ToLower(err.Error()), "provider alias") {
 				writeError(w, http.StatusBadRequest, "models_unsupported", err.Error())
 				return
 			}

--- a/internal/tarsserver/handler_providers_models_test.go
+++ b/internal/tarsserver/handler_providers_models_test.go
@@ -91,29 +91,129 @@ func TestProvidersAPI_ReturnsCurrentAndSupportedProviders(t *testing.T) {
 	if out.CurrentProvider != "openai-codex" || out.CurrentModel != "gpt-5.3-codex" || out.AuthMode != "oauth" {
 		t.Fatalf("unexpected providers payload: %+v", out)
 	}
-	if len(out.Providers) != len(supportedLiveModelProviders) {
-		t.Fatalf("expected %d providers, got %d", len(supportedLiveModelProviders), len(out.Providers))
-	}
-	for _, item := range out.Providers {
-		if item.ID == "openai-codex" && item.SupportsLiveModels {
-			t.Fatalf("expected openai-codex live_models=false, got %+v", item)
+		if len(out.Providers) != len(supportedLiveModelProviders) {
+			t.Fatalf("expected %d providers, got %d", len(supportedLiveModelProviders), len(out.Providers))
+		}
+		for _, item := range out.Providers {
+			if item.ID == "openai-codex" && !item.SupportsLiveModels {
+				t.Fatalf("expected openai-codex live_models=true, got %+v", item)
+			}
 		}
 	}
-}
 
-func TestModelsAPI_OpenAICodexUnsupported_(t *testing.T) {
+func TestModelsAPI_OpenAICodexLiveModelsSupported_(t *testing.T) {
 	now := time.Date(2026, 2, 22, 12, 0, 0, 0, time.UTC)
 	cfg := makePoolTestCfg("openai-codex", "gpt-5.3-codex", "oauth", "https://chatgpt.com/backend-api")
 	cache, err := newProviderModelsCache(filepath.Join(t.TempDir(), "provider_models_cache.json"), providerModelsCacheTTL, func() time.Time { return now })
 	if err != nil {
 		t.Fatalf("newProviderModelsCache: %v", err)
 	}
-	fetcher := &fakeModelFetcher{models: []string{"should-not-be-used"}}
+	fetcher := &fakeModelFetcher{models: []string{"gpt-5.3-codex", "gpt-4.1-codex"}}
 	service := newProviderModelsService(cfg, cache, fetcher, func() time.Time { return now })
 	handler := newProvidersModelsAPIHandler(service, zerolog.New(io.Discard))
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d body=%q", rec.Code, rec.Body.String())
+		}
+	if fetcher.calls != 1 {
+		t.Fatalf("expected one fetch attempt, got %d", fetcher.calls)
+	}
+	if !strings.Contains(rec.Body.String(), `"provider":"openai-codex"`) {
+		t.Fatalf("expected provider in response, got %q", rec.Body.String())
+	}
+	var out modelsAPIInfo
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode models response: %v", err)
+	}
+	if out.Provider != "openai-codex" {
+		t.Fatalf("unexpected provider in response: %+v", out.Provider)
+	}
+	if len(out.Models) != 2 {
+		t.Fatalf("expected 2 models, got %v", out.Models)
+	}
+}
+
+func TestModelsAPI_UsesProviderAliasQueryParam_(t *testing.T) {
+	now := time.Date(2026, 4, 2, 12, 0, 0, 0, time.UTC)
+	cfg := config.Config{
+		LLMConfig: config.LLMConfig{
+			LLMProviders: map[string]config.LLMProviderSettings{
+				"default": {
+					Kind:     "openai",
+					AuthMode: "api-key",
+					BaseURL:  "https://api.openai.com/v1",
+				},
+				"secondary": {
+					Kind:     "anthropic",
+					AuthMode: "api-key",
+					BaseURL:  "https://api.anthropic.com",
+				},
+			},
+			LLMTiers: map[string]config.LLMTierBinding{
+				"standard": {Provider: "default", Model: "gpt-4o-mini"},
+				"heavy":    {Provider: "secondary", Model: "claude-3-5-sonnet"},
+			},
+			LLMDefaultTier: "standard",
+		},
+	}
+	cache, err := newProviderModelsCache(filepath.Join(t.TempDir(), "provider_models_cache.json"), providerModelsCacheTTL, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("newProviderModelsCache: %v", err)
+	}
+	fetcher := &fakeModelFetcher{models: []string{"claude-3-opus", "claude-3-haiku"}}
+	service := newProviderModelsService(cfg, cache, fetcher, func() time.Time { return now })
+	handler := newProvidersModelsAPIHandler(service, zerolog.New(io.Discard))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/models?provider_alias=secondary", nil)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	if fetcher.calls != 1 {
+		t.Fatalf("expected one fetch attempt, got %d", fetcher.calls)
+	}
+	if fetcher.lastOps.Provider != "anthropic" {
+		t.Fatalf("expected anthropic provider, got %+v", fetcher.lastOps.Provider)
+	}
+	if fetcher.lastOps.BaseURL != "https://api.anthropic.com" {
+		t.Fatalf("expected anthropic base URL, got %q", fetcher.lastOps.BaseURL)
+	}
+
+	var out modelsAPIInfo
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode models response: %v", err)
+	}
+	if out.Provider != "anthropic" {
+		t.Fatalf("unexpected provider in response: %+v", out.Provider)
+	}
+	if out.CurrentModel != "claude-3-5-sonnet" {
+		t.Fatalf("unexpected current model, got %q", out.CurrentModel)
+	}
+	if out.Source != "live" {
+		t.Fatalf("expected live source, got %q", out.Source)
+	}
+	if len(out.Models) != 3 {
+		t.Fatalf("expected 3 models including current model, got %+v", out.Models)
+	}
+}
+
+func TestModelsAPI_UnknownProviderAlias_(t *testing.T) {
+	now := time.Date(2026, 4, 2, 12, 0, 0, 0, time.UTC)
+	cfg := makePoolTestCfg("openai", "gpt-4o-mini", "api-key", "https://api.openai.com/v1")
+	cache, err := newProviderModelsCache(filepath.Join(t.TempDir(), "provider_models_cache.json"), providerModelsCacheTTL, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("newProviderModelsCache: %v", err)
+	}
+	fetcher := &fakeModelFetcher{models: []string{"gpt-4o-mini"}}
+	service := newProviderModelsService(cfg, cache, fetcher, func() time.Time { return now })
+	handler := newProvidersModelsAPIHandler(service, zerolog.New(io.Discard))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/models?provider_alias=missing", nil)
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d body=%q", rec.Code, rec.Body.String())
@@ -121,11 +221,8 @@ func TestModelsAPI_OpenAICodexUnsupported_(t *testing.T) {
 	if fetcher.calls != 0 {
 		t.Fatalf("expected no fetch attempt, got %d", fetcher.calls)
 	}
-	if !strings.Contains(rec.Body.String(), "models_unsupported") {
-		t.Fatalf("expected models_unsupported code, got %q", rec.Body.String())
-	}
-	if !strings.Contains(rec.Body.String(), "openai-codex") {
-		t.Fatalf("expected openai-codex message, got %q", rec.Body.String())
+	if !strings.Contains(rec.Body.String(), "provider alias") {
+		t.Fatalf("expected provider alias message, got %q", rec.Body.String())
 	}
 }
 
@@ -223,6 +320,52 @@ func TestModelsAPI_NoCacheLiveFail_(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "models_unavailable") {
 		t.Fatalf("expected models_unavailable code, got %q", rec.Body.String())
+	}
+}
+
+func TestModelsAPI_NoCachePermissionFail_(t *testing.T) {
+	now := time.Date(2026, 2, 22, 12, 0, 0, 0, time.UTC)
+	cfg := makePoolTestCfg("openai-codex", "gpt-5.3-codex", "oauth", "")
+	cache, err := newProviderModelsCache(filepath.Join(t.TempDir(), "provider_models_cache.json"), providerModelsCacheTTL, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("newProviderModelsCache: %v", err)
+	}
+	fetcher := &fakeModelFetcher{
+		err: &llm.ProviderError{
+			Provider:   "openai-codex",
+			Operation:  "request",
+			StatusCode: http.StatusForbidden,
+			Message:    `{"error":"You have insufficient permissions for this operation. Missing scopes: api.model.read."}`,
+		},
+	}
+	service := newProviderModelsService(cfg, cache, fetcher, func() time.Time { return now })
+	handler := newProvidersModelsAPIHandler(service, zerolog.New(io.Discard))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	if fetcher.calls != 1 {
+		t.Fatalf("expected one fetch attempt, got %d", fetcher.calls)
+	}
+
+	var out modelsAPIInfo
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode models response: %v", err)
+	}
+	if out.Provider != "openai-codex" {
+		t.Fatalf("unexpected provider: %+v", out)
+	}
+	if out.Source != "provider_models_unavailable" {
+		t.Fatalf("expected provider_models_unavailable source, got %q", out.Source)
+	}
+	if len(out.Models) != 0 {
+		t.Fatalf("expected no models, got %+v", out.Models)
+	}
+	if !strings.Contains(out.Warning, "api.model.read") {
+		t.Fatalf("expected warning, got %q", out.Warning)
 	}
 }
 

--- a/internal/tarsserver/telegram_commands_runtime.go
+++ b/internal/tarsserver/telegram_commands_runtime.go
@@ -33,7 +33,7 @@ func (h *telegramCommandHandler) cmdModels(ctx context.Context) (string, error) 
 	if h.providerModels == nil {
 		return "SYSTEM > models unavailable: service is not configured", nil
 	}
-	info, err := h.providerModels.models(ctx)
+	info, err := h.providerModels.models(ctx, "")
 	if err != nil {
 		return "", err
 	}

--- a/internal/tarsserver/telegram_commands_test.go
+++ b/internal/tarsserver/telegram_commands_test.go
@@ -82,7 +82,7 @@ func TestTelegramCommand_Allowed_Providers(t *testing.T) {
 	}
 }
 
-func TestTelegramCommand_Allowed_ModelsUnsupportedForOpenAICodex(t *testing.T) {
+func TestTelegramCommand_Allowed_ModelsForOpenAICodex(t *testing.T) {
 	workspace := t.TempDir()
 	store := session.NewStore(workspace)
 	cache, err := newProviderModelsCache(filepath.Join(workspace, "provider_models_cache.json"), providerModelsCacheTTL, time.Now)
@@ -101,17 +101,17 @@ func TestTelegramCommand_Allowed_ModelsUnsupportedForOpenAICodex(t *testing.T) {
 	})
 
 	handled, result, nextSession, err := handler.Execute(context.Background(), "/models", "")
-	if err == nil {
-		t.Fatal("expected /models error for openai-codex")
+	if err != nil {
+		t.Fatalf("Execute /models: %v", err)
 	}
 	if !handled || strings.TrimSpace(nextSession) != "" {
 		t.Fatalf("expected handled without session switch, handled=%t next=%q", handled, nextSession)
 	}
-	if strings.TrimSpace(result) != "" {
-		t.Fatalf("expected empty result on error, got %q", result)
+	if !strings.Contains(result, "provider=openai-codex") {
+		t.Fatalf("unexpected /models output: %q", result)
 	}
-	if !strings.Contains(err.Error(), "unsupported for llm provider") {
-		t.Fatalf("unexpected /models error: %v", err)
+	if !strings.Contains(result, "- gpt-5.3-codex") {
+		t.Fatalf("unexpected /models output: %q", result)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add provider-aware model source API in console and backend.
- Use /v1/models provider parameter for tier form model field and show loading/error states.
- Keep quick-start visibility behavior consistent with field mode for save/discard UX.
- Add backend handling for provider alias, unknown provider, and permission failures (403/401) with graceful warning fallback.

## Verification
- go test ./internal/tarsserver -run 'TestModelsAPI_|TestTelegramCommand_|TestBuildLLMMessagesWithBlocks' -count=1 (pre-existing scope used during implementation)
