### PR TITLE
chore: add diff lint and coverage ci gates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,8 @@
 
 ## Validation
 
+- [ ] `make lint-diff`
+- [ ] `make test-cover-diff`
 - [ ] `make test`
 - [ ] `make security-scan`
 - [ ] Additional manual verification, if needed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
         run: PATH="$(go env GOPATH)/bin:$PATH" make security-scan
 
   test:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs: security
     steps:
@@ -62,7 +63,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Run tests with coverage
-        run: make test-cover
+        run: make test-cover-check
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
@@ -70,3 +71,31 @@ jobs:
           files: coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
+
+  pr-diff:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    needs: security
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Lint changed Go code
+        env:
+          DIFF_BASE: ${{ github.event.pull_request.base.sha }}
+          DIFF_HEAD: HEAD
+        run: make lint-diff
+
+      - name: Test changed Go packages with diff coverage
+        env:
+          DIFF_BASE: ${{ github.event.pull_request.base.sha }}
+          DIFF_HEAD: HEAD
+        run: make test-cover-diff

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,30 @@
+version: "2"
+
+run:
+  timeout: 5m
+  tests: true
+
+linters:
+  default: none
+  enable:
+    - govet
+    - ineffassign
+    - revive
+  settings:
+    revive:
+      confidence: 0.8
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: error-naming
+        - name: error-return
+        - name: error-strings
+        - name: errorf
+        - name: range
+        - name: receiver-naming
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,12 @@
 make build                # Go binary → bin/tars (ALWAYS Makefile, never go build)
 make console-build        # Svelte frontend assets (includes npm install)
 make test                 # go test ./...
+make lint-diff            # PR preflight: golangci-lint new issues since DIFF_BASE
+make test-diff            # PR preflight: changed Go packages + coverage check
+make test-cover-diff      # PR preflight: changed-line coverage >= DIFF_COVER_MIN
 make test-one TEST_NAME=TestFoo PKG=./internal/tarsserver/
 make test-race / make test-cover
-make fmt / make vet / make tidy / make security-scan
+make fmt / make vet / make lint / make tidy / make security-scan
 make dev-serve            # production-like (requires console-build first)
 make dev-console          # Vite (5173) + Go API (43180), auth off → http://127.0.0.1:43180/console
 cd frontend/console && npm run check   # svelte-check + tsc
@@ -155,6 +158,7 @@ TARS 기능 변경 시 홈페이지 콘텐츠도 갱신 필요 (매 변경마다
 
 `.github/workflows/ci.yml`:
 1. **security** — gitleaks + ripgrep secrets scan
-2. **test** — Node 20 → Playwright → Go test + coverage → Codecov
+2. **pr-diff** — pull requests run `make lint-diff` and `make test-cover-diff` against the PR base SHA
+3. **test** — pushes to main run Node 20 → Playwright → Go test + coverage threshold → Codecov
 
 `release-on-version-bump.yml` — triggered by `VERSION.txt` change on main. Builds console before binary.

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,12 @@ TEST_NAME ?=
 HEARTBEAT_INTERVAL ?= 30s
 MAX_HEARTBEATS ?= 0
 COVER_OUT ?= coverage.out
+COVER_OUT_DIFF ?= coverage.diff.out
+COVER_MIN ?= 60
+DIFF_COVER_MIN ?= 80
+DIFF_HEAD ?=
+GOLANGCI_LINT_VERSION ?= v2.12.2
+GOLANGCI_LINT ?= $(GO) run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 TARS_CONFIG ?= ./workspace/config/tars.config.yaml
 ROOT_DIR := $(abspath .)
 TARS_BIN := $(abspath $(BIN_DIR)/tars)
@@ -53,8 +59,9 @@ RELEASE_STAGE_DIR ?= $(DIST_DIR)/release-$(RELEASE_GOOS)-$(RELEASE_GOARCH)
 .DEFAULT_GOAL := help
 
 .PHONY: help \
-	test test-v test-one test-nocache test-race test-cover \
+	test test-v test-one test-nocache test-race test-cover test-cover-check test-diff test-cover-diff \
 	build build-bins release-asset clean tidy fmt vet lint \
+	lint-diff \
 	ensure-console-assets console-install console-build \
 	browser-install \
 	install install-server install-assistant uninstall uninstall-server uninstall-assistant reinstall \
@@ -71,6 +78,7 @@ help:
 	@echo ""
 	@echo "Common vars:"
 	@echo "  PKG=./... TEST_NAME=TestRun_ChatMessage CHAT_MSG='hello'"
+	@echo "  DIFF_BASE=<sha> DIFF_HEAD=<sha> COVER_MIN=$(COVER_MIN) DIFF_COVER_MIN=$(DIFF_COVER_MIN)"
 	@echo "  WORKSPACE_DIR=./workspace API_ADDR=127.0.0.1:43180 SERVER_URL=http://127.0.0.1:43180"
 	@echo "  TARS_CONFIG=./config/default.yaml ASSISTANT_API_TOKEN=... LAUNCH_PATH=$(LAUNCH_PATH)"
 	@echo "  ASSISTANT_WHISPER_LANGUAGE=$(ASSISTANT_WHISPER_LANGUAGE) (derived from locale; override with VAR=value)"
@@ -82,6 +90,9 @@ help:
 	@echo "  make test-nocache  - disable go test cache"
 	@echo "  make test-race     - run race detector"
 	@echo "  make test-cover    - write coverage to $(COVER_OUT)"
+	@echo "  make test-cover-check - require total coverage >= COVER_MIN ($(COVER_MIN)%)"
+	@echo "  make test-diff     - test changed Go packages + coverage check against DIFF_BASE"
+	@echo "  make test-cover-diff - require changed-line coverage >= DIFF_COVER_MIN ($(DIFF_COVER_MIN)%)"
 	@echo ""
 	@echo "Build/quality targets:"
 	@echo "  make build         - go build ./..."
@@ -102,7 +113,8 @@ help:
 	@echo "  make logs-assistant-err - tail assistant stderr log"
 	@echo "  make fmt           - go fmt ./..."
 	@echo "  make vet           - go vet ./..."
-	@echo "  make lint          - alias of vet for quality checks"
+	@echo "  make lint          - golangci-lint ./... (includes revive)"
+	@echo "  make lint-diff     - golangci-lint only new issues since DIFF_BASE"
 	@echo "  make tidy          - go mod tidy"
 	@echo "  make clean         - remove build artifacts"
 	@echo ""
@@ -141,6 +153,17 @@ test-race:
 
 test-cover:
 	$(GO) test -coverprofile=$(COVER_OUT) $(PKG)
+
+test-cover-check:
+	$(GO) test -coverprofile=$(COVER_OUT) $(PKG)
+	GO="$(GO)" ./scripts/check_coverage.sh "$(COVER_OUT)" "$(COVER_MIN)"
+
+test-diff:
+	GO="$(GO)" DIFF_HEAD="$(DIFF_HEAD)" COVER_OUT="$(COVER_OUT_DIFF)" COVER_MIN="$(COVER_MIN)" ./scripts/go_test_diff.sh
+
+test-cover-diff:
+	GO="$(GO)" DIFF_HEAD="$(DIFF_HEAD)" COVER_OUT="$(COVER_OUT_DIFF)" COVER_MIN="" ./scripts/go_test_diff.sh
+	GO="$(GO)" DIFF_HEAD="$(DIFF_HEAD)" ./scripts/check_diff_coverage.sh "$(COVER_OUT_DIFF)" "$(DIFF_COVER_MIN)"
 
 build: ensure-console-assets
 	mkdir -p $(BIN_DIR)
@@ -351,12 +374,18 @@ fmt:
 vet:
 	$(GO) vet ./...
 
-lint: vet
+lint:
+	$(GOLANGCI_LINT) run ./...
+
+lint-diff:
+	@base="$${DIFF_BASE:-$$(./scripts/diff_base.sh)}"; \
+	echo "Running golangci-lint for new issues since $${base}"; \
+	$(GOLANGCI_LINT) run --new-from-rev="$${base}" ./...
 
 tidy:
 	$(GO) mod tidy
 
 clean:
-	rm -rf $(BIN_DIR) $(COVER_OUT)
+	rm -rf $(BIN_DIR) $(COVER_OUT) $(COVER_OUT_DIFF)
 
 run-serve: dev-serve

--- a/scripts/check_coverage.sh
+++ b/scripts/check_coverage.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cover_file="${1:-coverage.out}"
+minimum="${2:-60}"
+go_bin="${GO:-go}"
+
+if [[ ! -s "${cover_file}" ]]; then
+  printf 'coverage profile not found: %s\n' "${cover_file}" >&2
+  exit 1
+fi
+
+total="$("${go_bin}" tool cover -func="${cover_file}" | awk '/^total:/ { gsub("%", "", $3); print $3 }')"
+if [[ -z "${total}" ]]; then
+  printf 'coverage total not found in %s\n' "${cover_file}" >&2
+  exit 1
+fi
+
+awk -v total="${total}" -v minimum="${minimum}" 'BEGIN {
+  if (total + 0 < minimum + 0) {
+    printf "coverage %.1f%% is below required %.1f%%\n", total, minimum > "/dev/stderr"
+    exit 1
+  }
+  printf "coverage %.1f%% meets required %.1f%%\n", total, minimum
+}'

--- a/scripts/check_diff_coverage.sh
+++ b/scripts/check_diff_coverage.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cover_file="${1:-coverage.diff.out}"
+minimum="${2:-80}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+base="${DIFF_BASE:-$("${script_dir}/diff_base.sh")}"
+head="${DIFF_HEAD:-}"
+go_bin="${GO:-go}"
+head_label="${head:-working tree}"
+
+changed_file="$(mktemp)"
+coverable_file="$(mktemp)"
+covered_file="$(mktemp)"
+relevant_file="$(mktemp)"
+covered_relevant_file="$(mktemp)"
+trap 'rm -f "${changed_file}" "${coverable_file}" "${covered_file}" "${relevant_file}" "${covered_relevant_file}"' EXIT
+
+diff_command() {
+  if [[ -n "${head}" ]]; then
+    git diff -U0 --diff-filter=ACMRT "${base}" "${head}" -- '*.go'
+  else
+    git diff -U0 --diff-filter=ACMRT "${base}" -- '*.go'
+  fi
+}
+
+current_file=""
+while IFS= read -r line; do
+  if [[ "${line}" == "+++ b/"* ]]; then
+    current_file="${line#+++ b/}"
+    continue
+  fi
+  if [[ "${line}" =~ ^@@[[:space:]] && "${current_file}" == *.go && "${current_file}" != *_test.go ]]; then
+    if [[ "${line}" =~ \+([0-9]+)(,([0-9]+))? ]]; then
+      start="${BASH_REMATCH[1]}"
+      count="${BASH_REMATCH[3]:-1}"
+      if [[ "${count}" == "0" ]]; then
+        continue
+      fi
+      for ((offset = 0; offset < count; offset++)); do
+        printf '%s:%d\n' "${current_file}" "$((start + offset))"
+      done
+    fi
+  fi
+done < <(diff_command) | sort -u > "${changed_file}"
+
+if [[ ! -s "${changed_file}" ]]; then
+  printf 'No changed non-test Go lines between %s and %s; skipping diff coverage.\n' "${base}" "${head_label}"
+  exit 0
+fi
+
+if [[ ! -s "${cover_file}" ]]; then
+  printf 'coverage profile not found: %s\n' "${cover_file}" >&2
+  exit 1
+fi
+
+module="$("${go_bin}" list -m)"
+while IFS= read -r line; do
+  [[ "${line}" == "mode:"* ]] && continue
+  if [[ "${line}" =~ ^([^:]+):([0-9]+)\.[0-9]+,([0-9]+)\.[0-9]+[[:space:]]+[0-9]+[[:space:]]+([0-9]+)$ ]]; then
+    file="${BASH_REMATCH[1]}"
+    start="${BASH_REMATCH[2]}"
+    end="${BASH_REMATCH[3]}"
+    count="${BASH_REMATCH[4]}"
+    file="${file#${module}/}"
+    file="${file#./}"
+    for ((line_no = start; line_no <= end; line_no++)); do
+      printf '%s:%d\n' "${file}" "${line_no}" >> "${coverable_file}"
+      if ((count > 0)); then
+        printf '%s:%d\n' "${file}" "${line_no}" >> "${covered_file}"
+      fi
+    done
+  fi
+done < "${cover_file}"
+
+sort -u -o "${coverable_file}" "${coverable_file}"
+sort -u -o "${covered_file}" "${covered_file}"
+comm -12 "${changed_file}" "${coverable_file}" > "${relevant_file}"
+
+if [[ ! -s "${relevant_file}" ]]; then
+  printf 'No coverable changed Go lines between %s and %s; skipping diff coverage.\n' "${base}" "${head_label}"
+  exit 0
+fi
+
+comm -12 "${relevant_file}" "${covered_file}" > "${covered_relevant_file}"
+
+total="$(wc -l < "${relevant_file}" | tr -d '[:space:]')"
+covered="$(wc -l < "${covered_relevant_file}" | tr -d '[:space:]')"
+percent="$(awk -v covered="${covered}" -v total="${total}" 'BEGIN { printf "%.1f", (covered / total) * 100 }')"
+
+awk -v percent="${percent}" -v minimum="${minimum}" -v covered="${covered}" -v total="${total}" 'BEGIN {
+  if (percent + 0 < minimum + 0) {
+    printf "diff coverage %.1f%% (%d/%d changed coverable lines) is below required %.1f%%\n", percent, covered, total, minimum > "/dev/stderr"
+    exit 1
+  }
+  printf "diff coverage %.1f%% (%d/%d changed coverable lines) meets required %.1f%%\n", percent, covered, total, minimum
+}'

--- a/scripts/diff_base.sh
+++ b/scripts/diff_base.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "${DIFF_BASE:-}" ]]; then
+  printf '%s\n' "${DIFF_BASE}"
+  exit 0
+fi
+
+diff_branch="${DIFF_BRANCH:-origin/main}"
+if git rev-parse --verify --quiet "${diff_branch}^{commit}" >/dev/null; then
+  git merge-base HEAD "${diff_branch}"
+  exit 0
+fi
+
+if git rev-parse --verify --quiet "main^{commit}" >/dev/null; then
+  git merge-base HEAD main
+  exit 0
+fi
+
+cat >&2 <<'EOF'
+Unable to resolve a diff base.
+Set DIFF_BASE=<sha> or fetch origin/main before running this target.
+EOF
+exit 1

--- a/scripts/go_changed_packages.sh
+++ b/scripts/go_changed_packages.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base="${1:-$("${BASH_SOURCE%/*}/diff_base.sh")}"
+head="${2:-${DIFF_HEAD:-}}"
+go_bin="${GO:-go}"
+
+if [[ -n "${head}" ]]; then
+  changed_files="$(git diff --name-only --diff-filter=ACMRT "${base}" "${head}" -- '*.go' 'go.mod' 'go.sum')"
+else
+  changed_files="$(git diff --name-only --diff-filter=ACMRT "${base}" -- '*.go' 'go.mod' 'go.sum')"
+fi
+if [[ -z "${changed_files}" ]]; then
+  exit 0
+fi
+
+if printf '%s\n' "${changed_files}" | grep -Eq '^(go\.mod|go\.sum)$'; then
+  printf '%s\n' './...'
+  exit 0
+fi
+
+dirs_file="$(mktemp)"
+trap 'rm -f "${dirs_file}"' EXIT
+
+printf '%s\n' "${changed_files}" |
+  awk 'NF { sub("/[^/]*$", "", $0); if ($0 == "") $0 = "."; print "./" $0 }' |
+  sed 's#^\./\./#./#' |
+  sort -u > "${dirs_file}"
+
+if [[ ! -s "${dirs_file}" ]]; then
+  exit 0
+fi
+
+"${go_bin}" list $(cat "${dirs_file}") 2>/dev/null | sed "s#^$("${go_bin}" list -m)#./#"

--- a/scripts/go_test_diff.sh
+++ b/scripts/go_test_diff.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+base="${DIFF_BASE:-$("${script_dir}/diff_base.sh")}"
+head="${DIFF_HEAD:-}"
+go_bin="${GO:-go}"
+cover_out="${COVER_OUT:-coverage.diff.out}"
+cover_min="${COVER_MIN:-60}"
+head_label="${head:-working tree}"
+
+packages_file="$(mktemp)"
+trap 'rm -f "${packages_file}"' EXIT
+
+if [[ -n "${head}" ]]; then
+  "${script_dir}/go_changed_packages.sh" "${base}" "${head}" > "${packages_file}"
+else
+  "${script_dir}/go_changed_packages.sh" "${base}" > "${packages_file}"
+fi
+if [[ ! -s "${packages_file}" ]]; then
+  printf 'No changed Go packages between %s and %s; skipping go test.\n' "${base}" "${head_label}"
+  exit 0
+fi
+
+printf 'Testing changed Go packages between %s and %s:\n' "${base}" "${head_label}"
+sed 's/^/  /' "${packages_file}"
+
+"${go_bin}" test -coverprofile="${cover_out}" $(cat "${packages_file}")
+if [[ -n "${cover_min}" ]]; then
+  "${script_dir}/check_coverage.sh" "${cover_out}" "${cover_min}"
+fi


### PR DESCRIPTION
## Summary

- Adds local and PR-time diff quality gates for Go lint, tests, and coverage.
- Lets developers run the same diff-focused checks locally before opening a PR.

## Changes

- Main user-visible or developer-visible changes: adds `make lint`, `make lint-diff`, `make test-diff`, and `make test-cover-diff`.
- API, config, or compatibility changes: adds golangci-lint/revive config and PR CI jobs for lint-diff, test-diff, and test-cover-diff.

## Validation

- [x] `make lint-diff`
- [x] `make test-diff`
- [x] `make test-cover-diff`
- [ ] `make security-scan`

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [x] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [x] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level: Medium. CI workflow changes can affect PR acceptance.
- Rollback plan: Revert this PR to restore the previous CI shape.