### PR TITLE
ci: guard public packages against Windows build breakage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,20 @@ jobs:
       - name: Run security scan
         run: make security-scan
 
+  windows-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Cross-compile public packages for Windows
+        run: make windows-build-check
+
   test:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ RELEASE_STAGE_DIR ?= $(DIST_DIR)/release-$(RELEASE_GOOS)-$(RELEASE_GOARCH)
 
 .PHONY: help \
 	test test-v test-one test-nocache test-race test-cover test-cover-check test-diff test-cover-diff \
-	build build-bins release-asset clean tidy fmt vet lint \
+	build build-bins windows-build-check release-asset clean tidy fmt vet lint \
 	lint-diff ci-static-analysis-check github-actions-hardening-check codeql-workflow-check sonarcloud-workflow-check \
 	ensure-console-assets console-install console-build \
 	browser-install \
@@ -176,6 +176,15 @@ build: ensure-console-assets
 build-bins: ensure-console-assets
 	mkdir -p $(BIN_DIR)
 	CGO_LDFLAGS="$(CGO_LDFLAGS_EXTRA)" $(GO) build -ldflags "$(GO_LDFLAGS)" -o $(BIN_DIR)/tars ./cmd/tars
+
+# windows-build-check cross-compiles the public packages that downstream
+# consumers import (e.g. linetta's desktop engine imports pkg/llm and
+# pkg/session and ships a Windows build). The full module is unix-only
+# (syscall use in internal/onboarding, internal/ops), so only ./pkg/... is
+# checked. This guards against unix-only code leaking into the public API,
+# which tars' own (Linux-only) test job would otherwise miss.
+windows-build-check:
+	GOOS=windows GOARCH=amd64 $(GO) build ./pkg/...
 
 # ensure-console-assets bootstraps the embedded Svelte console only
 # when the dist/ directory is empty (e.g. fresh clone, dev build).


### PR DESCRIPTION
## Summary
Adds a CI guard so the v0.34.0 → v0.34.1 Windows regression cannot recur. That bug (unix-only `syscall.Kill`/`Setpgid` in `internal/llm`, reachable via `pkg/llm`) passed tars CI — which only builds on Linux — and broke the downstream linetta desktop Windows build.

- New `windows-build` job in `ci.yml`: `GOOS=windows GOARCH=amd64 go build ./pkg/...`. Runs on **both push and PR** (the existing `test` job is push-only, so PRs like #888 had no Go build gate that would catch this).
- New `windows-build-check` make target for local use.
- Scope is `./pkg/...` only: the full module is intentionally unix-only (`internal/onboarding` uses `Setsid`, `internal/ops` uses `Statfs`), but the public API consumed downstream must cross-compile.

## Test plan
- [x] `make windows-build-check` passes locally (exit 0)
- [x] `make github-actions-hardening-check` passes with the edited workflow
- [x] Verified the same command fails on v0.34.0 and passes on current main (the regression it guards)
