### PR TITLE
fix: chat layout responsive — breakpoint 통일 및 탭바 오버플로 수정

### DIFF
--- a/frontend/console/src/components/Chat.svelte
+++ b/frontend/console/src/components/Chat.svelte
@@ -701,6 +701,7 @@
 <div class="chat-page">
   <!-- Mini dashboard pulse -->
   <div class="chat-pulse">
+    <div class="chat-pulse-stats">
     <div class="pulse-item">
       <span class="pulse-val" class:warn={!!pulse?.last_err}>
         {pulse?.total_ticks ?? 0}
@@ -718,6 +719,7 @@
       <span class="pulse-lbl">Unread</span>
     </div>
     <div class="pulse-sep"></div>
+    </div>
     <div class="pulse-panel-toggles">
       <button type="button" class="pulse-toggle-btn" class:active={isPanelOpen('sessions')} onclick={() => openPanel('sessions')} title="Session list">Sessions</button>
       <button type="button" class="pulse-toggle-btn" class:active={isPanelOpen('artifacts')} onclick={() => togglePanel('artifacts')} title="Files browser">Files{#if chatArtifacts.length > 0} ({chatArtifacts.length}){/if}</button>
@@ -994,6 +996,12 @@
     position: sticky;
     top: 0;
     z-index: 10;
+    min-width: 0;
+    overflow: hidden;
+  }
+
+  .chat-pulse-stats {
+    display: contents;
   }
 
   .pulse-item {
@@ -1022,6 +1030,7 @@
   .pulse-panel-toggles {
     display: flex;
     gap: 2px;
+    flex-shrink: 0;
   }
 
   .pulse-toggle-btn {
@@ -1341,7 +1350,7 @@
     text-align: right;
   }
 
-  @media (max-width: 768px) {
+  @media (max-width: 900px) {
     .chat-layout {
       grid-template-columns: 1fr;
       grid-template-rows: minmax(0, 1fr);
@@ -1357,10 +1366,30 @@
       inset: var(--space-2);
     }
     .chat-pulse {
-      flex-wrap: wrap;
-      gap: var(--space-2);
+      flex-wrap: nowrap;
+      gap: 0;
+      padding: 0;
+      flex-direction: column;
+      align-items: stretch;
+      overflow: visible;
+    }
+    .chat-pulse-stats {
+      display: flex;
+      align-items: center;
+      gap: var(--space-3);
+      padding: var(--space-1) var(--space-3);
+      overflow-x: auto;
     }
     .pulse-sep { display: none; }
+    .pulse-panel-toggles {
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+      padding: var(--space-1) var(--space-3);
+      border-top: 1px solid var(--border-subtle);
+      flex-shrink: 0;
+      scrollbar-width: none;
+    }
+    .pulse-panel-toggles::-webkit-scrollbar { display: none; }
     .session-actions {
       flex-wrap: wrap;
     }


### PR DESCRIPTION
## Summary
- **breakpoint 768px → 900px**: dock 패널 숨김 조건을 Shell/Nav와 통일. 기존에는 770~900px 구간에서 Nav는 사라지는데 dock 패널은 남아 채팅 영역이 절반으로 쪼개지는 버그 있었음
- **탭바 오버플로 수정**: `pulse-panel-toggles`에 `overflow-x: auto` 추가 → Sessions/Files/Context 등 11개 탭 버튼을 가로 스크롤로 탐색 가능
- **chat-pulse 레이아웃 분리**: 모바일에서 Pulse stats 줄 + 탭 줄을 2행으로 분리 (데스크탑은 기존 1행 유지)
- 스크롤바 숨김(`scrollbar-width: none`) 처리로 UI 깔끔하게 유지

## Test plan
- [ ] 데스크탑 (>900px): 기존과 동일 — dock 패널, 1행 탭바 정상 동작
- [ ] 모바일 (≤900px): dock 패널 숨김, 채팅 영역 전체 너비 사용
- [ ] 모바일 탭바: 11개 버튼이 가로 스크롤로 탐색 가능
- [ ] 770~900px 구간: 채팅 영역이 전체 너비 차지 (이전 버그 재현 안 됨)
- [ ] `svelte-check` 에러 없음