### PR TITLE
chore(tests): loosen headerBudgetIndicator regex

### DIFF
--- a/frontend/console/tests/headerBudgetIndicator.test.ts
+++ b/frontend/console/tests/headerBudgetIndicator.test.ts
@@ -19,7 +19,7 @@ test('Header renders a daily token budget chip backed by the usage today API', (
   assert.match(headerSource, /budget-chip/)
   assert.match(headerSource, /usageToday\.level === 'error'/)
   assert.match(headerSource, /\/console\/analytics\?focus=today/)
-  assert.match(shellSource, /<Header \{serverHealth\} \{unreadCount\} \{onUnreadChange\} \{onNavigate\} \/>/)
+  assert.match(shellSource, /<Header\b[^>]*\{serverHealth\}[^>]*\{unreadCount\}[^>]*\{onUnreadChange\}[^>]*\{onNavigate\}[^>]*\/>/)
 })
 
 test('Header budget labels are localized', () => {


### PR DESCRIPTION
Fix a pre-existing test-only failure (not in \`test:ci\` slice, so it didn't surface in CI).

\`Shell.svelte\` now passes \`navOpen\`, \`authRole\`, \`onLogout\`, \`onToggleNav\` to \`<Header />\` on top of the original four budget-related props. The existing regex required an exact match with only the original four, which made the test fail outside the CI slice.

Loosen the regex to only require the budget-relevant props (\`serverHealth\`, \`unreadCount\`, \`onUnreadChange\`, \`onNavigate\`) are forwarded; allow any additional sibling props.

## Test plan
- [x] \`node --test tests/headerBudgetIndicator.test.ts\` — passes