### PR TITLE
fix: hamburger nav drawer가 모바일에서 동작하지 않는 버그 수정

### DIFF
--- a/frontend/console/src/components/Nav.svelte
+++ b/frontend/console/src/components/Nav.svelte
@@ -100,7 +100,7 @@
   }
 </script>
 
-<nav class="nav" class:nav-open={navOpen} aria-label={$t.nav.mainNavigation}>
+<nav class="nav" style={navOpen ? 'transform: translateX(0)' : undefined} aria-label={$t.nav.mainNavigation}>
   <div class="nav-brand">
     <button type="button" class="nav-logo" onclick={(e: MouseEvent) => handleClick(e, '/console')}>
       <span class="nav-logo-mark">T</span>
@@ -271,11 +271,9 @@
   @media (max-width: 900px) {
     .nav {
       transform: translateX(-100%);
-      transition: transform var(--duration-normal) var(--ease-out);
-      box-shadow: none;
+      transition: transform var(--duration-normal) var(--ease-out), box-shadow var(--duration-normal) var(--ease-out);
     }
-    .nav.nav-open {
-      transform: translateX(0);
+    .nav[style*='translateX(0)'] {
       box-shadow: 8px 0 32px rgba(0, 0, 0, 0.5);
     }
     .nav-brand {

--- a/frontend/console/src/components/Shell.svelte
+++ b/frontend/console/src/components/Shell.svelte
@@ -25,12 +25,21 @@
   }: Props = $props()
 
   let navOpen = $state(false)
+  let navOpenedAt = 0
 
-  function toggleNav() { navOpen = !navOpen }
-  function closeNav() { navOpen = false }
+  function toggleNav() {
+    navOpen = !navOpen
+    if (navOpen) navOpenedAt = Date.now()
+  }
+
+  function closeNav() {
+    // Guard against ghost clicks that fire immediately after opening on touch devices
+    if (Date.now() - navOpenedAt < 350) return
+    navOpen = false
+  }
 
   function handleNavigate(path: string) {
-    closeNav()
+    navOpen = false
     onNavigate(path)
   }
 </script>


### PR DESCRIPTION
## 원인 분석

두 가지 근본 원인을 찾아 수정했습니다.

### 1. Svelte 5 CSS 스코핑 문제
- `class:nav-open={navOpen}` + `.nav.nav-open { transform: translateX(0) }` 조합이 Svelte 5의 스코핑된 CSS에서 신뢰성 있게 동작하지 않음
- **수정**: 클래스 기반 선택자 대신 `style={navOpen ? 'transform: translateX(0)' : undefined}` inline style 바인딩으로 변경. inline style은 CSS 스코핑을 우회하고 media query보다 항상 우선 적용됨

### 2. Ghost click (터치 디바이스 합성 클릭)
- 모바일에서 tap → pointerup 후 브라우저가 동일 좌표에 `click` 이벤트를 합성함
- 햄버거 버튼 tap → navOpen=true → overlay 등장 → ghost click이 overlay에 적중 → closeNav() 즉시 실행
- **수정**: `closeNav()`에 350ms 타임스탬프 가드 추가. navOpen이 된 지 350ms 이내에 closeNav가 호출되면 무시

## 변경 파일
- `Nav.svelte`: `class:nav-open` → inline style transform 바인딩, `[style*='translateX(0)']` 어트리뷰트 셀렉터로 box-shadow 제어
- `Shell.svelte`: `navOpenedAt` 타임스탬프 추적, `closeNav` 350ms 가드 추가

## Test plan
- [ ] 모바일 (≤900px): 햄버거 탭 → nav 드로어 슬라이드인 확인
- [ ] nav 드로어 열린 상태 → overlay 탭 → nav 닫힘 확인
- [ ] nav 드로어 열린 상태 → ✕ 버튼 탭 → nav 닫힘 확인  
- [ ] nav 드로어 열린 상태 → 메뉴 항목 탭 → nav 닫히고 페이지 이동 확인
- [ ] 데스크탑: 기존과 동일 동작 (햄버거 비표시, nav 항상 표시)
- [ ] `svelte-check` 에러 없음