### PR TITLE
chore: reduce pulse chat signal duplication

### DIFF
--- a/internal/pulse/signal.go
+++ b/internal/pulse/signal.go
@@ -186,29 +186,9 @@ func (s *Scanner) scanStalledChats(ctx context.Context, now time.Time) *Signal {
 		return nil
 	}
 	primary := candidates[0]
-	canAutoResume := false
-	for _, candidate := range candidates {
-		if candidate.CanAutoResume {
-			canAutoResume = true
-			break
-		}
-	}
-	details := map[string]any{
-		"stalled_count":       len(candidates),
-		"session_id":          primary.SessionID,
-		"session_title":       primary.Title,
-		"last_message_id":     primary.LastMessageID,
-		"age_minutes":         primary.AgeMinutes,
-		"can_auto_resume":     primary.CanAutoResume,
-		"auto_resume_enabled": primary.AutoResumeEnabled,
-		"resume_mode":         primary.ResumeMode,
-		"block_reason":        primary.BlockReason,
-		"autofix_candidate":   autofix.AutoContinueChatName,
-		"sessions":            candidates,
-	}
-	if canAutoResume {
-		details["has_auto_resume_candidate"] = true
-	}
+	details := newChatSignalDetails("stalled_count", candidates, autofix.AutoContinueChatName, map[string]any{
+		"resume_mode": primary.ResumeMode,
+	})
 	return &Signal{
 		Kind:     SignalKindStalledChat,
 		Severity: SeverityWarn,

--- a/internal/pulse/signal_chat_details.go
+++ b/internal/pulse/signal_chat_details.go
@@ -1,0 +1,82 @@
+package pulse
+
+type chatSignalCandidate interface {
+	chatSignalDetails() chatSignalCandidateDetails
+	canAutoResumeCandidate() bool
+}
+
+type chatSignalCandidateDetails struct {
+	sessionID         string
+	title             string
+	lastMessageID     string
+	ageMinutes        int
+	canAutoResume     bool
+	autoResumeEnabled bool
+	blockReason       string
+}
+
+func (candidate StalledChatCandidate) chatSignalDetails() chatSignalCandidateDetails {
+	return chatSignalCandidateDetails{
+		sessionID:         candidate.SessionID,
+		title:             candidate.Title,
+		lastMessageID:     candidate.LastMessageID,
+		ageMinutes:        candidate.AgeMinutes,
+		canAutoResume:     candidate.CanAutoResume,
+		autoResumeEnabled: candidate.AutoResumeEnabled,
+		blockReason:       candidate.BlockReason,
+	}
+}
+
+func (candidate StalledChatCandidate) canAutoResumeCandidate() bool {
+	return candidate.CanAutoResume
+}
+
+func (candidate FailedChatCandidate) chatSignalDetails() chatSignalCandidateDetails {
+	return chatSignalCandidateDetails{
+		sessionID:         candidate.SessionID,
+		title:             candidate.Title,
+		lastMessageID:     candidate.LastMessageID,
+		ageMinutes:        candidate.AgeMinutes,
+		canAutoResume:     candidate.CanAutoResume,
+		autoResumeEnabled: candidate.AutoResumeEnabled,
+		blockReason:       candidate.BlockReason,
+	}
+}
+
+func (candidate FailedChatCandidate) canAutoResumeCandidate() bool {
+	return candidate.CanAutoResume
+}
+
+func newChatSignalDetails[T chatSignalCandidate](
+	countKey string,
+	candidates []T,
+	autofixCandidate string,
+	extra map[string]any,
+) map[string]any {
+	if len(candidates) == 0 {
+		return nil
+	}
+	primary := candidates[0].chatSignalDetails()
+	details := map[string]any{
+		countKey:              len(candidates),
+		"session_id":          primary.sessionID,
+		"session_title":       primary.title,
+		"last_message_id":     primary.lastMessageID,
+		"age_minutes":         primary.ageMinutes,
+		"can_auto_resume":     primary.canAutoResume,
+		"auto_resume_enabled": primary.autoResumeEnabled,
+		"block_reason":        primary.blockReason,
+		"autofix_candidate":   autofixCandidate,
+		"sessions":            candidates,
+	}
+	for _, candidate := range candidates {
+		if candidate.canAutoResumeCandidate() {
+			details["has_auto_resume_candidate"] = true
+			break
+		}
+	}
+	for key, value := range extra {
+		details[key] = value
+	}
+	return details
+}

--- a/internal/pulse/signal_chat_details_test.go
+++ b/internal/pulse/signal_chat_details_test.go
@@ -1,0 +1,89 @@
+package pulse
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewChatSignalDetailsRecordsSharedPrimaryFields(t *testing.T) {
+	candidates := []StalledChatCandidate{
+		{
+			SessionID:         "sess_primary",
+			Title:             "Primary",
+			LastMessageID:     "msg_primary",
+			AgeMinutes:        45,
+			AutoResumeEnabled: true,
+			CanAutoResume:     false,
+			ResumeMode:        "record_assumption_and_proceed",
+		},
+		{
+			SessionID:         "sess_resume",
+			Title:             "Can resume",
+			LastMessageID:     "msg_resume",
+			AgeMinutes:        60,
+			AutoResumeEnabled: true,
+			CanAutoResume:     true,
+		},
+	}
+
+	details := newChatSignalDetails(
+		"stalled_count",
+		candidates,
+		"auto_continue_chat",
+		map[string]any{"resume_mode": candidates[0].ResumeMode},
+	)
+
+	want := map[string]any{
+		"stalled_count":             2,
+		"session_id":                "sess_primary",
+		"session_title":             "Primary",
+		"last_message_id":           "msg_primary",
+		"age_minutes":               45,
+		"can_auto_resume":           false,
+		"auto_resume_enabled":       true,
+		"block_reason":              "",
+		"autofix_candidate":         "auto_continue_chat",
+		"sessions":                  candidates,
+		"has_auto_resume_candidate": true,
+		"resume_mode":               "record_assumption_and_proceed",
+	}
+	if !reflect.DeepEqual(details, want) {
+		t.Fatalf("details = %#v, want %#v", details, want)
+	}
+}
+
+func TestNewChatSignalDetailsOmitsAggregateAutoResumeWhenAbsent(t *testing.T) {
+	candidates := []FailedChatCandidate{
+		{
+			SessionID:         "sess_failed",
+			Title:             "Failed",
+			LastMessageID:     "msg_tool_err",
+			AgeMinutes:        55,
+			FailureKind:       FailedChatKindToolError,
+			FailingToolName:   "exec",
+			AutoResumeEnabled: true,
+			CanAutoResume:     false,
+			BlockReason:       "high_risk_failure",
+		},
+	}
+
+	details := newChatSignalDetails(
+		"failed_count",
+		candidates,
+		"auto_resume_failed_chat",
+		map[string]any{
+			"failure_kind": FailedChatKindToolError,
+			"failing_tool": "exec",
+		},
+	)
+
+	if _, ok := details["has_auto_resume_candidate"]; ok {
+		t.Fatalf("has_auto_resume_candidate should be absent when no candidate can auto-resume: %#v", details)
+	}
+	if details["failed_count"] != 1 {
+		t.Fatalf("failed_count = %#v, want 1", details["failed_count"])
+	}
+	if details["block_reason"] != "high_risk_failure" {
+		t.Fatalf("block_reason = %#v", details["block_reason"])
+	}
+}

--- a/internal/pulse/signal_failed_chat.go
+++ b/internal/pulse/signal_failed_chat.go
@@ -186,30 +186,10 @@ func (s *Scanner) scanFailedChats(ctx context.Context, now time.Time) *Signal {
 		return nil
 	}
 	primary := candidates[0]
-	canAutoResume := false
-	for _, candidate := range candidates {
-		if candidate.CanAutoResume {
-			canAutoResume = true
-			break
-		}
-	}
-	details := map[string]any{
-		"failed_count":        len(candidates),
-		"session_id":          primary.SessionID,
-		"session_title":       primary.Title,
-		"last_message_id":     primary.LastMessageID,
-		"age_minutes":         primary.AgeMinutes,
-		"failure_kind":        primary.FailureKind,
-		"failing_tool":        primary.FailingToolName,
-		"can_auto_resume":     primary.CanAutoResume,
-		"auto_resume_enabled": primary.AutoResumeEnabled,
-		"block_reason":        primary.BlockReason,
-		"autofix_candidate":   autofix.AutoResumeFailedChatName,
-		"sessions":            candidates,
-	}
-	if canAutoResume {
-		details["has_auto_resume_candidate"] = true
-	}
+	details := newChatSignalDetails("failed_count", candidates, autofix.AutoResumeFailedChatName, map[string]any{
+		"failure_kind": primary.FailureKind,
+		"failing_tool": primary.FailingToolName,
+	})
 	return &Signal{
 		Kind:     SignalKindFailedChat,
 		Severity: SeverityWarn,


### PR DESCRIPTION
## Summary

- Reduces one behavior-preserving SonarCloud duplication cluster from #790: repeated Pulse chat signal detail assembly in stalled-chat and failed-chat scanners.
- Keeps the domain-specific signal scanners readable while moving shared primary-session fields, sessions, autofix candidate, and aggregate auto-resume flag into one typed helper.
- Initial #790 baseline: duplicated lines density `3.5%`, duplicated lines `3,483`, duplicated blocks `290`, duplicated files `44`, NCLOC `89,613` at 2026-05-09 08:19 UTC.

Closes #790.

## Changes

- Main user-visible or developer-visible changes:
  - Added a shared Pulse helper for common chat signal detail maps.
  - Updated stalled-chat and failed-chat signal generation to use the helper.
  - Added characterization tests for common detail fields and aggregate auto-resume flag behavior.
- API, config, or compatibility changes:
  - None. Internal refactor only.

## Validation

- [x] `go test ./internal/pulse`
- [x] `make lint-diff`
- [x] `make test-cover-diff`
- [ ] `make test` - Not run; PR touches only `internal/pulse` and targeted plus diff-coverage tests passed.
- [ ] `make security-scan` - Not run; no dependency, workflow, or security-sensitive surface changed.
- [x] `git diff --check`

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [x] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [x] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level: Low. This is a package-local refactor that preserves existing signal detail keys.
- Rollback plan: Revert this PR to restore inline detail map construction in each scanner.