### PR TITLE
feat: capture & expose openai-codex subscription rate-limit headers

### DIFF
--- a/internal/llm/openai_codex_client.go
+++ b/internal/llm/openai_codex_client.go
@@ -42,6 +42,7 @@ type OpenAICodexClient struct {
 
 	mu               sync.RWMutex
 	overrideCred     *auth.CodexCredential
+	lastRateLimit    *CodexRateLimitSnapshot
 	validatedOnStart bool
 }
 
@@ -198,6 +199,9 @@ func (c *OpenAICodexClient) chatWithCredential(
 	if err != nil {
 		return ChatResponse{}, err
 	}
+	if snap := parseCodexRateLimitHeaders(resp.Header); snap != nil {
+		c.setLastRateLimit(snap)
+	}
 
 	if (resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden) &&
 		allowRefreshRetry &&
@@ -287,6 +291,28 @@ func (c *OpenAICodexClient) setOverrideCredential(cred auth.CodexCredential) {
 	defer c.mu.Unlock()
 	copy := cred
 	c.overrideCred = &copy
+}
+
+// LastCodexRateLimit returns the most recent rate-limit snapshot observed
+// from `/codex/responses` response headers, if any. Implements
+// CodexRateLimitSource.
+func (c *OpenAICodexClient) LastCodexRateLimit() (CodexRateLimitSnapshot, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.lastRateLimit == nil {
+		return CodexRateLimitSnapshot{}, false
+	}
+	return *c.lastRateLimit, true
+}
+
+func (c *OpenAICodexClient) setLastRateLimit(snap *CodexRateLimitSnapshot) {
+	if snap == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	copy := *snap
+	c.lastRateLimit = &copy
 }
 
 func (c *OpenAICodexClient) defaultResolveCredential() (auth.CodexCredential, error) {

--- a/internal/llm/openai_codex_client_test.go
+++ b/internal/llm/openai_codex_client_test.go
@@ -12,6 +12,67 @@ import (
 	"github.com/devlikebear/tars/internal/auth"
 )
 
+func TestOpenAICodexClient_CapturesRateLimitHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("x-codex-primary-used-percent", "37.5")
+		w.Header().Set("x-codex-primary-window-minutes", "300")
+		w.Header().Set("x-codex-primary-reset-after-seconds", "1200")
+		w.Header().Set("x-codex-secondary-used-percent", "8")
+		w.Header().Set("x-codex-secondary-window-minutes", "10080")
+		w.Header().Set("x-codex-credits-remaining", "9001")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer srv.Close()
+
+	client, err := newOpenAICodexClientWithConfig(
+		srv.URL,
+		"gpt-5.3-codex",
+		"oauth",
+		"openai-codex",
+		"",
+		DefaultClientConfig(),
+		func() (auth.CodexCredential, error) {
+			return auth.CodexCredential{AccessToken: "tok"}, nil
+		},
+		func(context.Context, auth.CodexCredential) (auth.CodexCredential, error) {
+			t.Fatal("refresh should not be called")
+			return auth.CodexCredential{}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("new codex client: %v", err)
+	}
+
+	if _, ok := client.LastCodexRateLimit(); ok {
+		t.Fatal("expected no snapshot before any request")
+	}
+
+	if _, err := client.Chat(context.Background(), []ChatMessage{{Role: "user", Content: "hi"}}, ChatOptions{
+		OnDelta: func(string) {},
+	}); err != nil {
+		t.Fatalf("chat: %v", err)
+	}
+
+	snap, ok := client.LastCodexRateLimit()
+	if !ok {
+		t.Fatal("expected snapshot after request")
+	}
+	if snap.Primary == nil || snap.Primary.UsedPercent != 37.5 || snap.Primary.WindowMinutes != 300 {
+		t.Errorf("primary: %+v", snap.Primary)
+	}
+	if snap.Secondary == nil || snap.Secondary.UsedPercent != 8 || snap.Secondary.WindowMinutes != 10080 {
+		t.Errorf("secondary: %+v", snap.Secondary)
+	}
+	if got := snap.RawHeaders["x-codex-credits-remaining"]; got != "9001" {
+		t.Errorf("raw credits-remaining: got %q, want 9001", got)
+	}
+
+	// Sanity: client also satisfies the CodexRateLimitSource interface.
+	var _ CodexRateLimitSource = client
+}
+
 func TestOpenAICodexClient_Headers_SetsRequired(t *testing.T) {
 	var gotAuth, gotBeta, gotOriginator, gotAccept, gotAccountID, gotPath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/llm/openai_codex_ratelimit.go
+++ b/internal/llm/openai_codex_ratelimit.go
@@ -1,0 +1,94 @@
+package llm
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// CodexRateLimitWindow holds parsed values for one rate-limit window
+// (primary = 5h-ish, secondary = weekly) reported by OpenAI Codex via
+// `x-codex-*` response headers on /codex/responses calls.
+type CodexRateLimitWindow struct {
+	UsedPercent       float64 `json:"used_percent"`
+	WindowMinutes     int     `json:"window_minutes,omitempty"`
+	ResetAfterSeconds int     `json:"reset_after_seconds,omitempty"`
+}
+
+// CodexRateLimitSnapshot is the most recently observed Codex subscription
+// usage for a given client. RawHeaders preserves every `x-codex-*` header
+// (including ones we don't yet model) so the API surface is forward-compatible
+// when OpenAI ships new headers.
+type CodexRateLimitSnapshot struct {
+	Primary    *CodexRateLimitWindow `json:"primary,omitempty"`
+	Secondary  *CodexRateLimitWindow `json:"secondary,omitempty"`
+	RawHeaders map[string]string     `json:"raw_headers,omitempty"`
+	CapturedAt time.Time             `json:"captured_at"`
+}
+
+// CodexRateLimitSource is implemented by clients (and wrappers) that can
+// surface the most recently observed Codex rate-limit snapshot. Used by the
+// admin handler to fish the snapshot out of whatever client the router holds
+// (raw OpenAICodexClient, or a TrackedClient wrapping one).
+type CodexRateLimitSource interface {
+	LastCodexRateLimit() (CodexRateLimitSnapshot, bool)
+}
+
+const codexHeaderPrefix = "x-codex-"
+
+// parseCodexRateLimitHeaders extracts rate-limit info from response headers.
+// Returns nil if no `x-codex-*` header is present, otherwise returns a
+// snapshot with whatever could be parsed. Malformed numeric values fall back
+// to zero in the typed fields but are preserved verbatim in RawHeaders so
+// debugging can still see them.
+func parseCodexRateLimitHeaders(h http.Header) *CodexRateLimitSnapshot {
+	raw := map[string]string{}
+	for key, values := range h {
+		lower := strings.ToLower(key)
+		if !strings.HasPrefix(lower, codexHeaderPrefix) {
+			continue
+		}
+		if len(values) == 0 {
+			continue
+		}
+		raw[lower] = strings.TrimSpace(values[0])
+	}
+	if len(raw) == 0 {
+		return nil
+	}
+
+	snap := &CodexRateLimitSnapshot{
+		RawHeaders: raw,
+		CapturedAt: time.Now().UTC(),
+	}
+	snap.Primary = parseCodexWindow(raw, "primary")
+	snap.Secondary = parseCodexWindow(raw, "secondary")
+	return snap
+}
+
+func parseCodexWindow(raw map[string]string, kind string) *CodexRateLimitWindow {
+	used, hasUsed := raw[codexHeaderPrefix+kind+"-used-percent"]
+	window, hasWindow := raw[codexHeaderPrefix+kind+"-window-minutes"]
+	reset, hasReset := raw[codexHeaderPrefix+kind+"-reset-after-seconds"]
+	if !hasUsed && !hasWindow && !hasReset {
+		return nil
+	}
+	w := &CodexRateLimitWindow{}
+	if hasUsed {
+		if v, err := strconv.ParseFloat(used, 64); err == nil {
+			w.UsedPercent = v
+		}
+	}
+	if hasWindow {
+		if v, err := strconv.Atoi(window); err == nil {
+			w.WindowMinutes = v
+		}
+	}
+	if hasReset {
+		if v, err := strconv.Atoi(reset); err == nil {
+			w.ResetAfterSeconds = v
+		}
+	}
+	return w
+}

--- a/internal/llm/openai_codex_ratelimit_test.go
+++ b/internal/llm/openai_codex_ratelimit_test.go
@@ -1,0 +1,115 @@
+package llm
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestParseCodexRateLimitHeaders_ParsesPrimaryAndSecondary(t *testing.T) {
+	h := http.Header{}
+	h.Set("x-codex-primary-used-percent", "42.5")
+	h.Set("x-codex-primary-window-minutes", "300")
+	h.Set("x-codex-primary-reset-after-seconds", "1800")
+	h.Set("x-codex-secondary-used-percent", "12")
+	h.Set("x-codex-secondary-window-minutes", "10080")
+	h.Set("x-codex-secondary-reset-after-seconds", "604000")
+
+	snap := parseCodexRateLimitHeaders(h)
+	if snap == nil {
+		t.Fatal("expected snapshot, got nil")
+	}
+	if snap.Primary == nil {
+		t.Fatal("expected primary window")
+	}
+	if got, want := snap.Primary.UsedPercent, 42.5; got != want {
+		t.Errorf("primary used_percent: got %v, want %v", got, want)
+	}
+	if got, want := snap.Primary.WindowMinutes, 300; got != want {
+		t.Errorf("primary window_minutes: got %v, want %v", got, want)
+	}
+	if got, want := snap.Primary.ResetAfterSeconds, 1800; got != want {
+		t.Errorf("primary reset_after_seconds: got %v, want %v", got, want)
+	}
+	if snap.Secondary == nil {
+		t.Fatal("expected secondary window")
+	}
+	if got, want := snap.Secondary.UsedPercent, 12.0; got != want {
+		t.Errorf("secondary used_percent: got %v, want %v", got, want)
+	}
+	if got, want := snap.Secondary.WindowMinutes, 10080; got != want {
+		t.Errorf("secondary window_minutes: got %v, want %v", got, want)
+	}
+	if snap.CapturedAt.IsZero() {
+		t.Error("expected captured_at to be set")
+	}
+}
+
+func TestParseCodexRateLimitHeaders_PartialPrimaryOnly(t *testing.T) {
+	h := http.Header{}
+	h.Set("x-codex-primary-used-percent", "5.0")
+
+	snap := parseCodexRateLimitHeaders(h)
+	if snap == nil {
+		t.Fatal("expected snapshot, got nil")
+	}
+	if snap.Primary == nil || snap.Primary.UsedPercent != 5.0 {
+		t.Errorf("primary not parsed: %+v", snap.Primary)
+	}
+	if snap.Secondary != nil {
+		t.Errorf("expected nil secondary, got %+v", snap.Secondary)
+	}
+}
+
+func TestParseCodexRateLimitHeaders_NoCodexHeaders(t *testing.T) {
+	h := http.Header{}
+	h.Set("Content-Type", "application/json")
+	h.Set("X-Other-Provider", "stuff")
+
+	if snap := parseCodexRateLimitHeaders(h); snap != nil {
+		t.Errorf("expected nil for non-codex headers, got %+v", snap)
+	}
+}
+
+func TestParseCodexRateLimitHeaders_PreservesUnknownCodexHeaders(t *testing.T) {
+	h := http.Header{}
+	h.Set("x-codex-experimental-flag", "true")
+	h.Set("x-codex-credits-remaining", "1234")
+
+	snap := parseCodexRateLimitHeaders(h)
+	if snap == nil {
+		t.Fatal("expected snapshot, got nil")
+	}
+	if snap.Primary != nil || snap.Secondary != nil {
+		t.Errorf("unexpected typed windows: %+v %+v", snap.Primary, snap.Secondary)
+	}
+	if got := snap.RawHeaders["x-codex-experimental-flag"]; got != "true" {
+		t.Errorf("raw experimental-flag: got %q, want true", got)
+	}
+	if got := snap.RawHeaders["x-codex-credits-remaining"]; got != "1234" {
+		t.Errorf("raw credits-remaining: got %q, want 1234", got)
+	}
+}
+
+func TestParseCodexRateLimitHeaders_IgnoresMalformedNumbers(t *testing.T) {
+	h := http.Header{}
+	h.Set("x-codex-primary-used-percent", "not-a-number")
+	h.Set("x-codex-primary-window-minutes", "300")
+
+	snap := parseCodexRateLimitHeaders(h)
+	if snap == nil {
+		t.Fatal("expected snapshot, got nil")
+	}
+	if snap.Primary == nil {
+		t.Fatal("primary should still be present from window_minutes")
+	}
+	if snap.Primary.UsedPercent != 0 {
+		t.Errorf("malformed used_percent should default to 0, got %v", snap.Primary.UsedPercent)
+	}
+	if snap.Primary.WindowMinutes != 300 {
+		t.Errorf("primary window_minutes lost: got %v", snap.Primary.WindowMinutes)
+	}
+	// Malformed value preserved in RawHeaders for debugging.
+	if got := snap.RawHeaders["x-codex-primary-used-percent"]; got != "not-a-number" {
+		t.Errorf("raw header for malformed value should be preserved, got %q", got)
+	}
+}

--- a/internal/tarsserver/handler_llm_codex_usage.go
+++ b/internal/tarsserver/handler_llm_codex_usage.go
@@ -1,0 +1,68 @@
+package tarsserver
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/devlikebear/tars/internal/llm"
+	"github.com/devlikebear/tars/internal/serverauth"
+)
+
+type codexUsageTierResponse struct {
+	Tier     string                      `json:"tier"`
+	Provider string                      `json:"provider,omitempty"`
+	Model    string                      `json:"model,omitempty"`
+	Snapshot *llm.CodexRateLimitSnapshot `json:"snapshot,omitempty"`
+}
+
+type codexUsageResponse struct {
+	Tiers []codexUsageTierResponse `json:"tiers"`
+}
+
+// newCodexRateLimitAPIHandler exposes the most recently observed Codex
+// `x-codex-*` rate-limit headers (per tier) for admin consumers. Tiers whose
+// underlying client is not a Codex client, or which haven't seen a request
+// yet, are still listed but with a nil snapshot — that lets the console
+// distinguish "no data yet" from "wrong provider" downstream.
+func newCodexRateLimitAPIHandler(router llm.Router, authMode string) http.Handler {
+	normalizedAuthMode := serverauth.NormalizeMode(strings.TrimSpace(strings.ToLower(authMode)))
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/v1/admin/llm/codex/usage", func(w http.ResponseWriter, r *http.Request) {
+		if router == nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "llm router is not configured"})
+			return
+		}
+		if !requireMethod(w, r, http.MethodGet) {
+			return
+		}
+		if normalizedAuthMode != serverauth.ModeOff && strings.TrimSpace(serverauth.RoleFromContext(r.Context())) != serverauth.RoleAdmin {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+			return
+		}
+
+		out := codexUsageResponse{Tiers: make([]codexUsageTierResponse, 0, len(llm.AllTiers()))}
+		for _, tier := range llm.AllTiers() {
+			client, resolution, err := router.ClientForTier(tier)
+			if err != nil {
+				continue
+			}
+			entry := codexUsageTierResponse{
+				Tier:     string(tier),
+				Provider: resolution.Provider,
+				Model:    resolution.Model,
+			}
+			if src, ok := client.(llm.CodexRateLimitSource); ok {
+				if snap, present := src.LastCodexRateLimit(); present {
+					snapCopy := snap
+					entry.Snapshot = &snapCopy
+				}
+			}
+			out.Tiers = append(out.Tiers, entry)
+		}
+
+		writeJSON(w, http.StatusOK, out)
+	})
+
+	return mux
+}

--- a/internal/tarsserver/handler_llm_codex_usage_test.go
+++ b/internal/tarsserver/handler_llm_codex_usage_test.go
@@ -1,0 +1,141 @@
+package tarsserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/devlikebear/tars/internal/llm"
+)
+
+type stubCodexClient struct {
+	*llm.FakeClient
+	snap    llm.CodexRateLimitSnapshot
+	present bool
+}
+
+func (s *stubCodexClient) LastCodexRateLimit() (llm.CodexRateLimitSnapshot, bool) {
+	return s.snap, s.present
+}
+
+func mustNewRouter(t *testing.T, tiers map[llm.Tier]llm.TierEntry) llm.Router {
+	t.Helper()
+	router, err := llm.NewRouter(llm.RouterConfig{
+		Tiers:       tiers,
+		DefaultTier: llm.TierStandard,
+	})
+	if err != nil {
+		t.Fatalf("new router: %v", err)
+	}
+	return router
+}
+
+func TestCodexRateLimitAPIHandler_ReturnsSnapshotsPerTier(t *testing.T) {
+	heavyClient := &stubCodexClient{
+		FakeClient: &llm.FakeClient{Label: "heavy"},
+		snap: llm.CodexRateLimitSnapshot{
+			Primary:    &llm.CodexRateLimitWindow{UsedPercent: 25, WindowMinutes: 300},
+			RawHeaders: map[string]string{"x-codex-credits-remaining": "9001"},
+		},
+		present: true,
+	}
+	standardClient := &llm.FakeClient{Label: "standard"} // not a Codex source
+	lightClient := &stubCodexClient{
+		FakeClient: &llm.FakeClient{Label: "light"},
+		// present=false: tier listed but no snapshot yet
+	}
+
+	router := mustNewRouter(t, map[llm.Tier]llm.TierEntry{
+		llm.TierHeavy:    {Client: heavyClient, Provider: "openai-codex", Model: "gpt-5.3-codex"},
+		llm.TierStandard: {Client: standardClient, Provider: "anthropic", Model: "claude"},
+		llm.TierLight:    {Client: lightClient, Provider: "openai-codex", Model: "gpt-5.3-codex-mini"},
+	})
+
+	handler := newCodexRateLimitAPIHandler(router, "off")
+	req := httptest.NewRequest(http.MethodGet, "/v1/admin/llm/codex/usage", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	var got codexUsageResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, rec.Body.String())
+	}
+	if len(got.Tiers) != 3 {
+		t.Fatalf("expected 3 tiers, got %d", len(got.Tiers))
+	}
+
+	byTier := map[string]codexUsageTierResponse{}
+	for _, t := range got.Tiers {
+		byTier[t.Tier] = t
+	}
+	heavy := byTier["heavy"]
+	if heavy.Provider != "openai-codex" || heavy.Model != "gpt-5.3-codex" {
+		t.Errorf("heavy meta: %+v", heavy)
+	}
+	if heavy.Snapshot == nil || heavy.Snapshot.Primary == nil || heavy.Snapshot.Primary.UsedPercent != 25 {
+		t.Errorf("heavy snapshot: %+v", heavy.Snapshot)
+	}
+	if heavy.Snapshot.RawHeaders["x-codex-credits-remaining"] != "9001" {
+		t.Errorf("heavy raw headers: %+v", heavy.Snapshot.RawHeaders)
+	}
+
+	std := byTier["standard"]
+	if std.Snapshot != nil {
+		t.Errorf("standard tier should have nil snapshot (non-codex inner): %+v", std.Snapshot)
+	}
+
+	light := byTier["light"]
+	if light.Snapshot != nil {
+		t.Errorf("light tier should have nil snapshot (no request seen): %+v", light.Snapshot)
+	}
+	if light.Provider != "openai-codex" {
+		t.Errorf("light provider should still be exposed: %+v", light)
+	}
+}
+
+func TestCodexRateLimitAPIHandler_ForbidsNonAdminWhenAuthRequired(t *testing.T) {
+	router := mustNewRouter(t, map[llm.Tier]llm.TierEntry{
+		llm.TierHeavy:    {Client: &llm.FakeClient{}, Provider: "openai-codex", Model: "m"},
+		llm.TierStandard: {Client: &llm.FakeClient{}, Provider: "openai-codex", Model: "m"},
+		llm.TierLight:    {Client: &llm.FakeClient{}, Provider: "openai-codex", Model: "m"},
+	})
+	handler := newCodexRateLimitAPIHandler(router, "required")
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/admin/llm/codex/usage", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCodexRateLimitAPIHandler_RejectsNonGET(t *testing.T) {
+	router := mustNewRouter(t, map[llm.Tier]llm.TierEntry{
+		llm.TierHeavy:    {Client: &llm.FakeClient{}, Provider: "x", Model: "m"},
+		llm.TierStandard: {Client: &llm.FakeClient{}, Provider: "x", Model: "m"},
+		llm.TierLight:    {Client: &llm.FakeClient{}, Provider: "x", Model: "m"},
+	})
+	handler := newCodexRateLimitAPIHandler(router, "off")
+	req := httptest.NewRequest(http.MethodPost, "/v1/admin/llm/codex/usage", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", rec.Code)
+	}
+}
+
+func TestCodexRateLimitAPIHandler_NilRouter(t *testing.T) {
+	handler := newCodexRateLimitAPIHandler(nil, "off")
+	req := httptest.NewRequest(http.MethodGet, "/v1/admin/llm/codex/usage", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", rec.Code)
+	}
+}

--- a/internal/tarsserver/main_serve_api.go
+++ b/internal/tarsserver/main_serve_api.go
@@ -81,6 +81,7 @@ type apiRouteHandlers struct {
 	filesystem      http.Handler
 	workspaceFiles  http.Handler
 	terminal        http.Handler
+	codexUsage      http.Handler
 }
 
 func runServeAPICommand(
@@ -610,6 +611,7 @@ func buildAPIMux(
 	workspaceFilesHandler := newWorkspaceFilesHandler(cfg.WorkspaceDir, logger)
 	terminalHandler := newTerminalAPIHandler(cfg.WorkspaceDir, sessionStore, logger)
 	memoryHandler := newMemoryAPIHandler(cfg.WorkspaceDir, buildMemoryBackend(cfg.WorkspaceDir, semanticMemoryConfigFromConfig(cfg), cfg.MemoryBackend), logger)
+	codexUsageHandler := newCodexRateLimitAPIHandler(deps.llmRouter, cfg.APIAuthMode)
 	registerAPIRoutes(mux, apiRouteHandlers{
 		pulse:           pulseSetup.Handler,
 		reflection:      reflectionSetup.Handler,
@@ -644,6 +646,7 @@ func buildAPIMux(
 		filesystem:      filesystemHandler,
 		workspaceFiles:  workspaceFilesHandler,
 		terminal:        terminalHandler,
+		codexUsage:      codexUsageHandler,
 	})
 
 	server := &http.Server{
@@ -742,6 +745,7 @@ func registerAPIRoutes(mux *http.ServeMux, handlers apiRouteHandlers) {
 	mux.Handle("/v1/usage/limits", handlers.usage)
 	mux.Handle("/v1/admin/usage/today", handlers.usage)
 	mux.Handle("/v1/admin/analytics", handlers.usage)
+	mux.Handle("/v1/admin/llm/codex/usage", handlers.codexUsage)
 	mux.Handle("/v1/admin/logs", handlers.logs)
 	mux.Handle("/v1/ops/status", handlers.ops)
 	mux.Handle("/v1/ops/cleanup/plan", handlers.ops)

--- a/internal/tarsserver/main_serve_api_routes_test.go
+++ b/internal/tarsserver/main_serve_api_routes_test.go
@@ -52,6 +52,7 @@ func TestRegisterAPIRoutes_RegistersCoreRoutes(t *testing.T) {
 		"/v1/usage/limits",
 		"/v1/admin/usage/today",
 		"/v1/admin/analytics",
+		"/v1/admin/llm/codex/usage",
 		"/v1/admin/logs",
 		"/v1/ops/status",
 		"/v1/ops/cleanup/plan",
@@ -237,6 +238,7 @@ func testAPIRouteHandlers(handler, consoleHandler http.Handler) apiRouteHandlers
 		filesystem:      handler,
 		workspaceFiles:  handler,
 		terminal:        handler,
+		codexUsage:      handler,
 	}
 }
 

--- a/internal/usage/client.go
+++ b/internal/usage/client.go
@@ -89,6 +89,20 @@ func (c *TrackedClient) Chat(ctx context.Context, messages []llm.ChatMessage, op
 	return resp, nil
 }
 
+// LastCodexRateLimit forwards to the inner client when it implements
+// llm.CodexRateLimitSource. Lets admin handlers fish a Codex rate-limit
+// snapshot out of the router without unwrapping the TrackedClient manually.
+func (c *TrackedClient) LastCodexRateLimit() (llm.CodexRateLimitSnapshot, bool) {
+	if c == nil || c.inner == nil {
+		return llm.CodexRateLimitSnapshot{}, false
+	}
+	src, ok := c.inner.(llm.CodexRateLimitSource)
+	if !ok {
+		return llm.CodexRateLimitSnapshot{}, false
+	}
+	return src.LastCodexRateLimit()
+}
+
 func (c *TrackedClient) logSelection(ctx context.Context) {
 	if c == nil {
 		return

--- a/internal/usage/client_test.go
+++ b/internal/usage/client_test.go
@@ -11,6 +11,54 @@ import (
 	zlog "github.com/rs/zerolog/log"
 )
 
+type fakeCodexClient struct {
+	llm.FakeClient
+	snap CodexSnap
+}
+
+type CodexSnap struct {
+	llm.CodexRateLimitSnapshot
+	present bool
+}
+
+func (f *fakeCodexClient) LastCodexRateLimit() (llm.CodexRateLimitSnapshot, bool) {
+	return f.snap.CodexRateLimitSnapshot, f.snap.present
+}
+
+func TestTrackedClient_LastCodexRateLimit_Passthrough(t *testing.T) {
+	primary := &llm.CodexRateLimitWindow{UsedPercent: 50, WindowMinutes: 300}
+	inner := &fakeCodexClient{
+		FakeClient: llm.FakeClient{Label: "standard"},
+		snap: CodexSnap{
+			CodexRateLimitSnapshot: llm.CodexRateLimitSnapshot{Primary: primary},
+			present:                true,
+		},
+	}
+	tracked := NewTrackedClient(inner, nil, "openai-codex", "gpt-5.3-codex", llm.TierStandard)
+
+	got, ok := tracked.LastCodexRateLimit()
+	if !ok {
+		t.Fatal("expected snapshot to be present")
+	}
+	if got.Primary == nil || got.Primary.UsedPercent != 50 {
+		t.Errorf("primary mismatch: %+v", got.Primary)
+	}
+}
+
+func TestTrackedClient_LastCodexRateLimit_NonCodexInner(t *testing.T) {
+	tracked := NewTrackedClient(&llm.FakeClient{Label: "x"}, nil, "anthropic", "claude", llm.TierHeavy)
+	if _, ok := tracked.LastCodexRateLimit(); ok {
+		t.Error("expected ok=false when inner does not implement CodexRateLimitSource")
+	}
+}
+
+func TestTrackedClient_LastCodexRateLimit_NilSafe(t *testing.T) {
+	var tracked *TrackedClient
+	if _, ok := tracked.LastCodexRateLimit(); ok {
+		t.Error("expected ok=false on nil receiver")
+	}
+}
+
 func TestTrackedClient_LogsSelectionMetadata(t *testing.T) {
 	var buf bytes.Buffer
 	prev := zlog.Logger


### PR DESCRIPTION
## Summary

- OpenAI는 ChatGPT 구독으로 사용하는 Codex 잔여량을 조회하는 전용 REST API를 제공하지 않지만, `/codex/responses` 응답에 `x-codex-*` 헤더(primary 5h-window / secondary weekly의 `used_percent`, `window_minutes`, `reset_after_seconds`)로 잔여량을 흘려준다.
- `OpenAICodexClient`가 매 요청 응답에서 헤더를 파싱해 마지막 스냅샷을 캐싱한다 (mutex 보호, 기존 credential cache 패턴 재사용).
- 신규 admin 엔드포인트 `GET /v1/admin/llm/codex/usage`가 라우터의 3 tier(heavy/standard/light)를 순회하며 Codex provider 클라이언트에서 스냅샷을 모아 JSON으로 반환한다. 인증 모드는 `/v1/admin/usage/today`와 동일.
- 알려지지 않은 `x-codex-*` 헤더도 `raw_headers`에 그대로 보존 → OpenAI가 새 헤더를 추가해도 데이터 손실 없음.

이번 PR은 백엔드만. 콘솔 UI 인디케이터는 후속 PR에서.

## Test plan

- [x] `make test` (전체 통과)
- [x] `make vet`
- [x] 신규 단위 테스트
  - [x] `parseCodexRateLimitHeaders` — 정상/부분/빈/unknown header/malformed number 5케이스
  - [x] `OpenAICodexClient` — 응답 헤더 캡처 + `LastCodexRateLimit()` 반환 + interface 충족
  - [x] `TrackedClient.LastCodexRateLimit` — 패스스루/non-codex inner/nil receiver 3케이스
  - [x] admin 핸들러 — 정상 응답/non-admin 거부/non-GET 거부/nil router 4케이스
  - [x] `TestRegisterAPIRoutes_RegistersCoreRoutes`에 신규 경로 등록 확인