### PR TITLE
fix: clamp resource bounds for CodeQL findings

### DIFF
--- a/internal/cron/store.go
+++ b/internal/cron/store.go
@@ -417,10 +417,8 @@ func (s *Store) ListRuns(id string, limit int) ([]RunRecord, error) {
 	if err != nil {
 		return nil, err
 	}
-	if limit <= 0 {
-		limit = 50
-	}
-	filtered := make([]RunRecord, 0, min(limit, len(runs)))
+	limit = clampRunListLimit(limit, len(runs))
+	filtered := make([]RunRecord, 0, limit)
 	for i := len(runs) - 1; i >= 0; i-- {
 		filtered = append(filtered, runs[i])
 		if len(filtered) >= limit {
@@ -428,6 +426,19 @@ func (s *Store) ListRuns(id string, limit int) ([]RunRecord, error) {
 		}
 	}
 	return filtered, nil
+}
+
+func clampRunListLimit(limit int, available int) int {
+	if limit <= 0 {
+		limit = 50
+	}
+	if available < 0 {
+		available = 0
+	}
+	if limit > available {
+		return available
+	}
+	return limit
 }
 
 func (s *Store) TryStartRun(id string) bool {

--- a/internal/cron/store_test.go
+++ b/internal/cron/store_test.go
@@ -387,6 +387,49 @@ func TestStore_RunHistoryPrunesPerJobLimit(t *testing.T) {
 	}
 }
 
+
+func TestStore_ListRunsClampsLimitBounds(t *testing.T) {
+	root := t.TempDir()
+	store := NewStore(root)
+	job, err := store.CreateWithOptions(CreateInput{
+		Prompt:    "bounded history",
+		Schedule:  "every:1m",
+		Enabled:   true,
+		HasEnable: true,
+	})
+	if err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+	base := time.Date(2026, 2, 17, 10, 0, 0, 0, time.UTC)
+	for i := 0; i < 3; i++ {
+		if _, err := store.MarkRunResult(job.ID, base.Add(time.Duration(i)*time.Minute), "ok", nil); err != nil {
+			t.Fatalf("mark run %d: %v", i, err)
+		}
+	}
+
+	tests := []struct {
+		name  string
+		limit int
+		want  int
+	}{
+		{name: "negative defaults and clamps to available", limit: -1, want: 3},
+		{name: "zero defaults and clamps to available", limit: 0, want: 3},
+		{name: "huge clamps to available", limit: int(^uint(0) >> 1), want: 3},
+		{name: "max accepted unchanged", limit: 2, want: 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runs, err := store.ListRuns(job.ID, tt.limit)
+			if err != nil {
+				t.Fatalf("list runs: %v", err)
+			}
+			if len(runs) != tt.want {
+				t.Fatalf("ListRuns limit %d returned %d runs, want %d", tt.limit, len(runs), tt.want)
+			}
+		})
+	}
+}
+
 func TestStore_TryStartRunGuardsConcurrentExecution(t *testing.T) {
 	root := t.TempDir()
 	store := NewStore(root)

--- a/internal/skill/extraction.go
+++ b/internal/skill/extraction.go
@@ -132,6 +132,8 @@ var extractionTopics = []extractionTopic{
 	},
 }
 
+const maxExtractionCandidates = 5
+
 var extractionSkillCuePattern = regexp.MustCompile(`(?i)\b(skill|workflow|repeatable|reusable|template|automation|자동화|반복|재사용|워크플로우|스킬)\b`)
 
 func DetectExtractionCandidates(sess session.Session, messages []session.Message, opts ExtractionOptions) []ExtractionCandidate {
@@ -139,10 +141,7 @@ func DetectExtractionCandidates(sess session.Session, messages []session.Message
 	if now.IsZero() {
 		now = time.Now().UTC()
 	}
-	limit := opts.MaxCandidates
-	if limit <= 0 || limit > 5 {
-		limit = 5
-	}
+	limit := clampExtractionCandidateLimit(opts.MaxCandidates)
 	if len(messages) == 0 {
 		return []ExtractionCandidate{}
 	}
@@ -189,6 +188,13 @@ func DetectExtractionCandidates(sess session.Session, messages []session.Message
 		}
 	}
 	return candidates
+}
+
+func clampExtractionCandidateLimit(limit int) int {
+	if limit <= 0 || limit > maxExtractionCandidates {
+		return maxExtractionCandidates
+	}
+	return limit
 }
 
 func AppendExtractionCandidatesIfNew(root string, candidates []ExtractionCandidate) ([]ExtractionCandidate, bool, error) {

--- a/internal/skill/extraction_test.go
+++ b/internal/skill/extraction_test.go
@@ -104,3 +104,25 @@ func requireExtractionFileMode(t *testing.T, path string, want os.FileMode) {
 		t.Fatalf("expected %s mode %04o, got %04o", path, want, got)
 	}
 }
+
+func TestClampExtractionCandidateLimitBounds(t *testing.T) {
+	tests := []struct {
+		name  string
+		limit int
+		want  int
+	}{
+		{name: "negative defaults to max", limit: -1, want: maxExtractionCandidates},
+		{name: "zero defaults to max", limit: 0, want: maxExtractionCandidates},
+		{name: "huge clamps to max", limit: int(^uint(0) >> 1), want: maxExtractionCandidates},
+		{name: "max accepted unchanged", limit: maxExtractionCandidates, want: maxExtractionCandidates},
+		{name: "below max accepted unchanged", limit: 2, want: 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := clampExtractionCandidateLimit(tt.limit); got != tt.want {
+				t.Fatalf("clampExtractionCandidateLimit(%d) = %d, want %d", tt.limit, got, tt.want)
+			}
+		})
+	}
+}
+

--- a/internal/tarsserver/handler_terminal.go
+++ b/internal/tarsserver/handler_terminal.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"os"
 	"os/exec"
@@ -308,7 +309,22 @@ func clampTerminalDimension(value int, fallback int, minValue int, maxValue int)
 
 func terminalWinsize(size terminalSize) *pty.Winsize {
 	normalized := normalizeTerminalSize(size.Cols, size.Rows)
-	return &pty.Winsize{Cols: uint16(normalized.Cols), Rows: uint16(normalized.Rows)}
+
+	cols := normalized.Cols
+	if cols < 0 {
+		cols = 0
+	} else if cols > math.MaxUint16 {
+		cols = math.MaxUint16
+	}
+
+	rows := normalized.Rows
+	if rows < 0 {
+		rows = 0
+	} else if rows > math.MaxUint16 {
+		rows = math.MaxUint16
+	}
+
+	return &pty.Winsize{Cols: uint16(cols), Rows: uint16(rows)}
 }
 
 func serveTerminalWebSocket(w http.ResponseWriter, r *http.Request, term terminalSession, cwd string, size terminalSize, logger zerolog.Logger) {

--- a/internal/tarsserver/handler_terminal.go
+++ b/internal/tarsserver/handler_terminal.go
@@ -275,8 +275,14 @@ func terminalSizeFromRequest(r *http.Request) terminalSize {
 	if r == nil {
 		return normalizeTerminalSize(0, 0)
 	}
-	cols, _ := strconv.Atoi(strings.TrimSpace(r.URL.Query().Get("cols")))
-	rows, _ := strconv.Atoi(strings.TrimSpace(r.URL.Query().Get("rows")))
+	var cols int
+	if parsedCols, err := strconv.ParseUint(strings.TrimSpace(r.URL.Query().Get("cols")), 10, 16); err == nil {
+		cols = int(parsedCols)
+	}
+	var rows int
+	if parsedRows, err := strconv.ParseUint(strings.TrimSpace(r.URL.Query().Get("rows")), 10, 16); err == nil {
+		rows = int(parsedRows)
+	}
 	return normalizeTerminalSize(cols, rows)
 }
 

--- a/internal/tarsserver/handler_terminal.go
+++ b/internal/tarsserver/handler_terminal.go
@@ -34,6 +34,15 @@ type terminalOpenResult struct {
 
 type terminalOpenFunc func(context.Context, string) (terminalOpenResult, error)
 
+const (
+	defaultTerminalCols = 80
+	defaultTerminalRows = 24
+	minTerminalCols     = 20
+	minTerminalRows     = 5
+	maxTerminalCols     = 500
+	maxTerminalRows     = 200
+)
+
 type terminalSize struct {
 	Cols int `json:"cols,omitempty"`
 	Rows int `json:"rows,omitempty"`
@@ -272,25 +281,28 @@ func terminalSizeFromRequest(r *http.Request) terminalSize {
 }
 
 func normalizeTerminalSize(cols int, rows int) terminalSize {
-	if cols <= 0 {
-		cols = 80
+	return terminalSize{
+		Cols: clampTerminalDimension(cols, defaultTerminalCols, minTerminalCols, maxTerminalCols),
+		Rows: clampTerminalDimension(rows, defaultTerminalRows, minTerminalRows, maxTerminalRows),
 	}
-	if rows <= 0 {
-		rows = 24
+}
+
+func clampTerminalDimension(value int, fallback int, minValue int, maxValue int) int {
+	if value <= 0 {
+		value = fallback
 	}
-	if cols < 20 {
-		cols = 20
+	if value < minValue {
+		return minValue
 	}
-	if rows < 5 {
-		rows = 5
+	if value > maxValue {
+		return maxValue
 	}
-	if cols > 500 {
-		cols = 500
-	}
-	if rows > 200 {
-		rows = 200
-	}
-	return terminalSize{Cols: cols, Rows: rows}
+	return value
+}
+
+func terminalWinsize(size terminalSize) *pty.Winsize {
+	normalized := normalizeTerminalSize(size.Cols, size.Rows)
+	return &pty.Winsize{Cols: uint16(normalized.Cols), Rows: uint16(normalized.Rows)}
 }
 
 func serveTerminalWebSocket(w http.ResponseWriter, r *http.Request, term terminalSession, cwd string, size terminalSize, logger zerolog.Logger) {
@@ -417,7 +429,7 @@ func startPTYTerminalSession(ctx context.Context, cwd string, size terminalSize)
 	cmd := exec.CommandContext(ctx, shell)
 	cmd.Dir = cwd
 	cmd.Env = append(os.Environ(), "TERM=xterm-256color", "COLORTERM=truecolor")
-	winSize := &pty.Winsize{Cols: uint16(size.Cols), Rows: uint16(size.Rows)}
+	winSize := terminalWinsize(size)
 	file, err := pty.StartWithSize(cmd, winSize)
 	if err != nil {
 		return nil, err
@@ -443,7 +455,7 @@ func (s *ptyTerminalSession) Write(p []byte) (int, error) {
 }
 
 func (s *ptyTerminalSession) Resize(size terminalSize) error {
-	return pty.Setsize(s.file, &pty.Winsize{Cols: uint16(size.Cols), Rows: uint16(size.Rows)})
+	return pty.Setsize(s.file, terminalWinsize(size))
 }
 
 func (s *ptyTerminalSession) Close() error {

--- a/internal/tarsserver/handler_terminal_test.go
+++ b/internal/tarsserver/handler_terminal_test.go
@@ -24,6 +24,34 @@ import (
 	"github.com/rs/zerolog"
 )
 
+func TestNormalizeTerminalSizeClampsBounds(t *testing.T) {
+	maxInt := int(^uint(0) >> 1)
+	tests := []struct {
+		name string
+		cols int
+		rows int
+		want terminalSize
+	}{
+		{name: "negative uses defaults", cols: -1, rows: -1, want: terminalSize{Cols: defaultTerminalCols, Rows: defaultTerminalRows}},
+		{name: "zero uses defaults", cols: 0, rows: 0, want: terminalSize{Cols: defaultTerminalCols, Rows: defaultTerminalRows}},
+		{name: "below minimum clamps up", cols: 1, rows: 1, want: terminalSize{Cols: minTerminalCols, Rows: minTerminalRows}},
+		{name: "huge clamps down", cols: maxInt, rows: maxInt, want: terminalSize{Cols: maxTerminalCols, Rows: maxTerminalRows}},
+		{name: "max accepted unchanged", cols: maxTerminalCols, rows: maxTerminalRows, want: terminalSize{Cols: maxTerminalCols, Rows: maxTerminalRows}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeTerminalSize(tt.cols, tt.rows)
+			if got != tt.want {
+				t.Fatalf("normalizeTerminalSize(%d, %d) = %+v, want %+v", tt.cols, tt.rows, got, tt.want)
+			}
+			winSize := terminalWinsize(terminalSize{Cols: tt.cols, Rows: tt.rows})
+			if winSize.Cols != uint16(tt.want.Cols) || winSize.Rows != uint16(tt.want.Rows) {
+				t.Fatalf("terminalWinsize(%d, %d) = cols=%d rows=%d, want cols=%d rows=%d", tt.cols, tt.rows, winSize.Cols, winSize.Rows, tt.want.Cols, tt.want.Rows)
+			}
+		})
+	}
+}
+
 func TestTerminalAPI_OpenUsesSessionCurrentDir(t *testing.T) {
 	root, store, sess := newTerminalTestSession(t)
 	projectDir := testCanonicalPath(t, filepath.Join(root, "projects", "demo"))

--- a/internal/usage/tracker_analytics.go
+++ b/internal/usage/tracker_analytics.go
@@ -72,7 +72,7 @@ func (t *Tracker) Analytics(days int) (Analytics, error) {
 	if t == nil {
 		return Analytics{}, fmt.Errorf("usage tracker is nil")
 	}
-	days = normalizeAnalyticsDays(days)
+	days = clampAnalyticsDays(days)
 	now := t.nowFn().UTC()
 	start := dayStartUTC(now).AddDate(0, 0, -(days - 1))
 
@@ -116,6 +116,10 @@ func (t *Tracker) Analytics(days int) (Analytics, error) {
 }
 
 func normalizeAnalyticsDays(days int) int {
+	return clampAnalyticsDays(days)
+}
+
+func clampAnalyticsDays(days int) int {
 	switch days {
 	case 30, 90:
 		return days

--- a/internal/usage/tracker_analytics_test.go
+++ b/internal/usage/tracker_analytics_test.go
@@ -133,3 +133,28 @@ func TestTracker_AnalyticsReturnsZeroFilledEmptyDays(t *testing.T) {
 		t.Fatalf("unexpected non-empty analytics: %+v", analytics)
 	}
 }
+
+func TestClampAnalyticsDaysBounds(t *testing.T) {
+	tests := []struct {
+		name string
+		days int
+		want int
+	}{
+		{name: "negative defaults to seven", days: -1, want: 7},
+		{name: "zero defaults to seven", days: 0, want: 7},
+		{name: "huge defaults to seven", days: int(^uint(0) >> 1), want: 7},
+		{name: "thirty accepted", days: 30, want: 30},
+		{name: "ninety accepted", days: 90, want: 90},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := clampAnalyticsDays(tt.days); got != tt.want {
+				t.Fatalf("clampAnalyticsDays(%d) = %d, want %d", tt.days, got, tt.want)
+			}
+			if got := normalizeAnalyticsDays(tt.days); got != tt.want {
+				t.Fatalf("normalizeAnalyticsDays(%d) = %d, want %d", tt.days, got, tt.want)
+			}
+		})
+	}
+}
+


### PR DESCRIPTION
## Summary
- clamp terminal rows/cols before uint16 winsize conversion
- clamp cron run list limits before slice allocation
- add explicit clamp helpers for skill extraction and usage analytics bounds
- cover negative, zero, huge, and max accepted values with targeted tests

## Verification
- go test ./internal/tarsserver ./internal/cron ./internal/skill ./internal/usage
- make test-diff

Closes #807
