### PR TITLE
fix: onboarding wizard multi-provider support

### DIFF
--- a/frontend/console/src/components/Onboarding.svelte
+++ b/frontend/console/src/components/Onboarding.svelte
@@ -13,11 +13,13 @@
     popularModelsForKind,
   } from '../lib/llm-catalog'
   import {
+    allAliasesFromConfigValues,
     availableAuthModesForKind,
     buildConfigPayload,
     defaultBaseURLForKind,
     emptyOnboardingForm,
     formFromConfigValues,
+    providerFromConfigValues,
     providerKinds,
     suggestedAuthModeForKind,
     validateForm,
@@ -41,6 +43,14 @@
   let step = $state<StepId>('provider')
   let form = $state<OnboardingFormState>(emptyOnboardingForm())
   let availableAuthModes = $derived(availableAuthModesForKind(form.provider.kind))
+  // All provider aliases loaded from config on re-entry. Used to populate
+  // the provider selector in step 1 and the alias dropdown in step 2.
+  let configValues = $state<Record<string, unknown>>({})
+  let existingAliases = $derived(allAliasesFromConfigValues(configValues))
+  // Union of existing aliases + the alias being configured in step 1.
+  let allKnownAliases = $derived(
+    [...new Set([...existingAliases, form.provider.alias.trim()].filter(Boolean))].sort()
+  )
   // Live model list pulled from /v1/models when the user clicks Refresh
   // (reentry / normal mode only — the setup-only path has no on-disk
   // credentials yet so /v1/models has nothing to call).
@@ -66,7 +76,8 @@
     if (reentry) {
       try {
         const schema = await getConfigSchema()
-        form = formFromConfigValues(schema.values || {})
+        configValues = schema.values || {}
+        form = formFromConfigValues(configValues)
       } catch (err) {
         console.warn('reentry prefill failed', err)
       }
@@ -133,8 +144,16 @@
     }
   }
 
+  function handleSelectProviderForEdit(alias: string) {
+    if (alias === '__new__') {
+      form.provider = emptyOnboardingForm().provider
+    } else {
+      form.provider = providerFromConfigValues(configValues, alias)
+    }
+  }
+
   function goToReview() {
-    stepErrors = validateTiersStep(form)
+    stepErrors = validateTiersStep(form, allKnownAliases)
     if (stepErrors.length === 0) {
       step = 'review'
     }
@@ -165,7 +184,7 @@
   }
 
   async function handleSave(restart: boolean) {
-    const formErrors = validateForm(form)
+    const formErrors = validateForm(form, allKnownAliases)
     if (formErrors.length > 0) {
       stepErrors = formErrors
       return
@@ -275,6 +294,22 @@
       <div class="card-header">
         <span class="card-title">{$t.onboarding.step1.cardTitle}</span>
       </div>
+      {#if reentry && existingAliases.length > 0}
+        <div class="onboarding-provider-selector">
+          <label class="onboarding-field">
+            <span>{$t.onboarding.step1.selectProviderLabel}</span>
+            <select
+              value={form.provider.alias}
+              onchange={(e) => handleSelectProviderForEdit((e.currentTarget as HTMLSelectElement).value)}
+            >
+              {#each existingAliases as alias}
+                <option value={alias}>{alias}</option>
+              {/each}
+              <option value="__new__">{$t.onboarding.step1.addNewProviderOption}</option>
+            </select>
+          </label>
+        </div>
+      {/if}
       <div class="onboarding-grid">
         <label class="onboarding-field">
           <span>{$t.onboarding.step1.kindLabel} <em>{$t.onboarding.step1.kindHint}</em></span>
@@ -373,7 +408,15 @@
             <legend>{tier}</legend>
             <label class="onboarding-field">
               <span>{$t.onboarding.step2.providerAliasLabel}</span>
-              <input type="text" bind:value={form.tiers[tier].provider} />
+              {#if allKnownAliases.length > 1}
+                <select bind:value={form.tiers[tier].provider}>
+                  {#each allKnownAliases as alias}
+                    <option value={alias}>{alias}</option>
+                  {/each}
+                </select>
+              {:else}
+                <input type="text" bind:value={form.tiers[tier].provider} />
+              {/if}
             </label>
             <label class="onboarding-field">
               <span>{$t.onboarding.step2.modelLabel}</span>
@@ -589,6 +632,14 @@
   .onboarding-errors ul {
     margin: 0;
     padding-left: 1.2em;
+  }
+  .onboarding-provider-selector {
+    margin-bottom: var(--space-4);
+    padding-bottom: var(--space-4);
+    border-bottom: 1px solid var(--border-soft);
+  }
+  .onboarding-provider-selector .onboarding-field {
+    max-width: 340px;
   }
   .onboarding-grid {
     display: grid;

--- a/frontend/console/src/i18n/en.ts
+++ b/frontend/console/src/i18n/en.ts
@@ -229,6 +229,8 @@ export const en = {
       hintCliTitle: 'CLI auth',
       hintCliBody: 'Authentication is delegated to the locally installed claude-code CLI. No extra key needed (the CLI’s own login state is used).',
       nextButton: 'Next: tiers →',
+      selectProviderLabel: 'Select provider to configure',
+      addNewProviderOption: '+ Add new provider',
     },
     step2: {
       cardTitle: 'Step 2 · Tier bindings',

--- a/frontend/console/src/i18n/ko.ts
+++ b/frontend/console/src/i18n/ko.ts
@@ -229,6 +229,8 @@ export const ko = {
       hintCliTitle: 'CLI 인증',
       hintCliBody: '로컬에 설치된 claude-code CLI를 통해 인증합니다. 추가 키 입력 없이도 동작합니다 (CLI 자체 로그인 상태가 사용됩니다).',
       nextButton: '다음: Tier 설정 →',
+      selectProviderLabel: '설정할 프로바이더 선택',
+      addNewProviderOption: '+ 새 프로바이더 추가',
     },
     step2: {
       cardTitle: 'Step 2 · Tier 바인딩',

--- a/frontend/console/src/i18n/types.ts
+++ b/frontend/console/src/i18n/types.ts
@@ -229,6 +229,8 @@ export type Translations = {
       hintCliTitle: string
       hintCliBody: string
       nextButton: string
+      selectProviderLabel: string
+      addNewProviderOption: string
     }
     step2: {
       cardTitle: string

--- a/frontend/console/src/lib/onboarding.ts
+++ b/frontend/console/src/lib/onboarding.ts
@@ -100,13 +100,19 @@ export function validateProviderStep(form: OnboardingFormState): string[] {
 
 // validateTiersStep returns user-facing error messages for the tier
 // bindings step. All three tiers must point at a non-empty provider
-// alias and a non-empty model. The provider alias should match the
-// one configured on the previous step (or another tier's provider).
-export function validateTiersStep(form: OnboardingFormState): string[] {
+// alias and a non-empty model. The provider alias must match one of
+// the aliases known to the wizard (step-1 alias + any existing providers).
+export function validateTiersStep(form: OnboardingFormState, allKnownAliases?: string[]): string[] {
   const errs: string[] = []
   const knownAliases = new Set<string>()
   if (form.provider.alias.trim() !== '') {
     knownAliases.add(form.provider.alias.trim())
+  }
+  if (allKnownAliases) {
+    for (const a of allKnownAliases) {
+      const trimmed = a.trim()
+      if (trimmed !== '') knownAliases.add(trimmed)
+    }
   }
   for (const tier of requiredTiers) {
     const binding = form.tiers[tier]
@@ -126,8 +132,8 @@ export function validateTiersStep(form: OnboardingFormState): string[] {
 
 // validateForm returns the union of provider + tier errors. The
 // review step uses this to gate the Save button.
-export function validateForm(form: OnboardingFormState): string[] {
-  return [...validateProviderStep(form), ...validateTiersStep(form)]
+export function validateForm(form: OnboardingFormState, allKnownAliases?: string[]): string[] {
+  return [...validateProviderStep(form), ...validateTiersStep(form, allKnownAliases)]
 }
 
 // buildConfigPayload converts the form into the `updates` map shape
@@ -230,38 +236,49 @@ export function suggestedAuthModeForKind(kind: ProviderKind | ''): AuthMode {
   return availableAuthModesForKind(kind)[0]
 }
 
+// allAliasesFromConfigValues returns all provider aliases from the config
+// values map, sorted alphabetically. Used to populate the provider selector
+// in re-entry mode and the tier provider dropdowns.
+export function allAliasesFromConfigValues(values: Record<string, unknown>): string[] {
+  const providers = (values?.llm_providers ?? {}) as Record<string, unknown>
+  return Object.keys(providers).sort()
+}
+
+// providerFromConfigValues extracts the OnboardingProvider fields for a
+// specific alias from the config values map.
+export function providerFromConfigValues(
+  values: Record<string, unknown>,
+  alias: string,
+): OnboardingProvider {
+  const providers = (values?.llm_providers ?? {}) as Record<string, Record<string, unknown>>
+  const entry = providers[alias] || {}
+  const kind = String(entry.kind ?? '') as ProviderKind | ''
+  const apiKey = String(entry.api_key ?? '')
+  return {
+    alias,
+    kind,
+    auth_mode: (String(entry.auth_mode ?? 'api-key') as AuthMode) || 'api-key',
+    api_key: apiKey,
+    base_url: String(entry.base_url ?? ''),
+    oauth_provider: entry.oauth_provider ? String(entry.oauth_provider) : undefined,
+    keepExistingApiKey: apiKey.trim() !== '',
+  }
+}
+
 // formFromConfigValues maps a config schema's values map into the
 // wizard's form shape. Used by the re-entry path so the wizard opens
 // with the existing provider + tier bindings prefilled.
 //
-// Picks the FIRST provider alias as the active edit target. The
-// wizard does not yet support editing multiple providers from the
-// same screen — that lands as a separate enhancement.
+// Picks the FIRST provider alias as the active edit target. Call
+// providerFromConfigValues to switch to a different alias.
 //
-// API keys arrive masked from the schema endpoint; the form sets
-// keepExistingApiKey=true so saving without typing a new value
-// leaves the on-disk credential untouched.
+// Non-empty api_key values in the returned form have keepExistingApiKey=true
+// so saving without typing a new value leaves the on-disk credential untouched.
 export function formFromConfigValues(values: Record<string, unknown>): OnboardingFormState {
   const form = emptyOnboardingForm()
-  const providers = (values?.llm_providers ?? {}) as Record<string, Record<string, unknown>>
-  const aliases = Object.keys(providers).sort()
+  const aliases = allAliasesFromConfigValues(values)
   if (aliases.length > 0) {
-    const alias = aliases[0]
-    const entry = providers[alias] || {}
-    const kind = String(entry.kind ?? '') as ProviderKind | ''
-    form.provider.alias = alias
-    form.provider.kind = kind
-    form.provider.auth_mode = (String(entry.auth_mode ?? 'api-key') as AuthMode) || 'api-key'
-    form.provider.api_key = String(entry.api_key ?? '')
-    form.provider.base_url = String(entry.base_url ?? '')
-    if (entry.oauth_provider) {
-      form.provider.oauth_provider = String(entry.oauth_provider)
-    }
-    // The schema endpoint masks api_key; treat any non-empty masked
-    // value as "keep existing" until the user types a new key.
-    if (form.provider.api_key.trim() !== '') {
-      form.provider.keepExistingApiKey = true
-    }
+    form.provider = providerFromConfigValues(values, aliases[0])
   }
 
   const tiers = (values?.llm_tiers ?? {}) as Record<string, Record<string, unknown>>

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -68,8 +68,19 @@ func PatchYAML(path string, updates map[string]any) error {
 		if resolvedKey == "" {
 			continue
 		}
+		patchedValue := normalizePatchedConfigValue(resolvedKey, value)
+		// For two-level map values (e.g. llm_providers: alias → fields),
+		// merge the patch into the existing value BEFORE deleting it so
+		// that unpatched entries (other provider aliases, existing api_key)
+		// are preserved across wizard saves.
+		if newMap := anyToStringMap(patchedValue); newMap != nil {
+			if existingMap := readConfigYAMLMap(existing, resolvedKey); existingMap != nil {
+				nestedMapMerge(existingMap, newMap)
+				patchedValue = existingMap
+			}
+		}
 		deleteConfigYAMLRepresentations(existing, resolvedKey)
-		setConfigYAMLValue(existing, resolvedKey, normalizePatchedConfigValue(resolvedKey, value))
+		setConfigYAMLValue(existing, resolvedKey, patchedValue)
 	}
 
 	out, err := yaml.Marshal(existing)

--- a/internal/config/load_patch_test.go
+++ b/internal/config/load_patch_test.go
@@ -159,6 +159,76 @@ gateway:
 }
 
 
+func TestPatchYAML_PreservesOtherProviders(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	raw := []byte(strings.TrimSpace(`
+llm:
+  providers:
+    kimi:
+      kind: kimi
+      auth_mode: api-key
+      base_url: https://api.moonshot.ai/v1
+      api_key: real-kimi-key
+    anthropic:
+      kind: anthropic
+      auth_mode: api-key
+      base_url: https://api.anthropic.com
+      api_key: real-ant-key
+  tiers:
+    heavy:
+      provider: anthropic
+      model: claude-opus-4-5
+    standard:
+      provider: kimi
+      model: kimi-k2.6
+    light:
+      provider: kimi
+      model: kimi-k2.6
+`))
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	// Simulate wizard saving: edits kimi's base_url only, no api_key sent.
+	updates := map[string]any{
+		"llm_providers": map[string]any{
+			"kimi": map[string]any{
+				"kind":      "kimi",
+				"auth_mode": "api-key",
+				"base_url":  "https://api.moonshot.ai/v2",
+			},
+		},
+	}
+	if err := PatchYAML(path, updates); err != nil {
+		t.Fatalf("patch yaml: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("load patched config: %v", err)
+	}
+
+	// kimi's api_key must be preserved (not cleared by the patch).
+	if cfg.LLMProviders["kimi"].APIKey != "real-kimi-key" {
+		t.Fatalf("kimi api_key lost after patch: got %q want %q", cfg.LLMProviders["kimi"].APIKey, "real-kimi-key")
+	}
+	// kimi's base_url must be updated.
+	if cfg.LLMProviders["kimi"].BaseURL != "https://api.moonshot.ai/v2" {
+		t.Fatalf("kimi base_url not updated: got %q", cfg.LLMProviders["kimi"].BaseURL)
+	}
+	// anthropic must be preserved.
+	if cfg.LLMProviders["anthropic"].APIKey != "real-ant-key" {
+		t.Fatalf("anthropic lost after kimi-only patch: got api_key=%q", cfg.LLMProviders["anthropic"].APIKey)
+	}
+	if cfg.LLMProviders["anthropic"].Kind != "anthropic" {
+		t.Fatalf("anthropic entry corrupted: %+v", cfg.LLMProviders["anthropic"])
+	}
+	// tiers must be unchanged.
+	if cfg.LLMTiers["heavy"].Provider != "anthropic" {
+		t.Fatalf("heavy tier provider changed unexpectedly: %q", cfg.LLMTiers["heavy"].Provider)
+	}
+}
+
 func TestPatchYAML_CreatesParentDirectory(t *testing.T) {
 	root := t.TempDir()
 	// Use a path whose parent does NOT exist yet — simulates the

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -264,7 +264,7 @@ func extractValue(yamlKey string, cfg Config) any {
 		return cfg.APIMaxInflightAgentRuns
 	// LLM
 	case "llm_providers":
-		return cloneLLMProviders(cfg.LLMProviders)
+		return sparseProvidersMap(cfg.LLMProviders)
 	case "llm_tiers":
 		return cloneLLMTiers(cfg.LLMTiers)
 	case "llm_default_tier":
@@ -512,4 +512,35 @@ func extractValue(yamlKey string, cfg Config) any {
 	default:
 		return nil
 	}
+}
+
+// sparseProvidersMap converts an LLMProviders map to a two-level
+// map[string]map[string]any that only includes non-empty string fields.
+// This is used by extractValue so that PatchYAML's nested-map merge can
+// preserve existing fields (especially api_key) that the patch omits.
+func sparseProvidersMap(providers map[string]LLMProviderSettings) map[string]map[string]any {
+	out := make(map[string]map[string]any, len(providers))
+	for alias, p := range providers {
+		m := make(map[string]any)
+		if p.Kind != "" {
+			m["kind"] = p.Kind
+		}
+		if p.AuthMode != "" {
+			m["auth_mode"] = p.AuthMode
+		}
+		if p.OAuthProvider != "" {
+			m["oauth_provider"] = p.OAuthProvider
+		}
+		if p.BaseURL != "" {
+			m["base_url"] = p.BaseURL
+		}
+		if p.APIKey != "" {
+			m["api_key"] = p.APIKey
+		}
+		if p.ServiceTier != "" {
+			m["service_tier"] = p.ServiceTier
+		}
+		out[alias] = m
+	}
+	return out
 }

--- a/internal/config/yaml_paths.go
+++ b/internal/config/yaml_paths.go
@@ -1,6 +1,9 @@
 package config
 
-import "strings"
+import (
+	"maps"
+	"strings"
+)
 
 func preferredYAMLPathForKey(key string) string {
 	key = strings.TrimSpace(strings.ToLower(key))
@@ -182,6 +185,70 @@ func setConfigYAMLValue(dst map[string]any, key string, value any) {
 			current[part] = next
 		}
 		current = next
+	}
+}
+
+// readConfigYAMLMap navigates the existing YAML map to find the current
+// value at the given config key's preferred path and returns it as a
+// map[string]any. Returns nil if absent or not a map.
+func readConfigYAMLMap(src map[string]any, key string) map[string]any {
+	parts := preferredYAMLPathSegmentsForKey(key)
+	if len(parts) == 0 {
+		return nil
+	}
+	current := src
+	for i, part := range parts {
+		if i == len(parts)-1 {
+			m, ok := current[part].(map[string]any)
+			if !ok {
+				return nil
+			}
+			return m
+		}
+		next, ok := current[part].(map[string]any)
+		if !ok {
+			return nil
+		}
+		current = next
+	}
+	return nil
+}
+
+// anyToStringMap converts a value to map[string]any when possible.
+// Handles map[string]any and map[string]map[string]any.
+func anyToStringMap(v any) map[string]any {
+	switch m := v.(type) {
+	case map[string]any:
+		return m
+	case map[string]map[string]any:
+		out := make(map[string]any, len(m))
+		for k, v := range m {
+			out[k] = v
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+// nestedMapMerge updates dst in-place with entries from src.
+// Existing entries in dst not present in src are preserved.
+// For entries present in both where both values are maps, inner keys
+// from src are merged into dst (existing inner keys not in src kept).
+func nestedMapMerge(dst, src map[string]any) {
+	for k, srcVal := range src {
+		dstVal, exists := dst[k]
+		if !exists {
+			dst[k] = srcVal
+			continue
+		}
+		srcInner, srcIsMap := srcVal.(map[string]any)
+		dstInner, dstIsMap := dstVal.(map[string]any)
+		if srcIsMap && dstIsMap {
+			maps.Copy(dstInner, srcInner)
+		} else {
+			dst[k] = srcVal
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Step 1 (Provider)**: In reentry mode, adds a \"Select provider to configure\" dropdown showing all existing provider aliases + an \"Add new provider\" option. Selecting an existing alias prefills all fields from the live config, making it easy to edit any of your providers.
- **Step 2 (Tiers)**: Provider alias field is now a `<select>` dropdown (when multiple providers exist) instead of a plain text input, allowing tier assignments like heavy→anthropic, light→kimi.
- **Backend data integrity**: `PatchYAML` now does a two-level nested merge for `llm_providers` — patching one provider no longer deletes others, and api_key/other fields omitted from the patch are preserved from disk.

## Test plan

- [ ] Fresh setup (first-run mode): wizard still works normally, no provider selector visible
- [ ] Reentry with 1 provider: no selector shown (not needed), tier alias is text input
- [ ] Reentry with 2+ providers: selector appears in step 1, step 2 shows alias dropdown
- [ ] Select different provider in step 1, verify form prefills correctly
- [ ] Select \"+ Add new provider\", verify empty form appears
- [ ] In step 2, assign different providers to different tiers, verify saves correctly
- [ ] Save through wizard with 2 providers: verify both providers preserved in config (no data loss)
- [ ] Save through wizard without changing api_key: verify existing api_key preserved on disk