### PR TITLE
chore: reduce stalled chat detector complexity

### DIFF
--- a/internal/pulse/signal.go
+++ b/internal/pulse/signal.go
@@ -211,71 +211,95 @@ func DetectStalledChatCandidates(ctx context.Context, source ChatSessionSource, 
 	}
 	var candidates []StalledChatCandidate
 	for _, sess := range sessions {
-		if err := ctx.Err(); err != nil {
+		candidate, ok, err := detectStalledChatCandidate(ctx, source, sess, now)
+		if err != nil {
 			return candidates, err
 		}
-		tasks, err := source.GetTasks(sess.ID)
-		if err != nil {
-			zlog.Logger.Debug().Err(err).Str("session_id", sess.ID).Msg("pulse: skip stalled-chat task read failure")
-			continue
+		if ok {
+			candidates = append(candidates, candidate)
 		}
-		if !hasActiveSessionWork(tasks) {
-			continue
-		}
-		messages, err := session.ReadMessages(source.TranscriptPath(sess.ID))
-		if err != nil {
-			zlog.Logger.Debug().Err(err).Str("session_id", sess.ID).Msg("pulse: skip stalled-chat transcript read failure")
-			continue
-		}
-		msg, ok := latestConversationalMessage(messages)
-		if !ok || msg.Role != "assistant" {
-			continue
-		}
-		content := strings.TrimSpace(msg.Content)
-		if !looksLikeWaitingQuestion(content) {
-			continue
-		}
-		lastAt := msg.Timestamp.UTC()
-		if lastAt.IsZero() {
-			lastAt = sess.UpdatedAt.UTC()
-		}
-		consent := sess.AutomationConsent
-		afterMinutes := session.DefaultAutoResumeAfterMinutes
-		autoResumeEnabled := false
-		modes := []string{session.AutoResumeModeRecordAssumptionAndProceed}
-		if consent != nil {
-			afterMinutes = consent.EffectiveAutoResumeAfterMinutes()
-			autoResumeEnabled = consent.AllowsAutoResume()
-			modes = consent.EffectiveAllowedResumeModes()
-		}
-		if now.Sub(lastAt) < time.Duration(afterMinutes)*time.Minute {
-			continue
-		}
-		blockReason := ""
-		if isHighRiskQuestion(content) {
-			blockReason = "high_risk_question"
-		}
-		resumeMode := ""
-		if len(modes) > 0 {
-			resumeMode = modes[0]
-		}
-		canAutoResume := autoResumeEnabled && blockReason == "" && resumeMode != ""
-		candidates = append(candidates, StalledChatCandidate{
-			SessionID:              sess.ID,
-			Title:                  sess.Title,
-			LastMessageID:          msg.ID,
-			LastAssistantAt:        lastAt,
-			AgeMinutes:             int(now.Sub(lastAt).Minutes()),
-			AutoResumeEnabled:      autoResumeEnabled,
-			AutoResumeAfterMinutes: afterMinutes,
-			AllowedResumeModes:     modes,
-			ResumeMode:             resumeMode,
-			CanAutoResume:          canAutoResume,
-			BlockReason:            blockReason,
-			QuestionPreview:        trimPulsePreview(content, 180),
-		})
 	}
 	return candidates, nil
+}
+
+func detectStalledChatCandidate(ctx context.Context, source ChatSessionSource, sess session.Session, now time.Time) (StalledChatCandidate, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return StalledChatCandidate{}, false, err
+	}
+	tasks, err := source.GetTasks(sess.ID)
+	if err != nil {
+		zlog.Logger.Debug().Err(err).Str("session_id", sess.ID).Msg("pulse: skip stalled-chat task read failure")
+		return StalledChatCandidate{}, false, nil
+	}
+	if !hasActiveSessionWork(tasks) {
+		return StalledChatCandidate{}, false, nil
+	}
+	messages, err := session.ReadMessages(source.TranscriptPath(sess.ID))
+	if err != nil {
+		zlog.Logger.Debug().Err(err).Str("session_id", sess.ID).Msg("pulse: skip stalled-chat transcript read failure")
+		return StalledChatCandidate{}, false, nil
+	}
+	msg, ok := latestConversationalMessage(messages)
+	if !ok || msg.Role != "assistant" {
+		return StalledChatCandidate{}, false, nil
+	}
+	candidate, ok := classifyStalledChatCandidate(sess, msg, now)
+	return candidate, ok, nil
+}
+
+func classifyStalledChatCandidate(sess session.Session, msg session.Message, now time.Time) (StalledChatCandidate, bool) {
+	content := strings.TrimSpace(msg.Content)
+	if !looksLikeWaitingQuestion(content) {
+		return StalledChatCandidate{}, false
+	}
+	lastAt := msg.Timestamp.UTC()
+	if lastAt.IsZero() {
+		lastAt = sess.UpdatedAt.UTC()
+	}
+	afterMinutes, autoResumeEnabled, modes := stalledChatConsentSettings(sess)
+	if now.Sub(lastAt) < time.Duration(afterMinutes)*time.Minute {
+		return StalledChatCandidate{}, false
+	}
+	blockReason := ""
+	if isHighRiskQuestion(content) {
+		blockReason = "high_risk_question"
+	}
+	resumeMode := firstResumeMode(modes)
+	canAutoResume := autoResumeEnabled && blockReason == "" && resumeMode != ""
+	return StalledChatCandidate{
+		SessionID:              sess.ID,
+		Title:                  sess.Title,
+		LastMessageID:          msg.ID,
+		LastAssistantAt:        lastAt,
+		AgeMinutes:             int(now.Sub(lastAt).Minutes()),
+		AutoResumeEnabled:      autoResumeEnabled,
+		AutoResumeAfterMinutes: afterMinutes,
+		AllowedResumeModes:     modes,
+		ResumeMode:             resumeMode,
+		CanAutoResume:          canAutoResume,
+		BlockReason:            blockReason,
+		QuestionPreview:        trimPulsePreview(content, 180),
+	}, true
+}
+
+func stalledChatConsentSettings(sess session.Session) (int, bool, []string) {
+	consent := sess.AutomationConsent
+	afterMinutes := session.DefaultAutoResumeAfterMinutes
+	autoResumeEnabled := false
+	modes := []string{session.AutoResumeModeRecordAssumptionAndProceed}
+	if consent != nil {
+		afterMinutes = consent.EffectiveAutoResumeAfterMinutes()
+		autoResumeEnabled = consent.AllowsAutoResume()
+		modes = consent.EffectiveAllowedResumeModes()
+	}
+	return afterMinutes, autoResumeEnabled, modes
+}
+
+func firstResumeMode(modes []string) string {
+	if len(modes) == 0 {
+		return ""
+	}
+	return modes[0]
 }
 
 func hasActiveSessionWork(tasks session.SessionTasks) bool {

--- a/internal/pulse/signal_test.go
+++ b/internal/pulse/signal_test.go
@@ -313,6 +313,40 @@ func TestScanner_StalledChatHighRiskQuestionOnlyNotifies(t *testing.T) {
 	}
 }
 
+func TestClassifyStalledChatCandidateUsesDefaultConsentSettings(t *testing.T) {
+	now := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	lastAssistantAt := now.Add(-45 * time.Minute)
+	candidate, ok := classifyStalledChatCandidate(session.Session{
+		ID:        "sess_default",
+		Title:     "Default consent",
+		UpdatedAt: now.Add(-40 * time.Minute),
+	}, session.Message{
+		ID:        "msg_question",
+		Role:      "assistant",
+		Content:   "Should I continue with the default option?",
+		Timestamp: lastAssistantAt,
+	}, now)
+
+	if !ok {
+		t.Fatalf("expected stalled-chat candidate")
+	}
+	if candidate.AutoResumeAfterMinutes != session.DefaultAutoResumeAfterMinutes {
+		t.Fatalf("auto resume threshold = %d, want %d", candidate.AutoResumeAfterMinutes, session.DefaultAutoResumeAfterMinutes)
+	}
+	if candidate.AutoResumeEnabled {
+		t.Fatalf("auto resume should default to disabled")
+	}
+	if candidate.CanAutoResume {
+		t.Fatalf("candidate should not auto-resume without explicit consent")
+	}
+	if candidate.ResumeMode != session.AutoResumeModeRecordAssumptionAndProceed {
+		t.Fatalf("resume mode = %q", candidate.ResumeMode)
+	}
+	if !candidate.LastAssistantAt.Equal(lastAssistantAt) {
+		t.Fatalf("last assistant at = %s, want %s", candidate.LastAssistantAt, lastAssistantAt)
+	}
+}
+
 // --- disk ---
 
 func TestScanner_DiskWarn(t *testing.T) {


### PR DESCRIPTION
## Summary

- Reduces one SonarCloud `go:S3776` cognitive-complexity finding from #786 in `internal/pulse/signal.go`.
- Keeps `DetectStalledChatCandidates` focused on iterating sessions and delegates per-session detection/classification to named helpers.
- Preserves the existing stalled-chat signal behavior, including default consent settings, high-risk blocking, threshold handling, and transcript/task read skipping.

Closes #786.

## Changes

- Main user-visible or developer-visible changes:
  - Extracted per-session stalled-chat detection into `detectStalledChatCandidate`.
  - Extracted stalled-chat candidate construction into `classifyStalledChatCandidate`.
  - Added a characterization test for default auto-resume consent behavior.
- API, config, or compatibility changes:
  - None. Internal refactor only.

## Validation

- [x] `go test ./internal/pulse`
- [x] `make lint-diff`
- [x] `make test-cover-diff`
- [ ] `make test` - Not run; PR touches only `internal/pulse` and targeted plus diff-coverage tests passed.
- [ ] `make security-scan` - Not run; no dependency, workflow, or security-sensitive surface changed.
- [x] `git diff --check`

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [x] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [x] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level: Low. The change is package-local and covered by existing scanner tests plus a new helper-level characterization test.
- Rollback plan: Revert this PR to restore inline stalled-chat candidate construction.