### PR TITLE
fix: show dot-files in panel/mentions and refresh after tool calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ node_modules/
 # Local-only working docs (plans, code reviews) — kept on disk, not tracked
 docs/plans/
 docs/code-review/
+
+# for tars
+.tars/

--- a/frontend/console/src/components/ArtifactPanel.svelte
+++ b/frontend/console/src/components/ArtifactPanel.svelte
@@ -492,7 +492,7 @@
   }
 
   export function refresh() {
-    void browseDir(currentPath)
+    void loadWorkDirs().then(() => browseDir(currentPath))
   }
 
   export async function openArtifactPath(path: string) {

--- a/frontend/console/src/components/Chat.svelte
+++ b/frontend/console/src/components/Chat.svelte
@@ -559,12 +559,12 @@
 
   function handleToolComplete(toolName: string) {
     const taskTools = ['tasks']
-    const fileTools = ['write_file', 'edit_file', 'exec', 'list_dir', 'read_file']
+    const fileTools = ['write_file', 'edit_file', 'exec', 'list_dir', 'read_file', 'apply_patch']
 
     if (taskTools.includes(toolName)) {
       tasksPanelRef?.load()
     }
-    if (fileTools.includes(toolName) && isPanelOpen('artifacts')) {
+    if (fileTools.includes(toolName)) {
       artifactPanelRef?.refresh()
     }
   }

--- a/frontend/console/src/components/ChatPanel.svelte
+++ b/frontend/console/src/components/ChatPanel.svelte
@@ -413,6 +413,9 @@
             }
 
             onToolComplete?.(event.tool_name || '')
+            if (mentionOpen) {
+              void refreshMentionCandidates()
+            }
             if ((event.tool_name || '').trim() === 'project_skill') {
               void reloadSlashSkillsAndCandidates()
             }

--- a/internal/tarsserver/handler_chat_mentions.go
+++ b/internal/tarsserver/handler_chat_mentions.go
@@ -3,6 +3,7 @@ package tarsserver
 import (
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -142,6 +143,13 @@ func listChatFileMentionCandidates(roots []chatFileMentionRoot, rawQuery string,
 	if limit <= 0 {
 		limit = chatMentionDefaultLimit
 	}
+	// Recursive search when the query is a plain name (no path separator).
+	// Path-based queries (containing "/") use the directory listing below.
+	trimmedQuery := strings.TrimPrefix(strings.TrimSpace(rawQuery), "@")
+	isPathQuery := strings.Contains(trimmedQuery, "/")
+	if !isPathQuery && prefix != "" {
+		return listChatFileMentionCandidatesRecursive(roots, prefix, limit)
+	}
 	prefix = strings.ToLower(prefix)
 	candidates := make([]chatFileMentionCandidate, 0, limit)
 	for _, root := range roots {
@@ -239,7 +247,70 @@ func splitChatMentionQuery(rawQuery string) (parentPath string, prefix string, e
 }
 
 func shouldHideWorkspaceEntry(name string) bool {
-	return strings.HasPrefix(name, ".") || name == "node_modules"
+	return name == "node_modules"
+}
+
+// listChatFileMentionCandidatesRecursive walks each root recursively and returns
+// entries whose names start with prefix (case-insensitive). Hidden entries and
+// node_modules are skipped as with the directory listing path.
+func listChatFileMentionCandidatesRecursive(roots []chatFileMentionRoot, prefix string, limit int) ([]chatFileMentionCandidate, error) {
+	lowerPrefix := strings.ToLower(prefix)
+	candidates := make([]chatFileMentionCandidate, 0, limit)
+	for _, root := range roots {
+		walkErr := filepath.WalkDir(root.Dir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			name := d.Name()
+			if shouldHideWorkspaceEntry(name) {
+				if d.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if path == root.Dir {
+				return nil
+			}
+			if !strings.HasPrefix(strings.ToLower(name), lowerPrefix) {
+				return nil
+			}
+			rel, relErr := filepath.Rel(root.Dir, path)
+			if relErr != nil {
+				return nil
+			}
+			rel = filepath.ToSlash(rel)
+			kind := "file"
+			token := "@" + rel
+			if d.IsDir() {
+				kind = "directory"
+				token += "/"
+			}
+			candidate := chatFileMentionCandidate{
+				Kind:      kind,
+				Name:      name,
+				Path:      rel,
+				Root:      root.Dir,
+				RootLabel: root.Label,
+				Token:     token,
+			}
+			if info, infoErr := d.Info(); infoErr == nil {
+				candidate.Size = info.Size()
+				candidate.UpdatedAt = info.ModTime().UTC().Format(time.RFC3339)
+			}
+			candidates = append(candidates, candidate)
+			if len(candidates) >= limit {
+				return fs.SkipAll
+			}
+			return nil
+		})
+		if walkErr != nil {
+			return nil, walkErr
+		}
+		if len(candidates) >= limit {
+			break
+		}
+	}
+	return candidates, nil
 }
 
 func chatMentionsToContentBlocks(store *session.Store, workspaceDir string, sessionID string, mentions []chatFileMentionRequest) ([]llm.ContentBlock, []string, error) {

--- a/internal/tarsserver/handler_chat_mentions_test.go
+++ b/internal/tarsserver/handler_chat_mentions_test.go
@@ -74,6 +74,111 @@ func TestChatFileMentionCandidatesUseSessionCurrentDir(t *testing.T) {
 	}
 }
 
+func TestChatFileMentionCandidatesShowTarsDir(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "workspace")
+	if err := memory.EnsureWorkspace(root); err != nil {
+		t.Fatalf("ensure workspace: %v", err)
+	}
+	projectDir := filepath.Join(root, "project")
+	tarsDir := filepath.Join(projectDir, ".tars", "skills")
+	if err := os.MkdirAll(tarsDir, 0o755); err != nil {
+		t.Fatalf("mkdir .tars/skills: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tarsDir, "SKILL.md"), []byte("# Skill"), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+
+	store := session.NewStore(root)
+	sess, err := store.Create("tars dir mention test")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if err := store.SetWorkDirs(sess.ID, []string{projectDir}, projectDir); err != nil {
+		t.Fatalf("set work dirs: %v", err)
+	}
+
+	handler := newChatAPIHandler(root, store, &mockLLMClient{}, zerolog.New(io.Discard))
+	req := httptest.NewRequest(http.MethodGet, "/v1/chat/mentions/files?session_id="+url.QueryEscape(sess.ID)+"&q=.tars", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%q", rec.Code, rec.Body.String())
+	}
+
+	var got chatFileMentionCandidatesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(got.Candidates) == 0 {
+		t.Fatal("expected .tars directory to appear in mention candidates, got none")
+	}
+	found := false
+	for _, c := range got.Candidates {
+		if c.Path == ".tars" && c.Kind == "directory" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf(".tars directory not found in candidates: %+v", got.Candidates)
+	}
+}
+
+func TestChatFileMentionCandidatesRecursiveSearch(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "workspace")
+	if err := memory.EnsureWorkspace(root); err != nil {
+		t.Fatalf("ensure workspace: %v", err)
+	}
+	projectDir := filepath.Join(root, "project")
+	deepDir := filepath.Join(projectDir, "a", "b", "c")
+	if err := os.MkdirAll(deepDir, 0o755); err != nil {
+		t.Fatalf("mkdir deep: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(deepDir, "deep.md"), []byte("deep"), 0o644); err != nil {
+		t.Fatalf("write deep.md: %v", err)
+	}
+	// node_modules should not be walked
+	nodeDir := filepath.Join(projectDir, "node_modules")
+	if err := os.MkdirAll(nodeDir, 0o755); err != nil {
+		t.Fatalf("mkdir node_modules: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nodeDir, "deep.md"), []byte("hidden"), 0o644); err != nil {
+		t.Fatalf("write node_modules deep.md: %v", err)
+	}
+
+	store := session.NewStore(root)
+	sess, err := store.Create("recursive mention test")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if err := store.SetWorkDirs(sess.ID, []string{projectDir}, projectDir); err != nil {
+		t.Fatalf("set work dirs: %v", err)
+	}
+
+	handler := newChatAPIHandler(root, store, &mockLLMClient{}, zerolog.New(io.Discard))
+	req := httptest.NewRequest(http.MethodGet, "/v1/chat/mentions/files?session_id="+url.QueryEscape(sess.ID)+"&q=deep", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%q", rec.Code, rec.Body.String())
+	}
+
+	var got chatFileMentionCandidatesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(got.Candidates) != 1 {
+		t.Fatalf("expected exactly one candidate (deep.md), got %+v", got.Candidates)
+	}
+	c := got.Candidates[0]
+	if c.Name != "deep.md" || c.Path != "a/b/c/deep.md" {
+		t.Fatalf("unexpected candidate: %+v", c)
+	}
+	if c.Token != "@a/b/c/deep.md" {
+		t.Fatalf("unexpected token: %q", c.Token)
+	}
+}
+
 func TestChatFileMentionCandidatesRejectTraversal(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "workspace")
 	if err := memory.EnsureWorkspace(root); err != nil {

--- a/internal/tarsserver/handler_filesystem_test.go
+++ b/internal/tarsserver/handler_filesystem_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/rs/zerolog"
 )
 
-func TestFilesystemBrowseHandler_IncludesTarsDirectory(t *testing.T) {
+func TestFilesystemBrowseHandler_ShowsDotFilesHidesNodeModules(t *testing.T) {
 	root := t.TempDir()
-	for _, name := range []string{".tars", ".git", "node_modules", "visible"} {
+	for _, name := range []string{".tars", ".git", ".env", "node_modules", "visible"} {
 		if err := os.MkdirAll(filepath.Join(root, name), 0o755); err != nil {
 			t.Fatalf("mkdir %s: %v", name, err)
 		}
@@ -41,13 +41,13 @@ func TestFilesystemBrowseHandler_IncludesTarsDirectory(t *testing.T) {
 	for _, entry := range got.Entries {
 		names[entry.Name] = true
 	}
-	if !names[".tars"] || !names["visible"] {
-		t.Fatalf("expected .tars and visible directories, got %+v", got.Entries)
-	}
-	for _, hidden := range []string{".git", "node_modules"} {
-		if names[hidden] {
-			t.Fatalf("did not expect hidden directory %s in %+v", hidden, got.Entries)
+	for _, visible := range []string{".tars", ".git", ".env", "visible"} {
+		if !names[visible] {
+			t.Fatalf("expected %s to be visible, got %+v", visible, got.Entries)
 		}
+	}
+	if names["node_modules"] {
+		t.Fatalf("did not expect node_modules in %+v", got.Entries)
 	}
 }
 

--- a/internal/tarsserver/handler_workspace_files.go
+++ b/internal/tarsserver/handler_workspace_files.go
@@ -78,10 +78,7 @@ func firstNonEmpty(values ...string) string {
 }
 
 func shouldHideFilePanelEntry(name string) bool {
-	if name == "node_modules" {
-		return true
-	}
-	return strings.HasPrefix(name, ".") && name != ".tars"
+	return name == "node_modules"
 }
 
 func truncateWorkspacePreviewText(value string, limit int) (string, bool) {

--- a/internal/tarsserver/handler_workspace_files_test.go
+++ b/internal/tarsserver/handler_workspace_files_test.go
@@ -220,13 +220,13 @@ func TestWorkspaceFilesHandler_AllowsExplicitFilesystemRootPreview(t *testing.T)
 	}
 }
 
-func TestWorkspaceFilesHandler_ListIncludesTarsDirectory(t *testing.T) {
+func TestWorkspaceFilesHandler_ListShowsDotFilesHidesNodeModules(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "workspace")
 	if err := memory.EnsureWorkspace(root); err != nil {
 		t.Fatalf("ensure workspace: %v", err)
 	}
 	artifactsRoot := filepath.Join(root, "artifacts")
-	for _, name := range []string{".tars", ".git", "node_modules", "visible"} {
+	for _, name := range []string{".tars", ".git", ".env", "node_modules", "visible"} {
 		if err := os.MkdirAll(filepath.Join(artifactsRoot, name), 0o755); err != nil {
 			t.Fatalf("mkdir %s: %v", name, err)
 		}
@@ -250,13 +250,13 @@ func TestWorkspaceFilesHandler_ListIncludesTarsDirectory(t *testing.T) {
 	for _, file := range got.Files {
 		names[file.Name] = true
 	}
-	if !names[".tars"] || !names["visible"] {
-		t.Fatalf("expected .tars and visible directories, got %+v", got.Files)
-	}
-	for _, hidden := range []string{".git", "node_modules"} {
-		if names[hidden] {
-			t.Fatalf("did not expect hidden directory %s in %+v", hidden, got.Files)
+	for _, visible := range []string{".tars", ".git", ".env", "visible"} {
+		if !names[visible] {
+			t.Fatalf("expected %s to be visible, got %+v", visible, got.Files)
 		}
+	}
+	if names["node_modules"] {
+		t.Fatalf("did not expect node_modules in %+v", got.Files)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **dot-file visibility**: `shouldHideWorkspaceEntry` / `shouldHideFilePanelEntry` now hide only `node_modules`; all dot-prefixed entries (`.env`, `.tars`, `.git`, etc.) are visible in the file panel and mentionable via `@`
- **`@` recursive search**: plain-name queries (no `/`) walk the entire workspace tree, so deeply nested files like `.tars/skills/SKILL.md` are now discoverable
- **file panel stale root bug**: `ArtifactPanel.refresh()` now calls `loadWorkDirs()` first, ensuring the correct `effectiveRoot` is used even when the panel is on the session-artifacts tab (previously workDirs were not loaded, causing files to be listed from the wrong root)
- **`apply_patch` missing from fileTools**: added to `handleToolComplete` so the panel refreshes after patch-based edits
- **removed `isPanelOpen` guard**: mounted panels always receive a refresh call after file tool completion (`?.refresh()` is already a no-op when the ref is null)
- **mention popup auto-refresh**: `ChatPanel` now calls `refreshMentionCandidates()` after each tool completes if the mention popup is currently open

## Test plan

- [x] `make test` — all Go tests pass including new `TestChatFileMentionCandidatesShowTarsDir` and `TestChatFileMentionCandidatesRecursiveSearch`
- [x] `make vet` — no issues
- [x] `npm run check` (svelte-check + tsc) — 0 errors