### PR TITLE
fix: nav drawer가 모바일에서 보이지 않는 진짜 원인 수정

### DIFF
--- a/frontend/console/src/components/Nav.svelte
+++ b/frontend/console/src/components/Nav.svelte
@@ -270,6 +270,8 @@
 
   @media (max-width: 900px) {
     .nav {
+      /* Mobile drawer: use explicit width because :root overrides --nav-width to 0 on mobile */
+      width: min(280px, 80vw);
       transform: translateX(-100%);
       transition: transform var(--duration-normal) var(--ease-out), box-shadow var(--duration-normal) var(--ease-out);
     }


### PR DESCRIPTION
## 진짜 원인

Playwright로 모바일 viewport(375x812)에서 직접 검증해서 찾은 근본 원인:

\`app.css\` 556줄에 다음과 같은 모바일 오버라이드가 있음:
\`\`\`css
@media (max-width: 900px) {
  :root { --nav-width: 0px; }
}
\`\`\`

이건 예전에 Nav가 \`display: none\`이던 시절, Shell의 \`margin-left: var(--nav-width)\`를 0으로 만들기 위해 추가된 것으로 보임. 하지만 Nav.svelte의 \`width: var(--nav-width)\`도 함께 0이 되면서:

- Nav의 실제 width = 0px (border 1px만 남아 시각적으로는 1px)
- \`transform: translateX(-100%)\` = 0의 100%인 0px (이동 안 함)
- \`navOpen = true\`가 되어도 width 0짜리 nav가 보일 리 없음

Playwright 측정값:
- 수정 전: \`width: 1px\`, \`transform: matrix(1,0,0,1,-1,0)\`, \`rect.width: 1\`
- 수정 후: \`width: 280px\`, \`transform: matrix(1,0,0,1,-280,0)\`, \`rect.width: 280\`

## 수정

Nav.svelte의 모바일 미디어 쿼리에 명시적 width 추가:
\`\`\`css
@media (max-width: 900px) {
  .nav {
    width: min(280px, 80vw);  /* explicit override */
    transform: translateX(-100%);
    ...
  }
}
\`\`\`

\`:root\`의 \`--nav-width: 0\` 오버라이드는 유지 (Config.svelte, Shell.svelte의 레이아웃 오프셋 계산이 의존)

## Test plan
- [x] Playwright 375x812: Nav width 280px 확인
- [x] 햄버거 탭 → \`transform: translateX(0px)\` → drawer 슬라이드인 ✓
- [x] 메뉴 항목 탭 → 페이지 이동 + drawer 자동 닫힘 ✓
- [x] overlay 클릭 → drawer 닫힘 (350ms ghost click 가드 동작 확인) ✓
- [x] svelte-check 에러 없음