### PR TITLE
feat: add mobile navigation drawer (responsive nav)

### DIFF
--- a/frontend/console/src/components/Header.svelte
+++ b/frontend/console/src/components/Header.svelte
@@ -9,6 +9,8 @@
     unreadCount?: number
     onUnreadChange?: (count: number) => void
     onNavigate?: (path: string) => void
+    navOpen?: boolean
+    onToggleNav?: () => void
   }
 
   let {
@@ -16,6 +18,8 @@
     unreadCount = 0,
     onUnreadChange,
     onNavigate,
+    navOpen = false,
+    onToggleNav,
   }: Props = $props()
 
   let panelOpen = $state(false)
@@ -148,6 +152,18 @@
 
 <header class="header">
   <div class="header-left">
+    <button
+      type="button"
+      class="hamburger-btn"
+      class:active={navOpen}
+      aria-label="Toggle navigation"
+      aria-expanded={navOpen}
+      onclick={onToggleNav}
+    >
+      <span class="hamburger-line"></span>
+      <span class="hamburger-line"></span>
+      <span class="hamburger-line"></span>
+    </button>
     <h1 class="header-title">{$t.header.title}</h1>
   </div>
 
@@ -570,6 +586,50 @@
     font-family: var(--font-mono);
     font-size: 10px;
     color: var(--text-ghost);
+  }
+
+  .hamburger-btn {
+    display: none;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 4px;
+    width: 32px;
+    height: 32px;
+    border: none;
+    border-radius: var(--radius-md);
+    background: transparent;
+    cursor: pointer;
+    padding: var(--space-1);
+    transition: background var(--duration-fast) var(--ease-out);
+    flex-shrink: 0;
+  }
+  .hamburger-btn:hover {
+    background: var(--surface-elevated);
+  }
+  .hamburger-line {
+    display: block;
+    width: 16px;
+    height: 1.5px;
+    background: var(--text-secondary);
+    border-radius: 1px;
+    transition: transform var(--duration-normal) var(--ease-out), opacity var(--duration-fast) var(--ease-out), background var(--duration-fast) var(--ease-out);
+    transform-origin: center;
+  }
+  .hamburger-btn.active .hamburger-line:nth-child(1) {
+    transform: translateY(5.5px) rotate(45deg);
+    background: var(--primary);
+  }
+  .hamburger-btn.active .hamburger-line:nth-child(2) {
+    opacity: 0;
+  }
+  .hamburger-btn.active .hamburger-line:nth-child(3) {
+    transform: translateY(-5.5px) rotate(-45deg);
+    background: var(--primary);
+  }
+
+  @media (max-width: 900px) {
+    .hamburger-btn { display: flex; }
   }
 
   @media (max-width: 768px) {

--- a/frontend/console/src/components/Nav.svelte
+++ b/frontend/console/src/components/Nav.svelte
@@ -22,9 +22,11 @@
   interface Props {
     currentPath: string
     onNavigate: (path: string) => void
+    navOpen?: boolean
+    onClose?: () => void
   }
 
-  let { currentPath, onNavigate }: Props = $props()
+  let { currentPath, onNavigate, navOpen = false, onClose }: Props = $props()
   let version = $state('')
 
   onMount(async () => {
@@ -84,6 +86,11 @@
     onNavigate(path)
   }
 
+  function handleClose(event: MouseEvent) {
+    event.preventDefault()
+    onClose?.()
+  }
+
   function groupLabel(id: NavGroupId): string {
     return $t.nav.groups[id]
   }
@@ -93,12 +100,13 @@
   }
 </script>
 
-<nav class="nav" aria-label={$t.nav.mainNavigation}>
+<nav class="nav" class:nav-open={navOpen} aria-label={$t.nav.mainNavigation}>
   <div class="nav-brand">
     <button type="button" class="nav-logo" onclick={(e: MouseEvent) => handleClick(e, '/console')}>
       <span class="nav-logo-mark">T</span>
       <span class="nav-logo-text">TARS</span>
     </button>
+    <button type="button" class="nav-close-btn" aria-label="Close navigation" onclick={handleClose}>✕</button>
   </div>
 
   <div class="nav-items">
@@ -256,7 +264,43 @@
     color: var(--text-ghost);
   }
 
+  .nav-close-btn {
+    display: none;
+  }
+
   @media (max-width: 900px) {
-    .nav { display: none; }
+    .nav {
+      transform: translateX(-100%);
+      transition: transform var(--duration-normal) var(--ease-out);
+      box-shadow: none;
+    }
+    .nav.nav-open {
+      transform: translateX(0);
+      box-shadow: 8px 0 32px rgba(0, 0, 0, 0.5);
+    }
+    .nav-brand {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .nav-close-btn {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 28px;
+      height: 28px;
+      border: none;
+      border-radius: var(--radius-md);
+      background: transparent;
+      color: var(--text-tertiary);
+      font-size: var(--text-base);
+      cursor: pointer;
+      transition: background var(--duration-fast) var(--ease-out), color var(--duration-fast) var(--ease-out);
+      flex-shrink: 0;
+    }
+    .nav-close-btn:hover {
+      background: var(--surface-elevated);
+      color: var(--text-primary);
+    }
   }
 </style>

--- a/frontend/console/src/components/Shell.svelte
+++ b/frontend/console/src/components/Shell.svelte
@@ -23,14 +23,27 @@
     onUnreadChange,
     children,
   }: Props = $props()
+
+  let navOpen = $state(false)
+
+  function toggleNav() { navOpen = !navOpen }
+  function closeNav() { navOpen = false }
+
+  function handleNavigate(path: string) {
+    closeNav()
+    onNavigate(path)
+  }
 </script>
 
 <div class="shell" class:setup-only={needsSetup}>
   {#if !needsSetup}
-    <Nav {currentPath} {onNavigate} />
+    <Nav {currentPath} onNavigate={handleNavigate} {navOpen} onClose={closeNav} />
+    {#if navOpen}
+      <div class="nav-overlay" role="presentation" onclick={closeNav}></div>
+    {/if}
   {/if}
   <div class="shell-main" class:no-nav={needsSetup}>
-    <Header {serverHealth} {unreadCount} {onUnreadChange} {onNavigate} />
+    <Header {serverHealth} {unreadCount} {onUnreadChange} {onNavigate} {navOpen} onToggleNav={toggleNav} />
     {#if needsSetup}
       <div class="setup-only-banner" role="alert">
         <strong>{$t.shell.setupOnlyKicker}</strong>
@@ -84,6 +97,10 @@
     width: 100%;
   }
 
+  .nav-overlay {
+    display: none;
+  }
+
   @media (max-width: 900px) {
     .shell-main {
       margin-left: 0;
@@ -91,5 +108,18 @@
     .shell-content {
       padding: var(--space-4);
     }
+    .nav-overlay {
+      display: block;
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.55);
+      z-index: 39;
+      animation: overlayIn var(--duration-normal) var(--ease-out);
+    }
+  }
+
+  @keyframes overlayIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
   }
 </style>


### PR DESCRIPTION
## Summary
- Header에 ハンバーガーボタン追加 (≤900px のみ表示、アニメーション付き ☰ → ✕)
- Nav をスライドインドロワーに変更 — モバイル時は `translateX(-100%)` で非表示、open 時に `translateX(0)` へアニメーション
- Shell に半透明オーバーレイ (`rgba(0,0,0,0.55)`) 追加 — クリックでドロワーを閉じる
- ナビ項目をタップするとドロワー自動クローズ
- DESIGN.md 記載の「768px以下でheader-driven menu」要件を実装

## Test plan
- [ ] `make console-build` 通過
- [ ] `svelte-check` エラーゼロ確認済み
- [ ] デスクトップ (>900px): 従来と同じ固定左ナビ、ハンバーガーボタン非表示
- [ ] モバイル (≤900px): ハンバーガーボタン表示、タップでドロワーが左からスライドイン、オーバーレイ表示
- [ ] ドロワー外クリックまたは ✕ ボタンで閉じる
- [ ] ナビ項目タップ後にドロワーが閉じてページ遷移