### PR TITLE
fix: sync tool group policy with individual tool checkboxes

### DIFF
--- a/frontend/console/src/components/SessionConfigPanel.svelte
+++ b/frontend/console/src/components/SessionConfigPanel.svelte
@@ -321,8 +321,18 @@
   }
 
   function isToolEnabled(name: string): boolean {
+    const group = tools.find((t) => t.name === name)?.group
+    if (group && denyGroupsSet.has(group)) return false
+    if (allowGroupsSet.size > 0 && (!group || !allowGroupsSet.has(group))) return false
     if (!useCustomConfig) return !disabledSet.has(name)
     return enabledSet.has(name) && !disabledSet.has(name)
+  }
+
+  function isToolGroupControlled(name: string): boolean {
+    const group = tools.find((t) => t.name === name)?.group
+    if (group && denyGroupsSet.has(group)) return true
+    if (allowGroupsSet.size > 0 && (!group || !allowGroupsSet.has(group))) return true
+    return false
   }
 
   function toggleTool(name: string) {
@@ -828,13 +838,13 @@
           <input type="checkbox" checked={!useCustomConfig} onchange={toggleAllTools} />
           <span>All tools</span>
         </label>
-        <span class="config-count">{useCustomConfig ? enabledSet.size : tools.length - disabledSet.size} active</span>
+        <span class="config-count">{tools.filter((t) => isToolEnabled(t.name)).length} active</span>
       </div>
       <div class="config-list">
         {#each filteredTools as t}
           {@const toolSrc = sourceForToolList(t.name)}
           <label class="config-item" class:high-risk={t.high_risk}>
-            <input type="checkbox" checked={isToolEnabled(t.name)} onchange={() => toggleTool(t.name)} />
+            <input type="checkbox" checked={isToolEnabled(t.name)} disabled={isToolGroupControlled(t.name)} onchange={() => toggleTool(t.name)} />
             <span class="item-name">{t.name}</span>
             {#if t.group}
               <span class="badge badge-neutral" style="font-size:9px;padding:0 4px;">{t.group}</span>
@@ -1376,6 +1386,8 @@
   .config-item:hover { background: rgba(255, 255, 255, 0.03); }
 
   .config-item.high-risk { border-left: 2px solid rgba(248, 113, 113, 0.3); }
+
+  .config-list input[type='checkbox']:disabled + .item-name { opacity: 0.4; }
 
   .item-name {
     font-family: var(--font-mono);


### PR DESCRIPTION
## Summary
- `isToolEnabled()`이 `allowGroupsSet`/`denyGroupsSet`을 무시해 그룹 정책이 개별 툴 체크박스에 반영되지 않던 문제 수정
- Deny 그룹 소속 툴: 항상 unchecked
- Allow 그룹이 하나라도 체크된 경우: 해당 그룹 외 툴은 unchecked
- `isToolGroupControlled()` 헬퍼 추가 — 그룹 정책으로 상태가 고정된 툴의 체크박스를 `disabled` 처리
- active 카운트를 그룹 정책 포함한 실제 활성 수로 수정
- 그룹 제어 툴의 이름 opacity 0.4로 흐리게 표시

## Test plan
- [x] `npx svelte-check` — 0 errors
- [x] `npm run test:ci` — 13/13 pass