### PR TITLE
fix: clarify secure auth cookie handling

### DIFF
--- a/internal/tarsserver/handler_auth.go
+++ b/internal/tarsserver/handler_auth.go
@@ -132,7 +132,7 @@ func (h *authAPIHandler) handleLogin(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create session", "code": "session_create_failed"})
 		return
 	}
-	h.setSessionCookie(w, session.ID, gate.CookieSecure)
+	h.writeSessionCookie(w, session.ID, gate.CookieSecure)
 	writeJSON(w, http.StatusOK, map[string]any{
 		"authenticated": true,
 		"auth_role":     role,
@@ -189,7 +189,7 @@ func (h *authAPIHandler) handlePairingLogin(w http.ResponseWriter, r *http.Reque
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create session", "code": "session_create_failed"})
 		return
 	}
-	h.setSessionCookie(w, session.ID, gate.CookieSecure)
+	h.writeSessionCookie(w, session.ID, gate.CookieSecure)
 	writeJSON(w, http.StatusOK, map[string]any{
 		"authenticated": true,
 		"auth_role":     consoleauth.RoleUser,
@@ -210,15 +210,7 @@ func (h *authAPIHandler) handleLogout(w http.ResponseWriter, r *http.Request) {
 	}
 	// Secure must match the request class so loopback HTTP can clear local
 	// development cookies while HTTPS/Tailscale flows clear Secure cookies.
-	http.SetCookie(w, &http.Cookie{ // NOSONAR
-		Name:     h.cookieName,
-		Value:    "",
-		Path:     "/",
-		HttpOnly: true,
-		SameSite: http.SameSiteLaxMode,
-		Secure:   shouldClearSecureCookie(r),
-		MaxAge:   -1,
-	})
+	h.writeClearSessionCookie(w, shouldClearSecureCookie(r))
 	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
 }
 
@@ -267,17 +259,64 @@ func (h *authAPIHandler) handleUserPassword(w http.ResponseWriter, r *http.Reque
 	})
 }
 
-func (h *authAPIHandler) setSessionCookie(w http.ResponseWriter, sessionID string, secure bool) {
-	// Local loopback HTTP intentionally uses a non-Secure cookie; remote HTTPS
-	// and Tailscale-authenticated flows pass secure=true from evaluateLoginRequest.
-	http.SetCookie(w, &http.Cookie{ // NOSONAR
+// writeSessionCookie emits the browser session cookie, branching on the request
+// class decided by evaluateLoginRequest so each call site of http.SetCookie has a
+// literal Secure value that CodeQL/Sonar can reason about. The non-Secure branch
+// is reachable only when evaluateLoginRequest classified the request as local
+// loopback (127.0.0.1 / localhost / ::1); remote HTTPS and Tailscale-authenticated
+// flows always take the Secure: true branch.
+func (h *authAPIHandler) writeSessionCookie(w http.ResponseWriter, sessionID string, secure bool) {
+	if secure {
+		http.SetCookie(w, &http.Cookie{
+			Name:     h.cookieName,
+			Value:    sessionID,
+			Path:     "/",
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+			Secure:   true,
+			MaxAge:   h.cookieMaxAge,
+		})
+		return
+	}
+	// Loopback-only fallback. evaluateLoginRequest gates this branch so a
+	// non-Secure cookie cannot escape 127.0.0.1/localhost/::1; insecure non-local
+	// HTTP is rejected with 403 before we ever reach this code path.
+	http.SetCookie(w, &http.Cookie{ // NOSONAR -- gated to loopback by evaluateLoginRequest
 		Name:     h.cookieName,
 		Value:    sessionID,
 		Path:     "/",
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
-		Secure:   secure,
+		Secure:   false,
 		MaxAge:   h.cookieMaxAge,
+	})
+}
+
+// writeClearSessionCookie mirrors writeSessionCookie for the logout path. The
+// Secure attribute on a clearing cookie must match the original cookie or the
+// browser silently keeps the stale cookie around, so we still need the loopback
+// branch — but each branch carries an explicit Secure literal.
+func (h *authAPIHandler) writeClearSessionCookie(w http.ResponseWriter, secure bool) {
+	if secure {
+		http.SetCookie(w, &http.Cookie{
+			Name:     h.cookieName,
+			Value:    "",
+			Path:     "/",
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+			Secure:   true,
+			MaxAge:   -1,
+		})
+		return
+	}
+	http.SetCookie(w, &http.Cookie{ // NOSONAR -- clears the loopback-only cookie set by writeSessionCookie
+		Name:     h.cookieName,
+		Value:    "",
+		Path:     "/",
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   false,
+		MaxAge:   -1,
 	})
 }
 

--- a/internal/tarsserver/handler_auth.go
+++ b/internal/tarsserver/handler_auth.go
@@ -309,6 +309,8 @@ func (h *authAPIHandler) writeClearSessionCookie(w http.ResponseWriter, secure b
 		})
 		return
 	}
+
+	// codeql[go/cookie-secure-not-set] -- This only clears the loopback-only HTTP cookie emitted above; Secure=false must match that cookie so browsers actually delete it.
 	http.SetCookie(w, &http.Cookie{ // NOSONAR -- clears the loopback-only cookie set by writeSessionCookie
 		Name:     h.cookieName,
 		Value:    "",

--- a/internal/tarsserver/handler_auth_test.go
+++ b/internal/tarsserver/handler_auth_test.go
@@ -139,6 +139,64 @@ func TestAuthLoginAPI_LocalSetsInsecureCookie(t *testing.T) {
 	}
 }
 
+func TestAuthLoginAPI_RemoteHTTPSSetsSecureCookie(t *testing.T) {
+	workspace := t.TempDir()
+	store := consoleauth.NewStore(workspace)
+	if err := store.SetPassword(consoleauth.RoleUser, "user secret"); err != nil {
+		t.Fatalf("set user password: %v", err)
+	}
+	handler := newAuthAPIHandler("required", workspace)
+	req := httptest.NewRequest(http.MethodPost, "/v1/auth/login", strings.NewReader(`{"username":"user","password":"user secret"}`))
+	req.Host = "example.com"
+	req.RemoteAddr = "192.0.2.10:5555"
+	req.TLS = &tls.ConnectionState{}
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	cookie := findCookie(rec.Result().Cookies(), serverauth.DefaultBrowserSessionCookieName)
+	if cookie == nil {
+		t.Fatalf("expected session cookie")
+	}
+	if !cookie.Secure {
+		t.Fatalf("remote HTTPS login cookie must be Secure, got %+v", cookie)
+	}
+	if !cookie.HttpOnly || cookie.SameSite != http.SameSiteLaxMode || cookie.Path != "/" {
+		t.Fatalf("unexpected cookie attributes: %+v", cookie)
+	}
+	if _, ok, err := store.ValidateSession(cookie.Value); err != nil || !ok {
+		t.Fatalf("expected created session to validate, ok=%v err=%v", ok, err)
+	}
+}
+
+func TestAuthLoginAPI_TailscaleHTTPSSetsSecureCookie(t *testing.T) {
+	workspace := t.TempDir()
+	store := consoleauth.NewStore(workspace)
+	if err := store.SetPassword(consoleauth.RoleUser, "user secret"); err != nil {
+		t.Fatalf("set user password: %v", err)
+	}
+	handler := newAuthAPIHandler("required", workspace)
+	req := httptest.NewRequest(http.MethodPost, "/v1/auth/login", strings.NewReader(`{"username":"user","password":"user secret"}`))
+	req.Host = "macbook.tailnet.ts.net"
+	req.RemoteAddr = "100.64.0.5:5555"
+	req.TLS = &tls.ConnectionState{}
+	req.Header.Set(serverauth.TailscaleUserLoginHeader, "user@example.com")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	cookie := findCookie(rec.Result().Cookies(), serverauth.DefaultBrowserSessionCookieName)
+	if cookie == nil || !cookie.Secure {
+		t.Fatalf("expected secure Tailscale HTTPS session cookie, got %+v", cookie)
+	}
+}
+
 func TestAuthLoginAPI_TailscaleSetsSecureCookieAndRejectsAdmin(t *testing.T) {
 	workspace := t.TempDir()
 	store := consoleauth.NewStore(workspace)
@@ -175,6 +233,39 @@ func TestAuthLoginAPI_TailscaleSetsSecureCookieAndRejectsAdmin(t *testing.T) {
 	}
 	if findCookie(rec.Result().Cookies(), serverauth.DefaultBrowserSessionCookieName) != nil {
 		t.Fatalf("remote admin rejection must not set a session cookie")
+	}
+}
+
+func TestAuthPairingLoginAPI_LoopbackHTTPSetsInsecureCookie(t *testing.T) {
+	workspace := t.TempDir()
+	store := consoleauth.NewStore(workspace)
+	code, err := store.CreatePairingCode(consoleauth.RoleUser, time.Minute)
+	if err != nil {
+		t.Fatalf("create pairing code: %v", err)
+	}
+	handler := newAuthAPIHandler("required", workspace)
+	req := httptest.NewRequest(http.MethodPost, "/v1/auth/pairing-login", strings.NewReader(`{"code":"`+code.Code+`"}`))
+	req.Host = "127.0.0.1:43180"
+	req.RemoteAddr = "127.0.0.1:1234"
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	cookie := findCookie(rec.Result().Cookies(), serverauth.DefaultBrowserSessionCookieName)
+	if cookie == nil {
+		t.Fatalf("expected session cookie")
+	}
+	if cookie.Secure {
+		t.Fatalf("loopback pairing login cookie must not be Secure, got %+v", cookie)
+	}
+	if !cookie.HttpOnly || cookie.SameSite != http.SameSiteLaxMode || cookie.Path != "/" {
+		t.Fatalf("unexpected cookie attributes: %+v", cookie)
+	}
+	if _, ok, err := store.ValidateSession(cookie.Value); err != nil || !ok {
+		t.Fatalf("expected created session to validate, ok=%v err=%v", ok, err)
 	}
 }
 
@@ -259,6 +350,36 @@ func TestAuthLogoutAPI_ClearsSecureCookieForHTTPSRequest(t *testing.T) {
 	cookie := findCookie(rec.Result().Cookies(), serverauth.DefaultBrowserSessionCookieName)
 	if cookie == nil || cookie.MaxAge >= 0 || !cookie.Secure {
 		t.Fatalf("expected Secure clearing cookie for HTTPS logout, got %+v", cookie)
+	}
+}
+
+func TestAuthLogoutAPI_ClearsSecureCookieForTailscaleHTTPSRequest(t *testing.T) {
+	workspace := t.TempDir()
+	store := consoleauth.NewStore(workspace)
+	session, err := store.CreateSession(consoleauth.RoleUser, "safari", time.Hour)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	handler := newAuthAPIHandler("required", workspace)
+	req := httptest.NewRequest(http.MethodPost, "/v1/auth/logout", nil)
+	req.Host = "macbook.tailnet.ts.net"
+	req.RemoteAddr = "100.64.0.5:5555"
+	req.TLS = &tls.ConnectionState{}
+	req.Header.Set(serverauth.TailscaleUserLoginHeader, "user@example.com")
+	req.AddCookie(&http.Cookie{Name: serverauth.DefaultBrowserSessionCookieName, Value: session.ID})
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	cookie := findCookie(rec.Result().Cookies(), serverauth.DefaultBrowserSessionCookieName)
+	if cookie == nil || cookie.MaxAge >= 0 || !cookie.Secure {
+		t.Fatalf("expected Secure clearing cookie for Tailscale HTTPS logout, got %+v", cookie)
+	}
+	if _, ok, err := store.ValidateSession(session.ID); err != nil || ok {
+		t.Fatalf("expected revoked session, ok=%v err=%v", ok, err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- split auth session cookie writes into explicit Secure=true and loopback-only Secure=false branches
- keep local loopback HTTP support while ensuring remote HTTPS and Tailscale-authenticated flows use Secure cookies
- add regression coverage for remote HTTPS login, Tailscale HTTPS login, loopback HTTP pairing-login, and secure logout clearing

Closes #808

## Tests
- go test ./internal/tarsserver
- make test-diff