### PR TITLE
feat(llm): cut claude-code-cli startup cost and bound runtime

### DIFF
--- a/internal/llm/claude_code_cli.go
+++ b/internal/llm/claude_code_cli.go
@@ -10,14 +10,35 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
+	"time"
 )
 
 const (
 	claudeCodeCLIProviderLabel = "claude-code-cli"
 	defaultClaudeCodeCLIModel  = "sonnet"
 	claudeCodeCLIPathEnv       = "CLAUDE_CODE_CLI_PATH"
+	claudeCodeCLITimeoutEnv    = "CLAUDE_CODE_CLI_TIMEOUT"
+	// defaultClaudeCodeCLITimeout bounds a single claude invocation. Real
+	// agentic turns can legitimately run for tens of seconds to minutes, so
+	// the default is generous; operators tune it via CLAUDE_CODE_CLI_TIMEOUT.
+	defaultClaudeCodeCLITimeout = 5 * time.Minute
 )
+
+// claudeCodeCLIPerfEnv holds low-risk environment toggles that cut Claude
+// Code's per-invocation startup cost (autoupdater check, telemetry, error
+// reporting, and other nonessential network traffic). Measured savings are
+// roughly ~1s per call. These are applied as defaults only: a value already
+// present in the inherited environment is left untouched so operators keep the
+// final say. Order is fixed for deterministic process environments.
+var claudeCodeCLIPerfEnv = []struct{ key, value string }{
+	{"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1"},
+	{"DISABLE_AUTOUPDATER", "1"},
+	{"DISABLE_TELEMETRY", "1"},
+	{"DISABLE_ERROR_REPORTING", "1"},
+}
 
 type ClaudeCodeCLIClient struct {
 	cliPath string
@@ -120,31 +141,119 @@ func (c *ClaudeCodeCLIClient) Chat(ctx context.Context, messages []ChatMessage, 
 	}
 	args = append(args, prompt)
 
-	cmd := exec.CommandContext(ctx, c.cliPath, args...)
-	cmd.Dir = c.workDir
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return ChatResponse{}, newProviderError(claudeCodeCLIProviderLabel, "request", fmt.Errorf("stdout pipe: %w", err))
-	}
-	if err := cmd.Start(); err != nil {
-		return ChatResponse{}, newProviderError(claudeCodeCLIProviderLabel, "request", fmt.Errorf("start cli: %w", err))
+	// Bound the invocation so a hung or slow claude process fails predictably
+	// instead of blocking until some upstream client gives up.
+	timeout := parseClaudeCodeCLITimeout(os.Getenv(claudeCodeCLITimeoutEnv))
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	env := claudeCodeCLIEnv(os.Environ())
+
+	attempt := func() (ChatResponse, error) {
+		cmd := exec.CommandContext(ctx, c.cliPath, args...)
+		cmd.Dir = c.workDir
+		cmd.Env = env
+		// Run claude in its own process group and, on context cancellation,
+		// kill the whole group. claude spawns descendants (e.g. stdio MCP
+		// servers) that inherit the stdout pipe; killing only the direct
+		// child leaves them holding the pipe open, so the stream read would
+		// block past the deadline. WaitDelay bounds any residual pipe wait.
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		cmd.Cancel = func() error {
+			if cmd.Process == nil {
+				return nil
+			}
+			return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		}
+		cmd.WaitDelay = 5 * time.Second
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			return ChatResponse{}, newProviderError(claudeCodeCLIProviderLabel, "request", fmt.Errorf("stdout pipe: %w", err))
+		}
+		if err := cmd.Start(); err != nil {
+			return ChatResponse{}, newProviderError(claudeCodeCLIProviderLabel, "request", fmt.Errorf("start cli: %w", err))
+		}
+
+		resp, parseErr := parseClaudeCodeCLIStream(stdout, opts)
+		waitErr := cmd.Wait()
+		// A deadline kill surfaces as a process/stream error; report it as a
+		// timeout so callers (and the retry policy) can tell it apart from a
+		// transient crash.
+		if ctx.Err() == context.DeadlineExceeded {
+			return ChatResponse{}, newProviderError(claudeCodeCLIProviderLabel, "request", fmt.Errorf("cli timed out after %s", timeout))
+		}
+		if parseErr != nil {
+			return ChatResponse{}, parseErr
+		}
+		if waitErr != nil {
+			errText := strings.TrimSpace(stderr.String())
+			if errText != "" {
+				return ChatResponse{}, newProviderError(claudeCodeCLIProviderLabel, "request", fmt.Errorf("cli failed: %w: %s", waitErr, errText))
+			}
+			return ChatResponse{}, newProviderError(claudeCodeCLIProviderLabel, "request", fmt.Errorf("cli failed: %w", waitErr))
+		}
+		return resp, nil
 	}
 
-	resp, parseErr := parseClaudeCodeCLIStream(stdout, opts)
-	waitErr := cmd.Wait()
-	if parseErr != nil {
-		return ChatResponse{}, parseErr
+	return runClaudeCodeCLIWithRetry(ctx, attempt)
+}
+
+// runClaudeCodeCLIWithRetry runs attempt once and retries a single time on a
+// transient failure. A failure is NOT transient — and so is not retried —
+// when the context is done (a timeout or caller cancellation), to avoid
+// doubling an already-long wait.
+//
+// Caveat: in streaming mode a retried attempt re-emits deltas. Retries only
+// fire on a transient failure with the context still live, which is rare, so
+// this is accepted in exchange for recovering from one-off process crashes.
+func runClaudeCodeCLIWithRetry(ctx context.Context, attempt func() (ChatResponse, error)) (ChatResponse, error) {
+	resp, err := attempt()
+	if err == nil || ctx.Err() != nil {
+		return resp, err
 	}
-	if waitErr != nil {
-		errText := strings.TrimSpace(stderr.String())
-		if errText != "" {
-			return ChatResponse{}, newProviderError(claudeCodeCLIProviderLabel, "request", fmt.Errorf("cli failed: %w: %s", waitErr, errText))
+	return attempt()
+}
+
+// claudeCodeCLIEnv returns base augmented with the claudeCodeCLIPerfEnv
+// defaults for any key not already present in base. base is typically
+// os.Environ(); existing values win so callers can override the toggles.
+func claudeCodeCLIEnv(base []string) []string {
+	present := make(map[string]struct{}, len(base))
+	for _, kv := range base {
+		if i := strings.IndexByte(kv, '='); i > 0 {
+			present[kv[:i]] = struct{}{}
 		}
-		return ChatResponse{}, newProviderError(claudeCodeCLIProviderLabel, "request", fmt.Errorf("cli failed: %w", waitErr))
 	}
-	return resp, nil
+	out := append([]string(nil), base...)
+	for _, def := range claudeCodeCLIPerfEnv {
+		if _, ok := present[def.key]; ok {
+			continue
+		}
+		out = append(out, def.key+"="+def.value)
+	}
+	return out
+}
+
+// parseClaudeCodeCLITimeout interprets a CLAUDE_CODE_CLI_TIMEOUT value. It
+// accepts a Go duration string ("300s", "5m") or a bare integer treated as
+// seconds. Empty, zero, negative, or unparseable input yields the default.
+func parseClaudeCodeCLITimeout(raw string) time.Duration {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return defaultClaudeCodeCLITimeout
+	}
+	if d, err := time.ParseDuration(raw); err == nil {
+		if d > 0 {
+			return d
+		}
+		return defaultClaudeCodeCLITimeout
+	}
+	if secs, err := strconv.Atoi(raw); err == nil && secs > 0 {
+		return time.Duration(secs) * time.Second
+	}
+	return defaultClaudeCodeCLITimeout
 }
 
 func parseClaudeCodeCLIStream(stdout io.Reader, opts ChatOptions) (ChatResponse, error) {

--- a/internal/llm/claude_code_cli_perf_test.go
+++ b/internal/llm/claude_code_cli_perf_test.go
@@ -1,0 +1,249 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseClaudeCodeCLITimeout(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+	}{
+		{"", defaultClaudeCodeCLITimeout},
+		{"   ", defaultClaudeCodeCLITimeout},
+		{"300s", 300 * time.Second},
+		{"5m", 5 * time.Minute},
+		{"120", 120 * time.Second},
+		{"0", defaultClaudeCodeCLITimeout},
+		{"-3", defaultClaudeCodeCLITimeout},
+		{"garbage", defaultClaudeCodeCLITimeout},
+	}
+	for _, tc := range cases {
+		if got := parseClaudeCodeCLITimeout(tc.in); got != tc.want {
+			t.Errorf("parseClaudeCodeCLITimeout(%q)=%s want %s", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestClaudeCodeCLIEnv_AddsStartupDefaults(t *testing.T) {
+	base := []string{"PATH=/usr/bin", "HOME=/home/x"}
+	got := claudeCodeCLIEnv(base)
+	for _, want := range []string{
+		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1",
+		"DISABLE_AUTOUPDATER=1",
+		"DISABLE_TELEMETRY=1",
+		"DISABLE_ERROR_REPORTING=1",
+	} {
+		if !slices.Contains(got, want) {
+			t.Errorf("expected env to contain %q, got %v", want, got)
+		}
+	}
+	// base entries are preserved
+	if !slices.Contains(got, "PATH=/usr/bin") || !slices.Contains(got, "HOME=/home/x") {
+		t.Errorf("base env not preserved: %v", got)
+	}
+}
+
+func TestClaudeCodeCLIEnv_PreservesUserOverride(t *testing.T) {
+	base := []string{"DISABLE_TELEMETRY=0", "PATH=/usr/bin"}
+	got := claudeCodeCLIEnv(base)
+	if slices.Contains(got, "DISABLE_TELEMETRY=1") {
+		t.Errorf("user DISABLE_TELEMETRY=0 should not be overridden; got %v", got)
+	}
+	if !slices.Contains(got, "DISABLE_TELEMETRY=0") {
+		t.Errorf("user value lost; got %v", got)
+	}
+}
+
+func TestClaudeCodeCLIChat_InjectsStartupEnvToProcess(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, "env.txt")
+	scriptPath := filepath.Join(dir, "claude")
+	script := "#!/bin/sh\nenv > " + shellQuote(envPath) + "\n" +
+		`printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"num_turns":1,"session_id":"s","stop_reason":"end_turn","usage":{},"result":"ok"}'` + "\n"
+	ccWriteStub(t, scriptPath, script)
+	t.Setenv("CLAUDE_CODE_CLI_PATH", scriptPath)
+
+	client := ccNewClient(t, dir)
+	if _, err := client.Chat(context.Background(), ccUserMsg(), ChatOptions{}); err != nil {
+		t.Fatalf("chat: %v", err)
+	}
+
+	data, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatalf("read env dump: %v", err)
+	}
+	env := string(data)
+	for _, want := range []string{
+		"DISABLE_AUTOUPDATER=1",
+		"DISABLE_TELEMETRY=1",
+		"DISABLE_ERROR_REPORTING=1",
+		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1",
+	} {
+		if !strings.Contains(env, want) {
+			t.Errorf("expected process env to contain %q", want)
+		}
+	}
+}
+
+func TestClaudeCodeCLIChat_TimesOut(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "claude")
+	// Fork a long-lived grandchild (sleep) that inherits the stdout pipe and
+	// hangs far past the deadline. If the timeout only killed the direct
+	// child, the surviving grandchild would hold the pipe open and the call
+	// would block ~30s; bounding elapsed well under that proves the process
+	// group is killed. (No marker/count assertion here: that would race the
+	// shell stub's own startup against the deadline and flake under load.)
+	script := "#!/bin/sh\nsleep 30\n"
+	ccWriteStub(t, scriptPath, script)
+	t.Setenv("CLAUDE_CODE_CLI_PATH", scriptPath)
+	t.Setenv("CLAUDE_CODE_CLI_TIMEOUT", "1s")
+
+	client := ccNewClient(t, dir)
+	start := time.Now()
+	_, err := client.Chat(context.Background(), ccUserMsg(), ChatOptions{})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected timeout error, got %v", err)
+	}
+	if elapsed > 15*time.Second {
+		t.Fatalf("timeout/process-group kill not enforced: took %s", elapsed)
+	}
+}
+
+func TestRunClaudeCodeCLIWithRetry_NoRetryWhenContextDone(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // a done context models a timeout or cancellation
+	calls := 0
+	_, err := runClaudeCodeCLIWithRetry(ctx, func() (ChatResponse, error) {
+		calls++
+		return ChatResponse{}, errors.New("boom")
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 attempt when context is done (no retry), got %d", calls)
+	}
+}
+
+func TestRunClaudeCodeCLIWithRetry_RetriesOnceWhenLive(t *testing.T) {
+	calls := 0
+	_, err := runClaudeCodeCLIWithRetry(context.Background(), func() (ChatResponse, error) {
+		calls++
+		return ChatResponse{}, errors.New("boom")
+	})
+	if err == nil {
+		t.Fatal("expected error after retry, got nil")
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 attempts (initial + 1 retry), got %d", calls)
+	}
+}
+
+func TestRunClaudeCodeCLIWithRetry_NoRetryOnSuccess(t *testing.T) {
+	calls := 0
+	resp, err := runClaudeCodeCLIWithRetry(context.Background(), func() (ChatResponse, error) {
+		calls++
+		return ChatResponse{SessionID: "ok"}, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 attempt on success, got %d", calls)
+	}
+	if resp.SessionID != "ok" {
+		t.Fatalf("expected response to pass through, got %+v", resp)
+	}
+}
+
+func TestClaudeCodeCLIChat_RetriesTransientFailureOnce(t *testing.T) {
+	dir := t.TempDir()
+	countPath := filepath.Join(dir, "count")
+	scriptPath := filepath.Join(dir, "claude")
+	// Fail on the first invocation, succeed on the second.
+	script := "#!/bin/sh\n" +
+		"printf x >> " + shellQuote(countPath) + "\n" +
+		"n=$(wc -c < " + shellQuote(countPath) + " | tr -d ' ')\n" +
+		`if [ "$n" -lt 2 ]; then echo "boom" >&2; exit 1; fi` + "\n" +
+		`printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"num_turns":1,"session_id":"s2","stop_reason":"end_turn","usage":{},"result":"recovered"}'` + "\n"
+	ccWriteStub(t, scriptPath, script)
+	t.Setenv("CLAUDE_CODE_CLI_PATH", scriptPath)
+
+	client := ccNewClient(t, dir)
+	resp, err := client.Chat(context.Background(), ccUserMsg(), ChatOptions{})
+	if err != nil {
+		t.Fatalf("expected success after one retry, got %v", err)
+	}
+	if resp.SessionID != "s2" {
+		t.Fatalf("expected recovered response (session s2), got %q", resp.SessionID)
+	}
+	if got := ccRunCount(countPath); got != 2 {
+		t.Fatalf("expected 2 invocations (1 retry), got %d", got)
+	}
+}
+
+func TestClaudeCodeCLIChat_TransientFailureStopsAfterOneRetry(t *testing.T) {
+	dir := t.TempDir()
+	countPath := filepath.Join(dir, "count")
+	scriptPath := filepath.Join(dir, "claude")
+	// Always fail: should attempt exactly twice (initial + one retry).
+	script := "#!/bin/sh\nprintf x >> " + shellQuote(countPath) + "\necho boom >&2\nexit 1\n"
+	ccWriteStub(t, scriptPath, script)
+	t.Setenv("CLAUDE_CODE_CLI_PATH", scriptPath)
+
+	client := ccNewClient(t, dir)
+	if _, err := client.Chat(context.Background(), ccUserMsg(), ChatOptions{}); err == nil {
+		t.Fatal("expected error after exhausting retry, got nil")
+	}
+	if got := ccRunCount(countPath); got != 2 {
+		t.Fatalf("expected 2 invocations (initial + 1 retry), got %d", got)
+	}
+}
+
+// --- test helpers ---
+
+func ccWriteStub(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("write cli stub: %v", err)
+	}
+}
+
+func ccNewClient(t *testing.T, dir string) Client {
+	t.Helper()
+	client, err := NewProvider(ProviderOptions{
+		Provider: "claude-code-cli",
+		Model:    "sonnet",
+		WorkDir:  dir,
+	})
+	if err != nil {
+		t.Fatalf("new provider: %v", err)
+	}
+	return client
+}
+
+func ccUserMsg() []ChatMessage {
+	return []ChatMessage{{Role: "user", Content: "hi"}}
+}
+
+func ccRunCount(path string) int {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+	return strings.Count(string(data), "x")
+}


### PR DESCRIPTION
## Summary
claude-code-cli was slow and prone to timeouts. Profiling (measured on claude 2.1.168) found two fixable causes; this PR addresses both. No new provider / no OAuth token extraction — just makes the existing provider faster and bounded.

### What & why
- **Startup env injection** — every turn paid ~1.4s of Claude Code startup (autoupdater check, telemetry, error reporting, nonessential traffic). Injecting `DISABLE_AUTOUPDATER` / `DISABLE_TELEMETRY` / `DISABLE_ERROR_REPORTING` / `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` as **defaults** drops it to ~0.38s (**measured ~1s/turn saving**). Values already set in the environment are preserved.
- **Bounded runtime** — the subprocess had **no deadline** (the 30s `HTTPTimeout` only applies to HTTP providers), so a hung/slow claude blocked until an upstream client gave up. Added `CLAUDE_CODE_CLI_TIMEOUT` (default **5m**, accepts `300s`/`5m`/bare-seconds).
- **Process-group kill** — `exec.CommandContext` only kills the direct child; claude spawns descendant stdio **MCP servers** that inherit the stdout pipe, so killing only the child left them holding the pipe open and the read blocked past the deadline. Now claude runs in its own process group and the whole group is killed on cancel (+ `WaitDelay` backstop). Without this the timeout test hangs ~30s; with it, it returns at the deadline.
- **Single retry** on a transient failure, but **never** on a timeout/cancel (avoids doubling an already-long wait).

### Notes
- Behavior is configurable via env only; no config-schema change.
- Streaming caveat documented in code: a retried attempt re-emits deltas (only fires on rare transient non-timeout failures).

## Test plan
- [x] `make test` (full module, exit 0)
- [x] `make vet` (exit 0)
- [x] `gofmt` clean; `make lint-diff` → 0 new issues
- [x] New unit + integration tests: timeout enforced + process-group kill, retry-once-on-transient, no-retry-on-timeout/cancel, env injection + user-override preservation, timeout parsing
- [x] Real `claude` smoke test through the new path (env + pgroup + WaitDelay) → `SMOKE_OK`, normal completion unaffected