### PR TITLE
fix: include max_tokens for OpenAI-compatible chat

### DIFF
--- a/internal/llm/openai_compat_client.go
+++ b/internal/llm/openai_compat_client.go
@@ -94,6 +94,9 @@ func (c *OpenAICompatibleClient) buildChatRequest(messages []ChatMessage, opts C
 		"model":    c.model,
 		"messages": toOpenAIWireMessages(messages, c.label == "kimi"),
 	}
+	if c.config.MaxTokens > 0 {
+		reqBody["max_tokens"] = c.config.MaxTokens
+	}
 	if c.label != "gemini" && !(c.label == "kimi" && len(opts.Tools) > 0) {
 		if effort := effectiveReasoningEffort(c.config, opts); effort != "" && effort != "none" {
 			reqBody["reasoning_effort"] = effort

--- a/internal/llm/openai_compat_client_test.go
+++ b/internal/llm/openai_compat_client_test.go
@@ -117,6 +117,38 @@ func TestOpenAICompatibleChat_IncludesToolsAndParsesToolCalls(t *testing.T) {
 	}
 }
 
+func TestOpenAICompatibleChat_IncludesConfiguredMaxTokens(t *testing.T) {
+	var captured struct {
+		Model     string `json:"model"`
+		MaxTokens int    `json:"max_tokens"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+	}))
+	defer srv.Close()
+
+	client, err := newOpenAICompatibleClientWithConfig("openai", srv.URL+"/v1", "k", "gpt-test", ClientConfig{MaxTokens: 2048})
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	if _, err := client.Chat(context.Background(), []ChatMessage{{Role: "user", Content: "hello"}}, ChatOptions{}); err != nil {
+		t.Fatalf("chat: %v", err)
+	}
+	if captured.Model != "gpt-test" {
+		t.Fatalf("model=%q, want gpt-test", captured.Model)
+	}
+	if captured.MaxTokens != 2048 {
+		t.Fatalf("max_tokens=%d, want 2048", captured.MaxTokens)
+	}
+}
+
 func TestOpenAICompatibleChat_KimiSkipsReasoningAndServiceTierWithTools(t *testing.T) {
 	type captured struct {
 		ReasoningEffort string          `json:"reasoning_effort"`


### PR DESCRIPTION
## Summary

- Fixes OpenAI-compatible chat clients ignoring `ProviderOptions.MaxTokens`.
- This belongs in TARS because downstream apps such as Linetta should configure provider behavior through TARS instead of shipping provider-specific chat clients.

## Changes

- Main user-visible or developer-visible changes:
  - OpenAI-compatible chat requests now include `max_tokens` when `ClientConfig.MaxTokens` is configured.
  - Added regression coverage for the serialized `/chat/completions` payload.
- API, config, or compatibility changes:
  - No API shape changes; existing `ProviderOptions.MaxTokens` now applies to OpenAI-compatible providers.

## Validation

- [x] `make lint-diff`
- [x] `make test-cover-diff`
- [x] `make test`
- [x] `make security-scan`
- [x] Additional manual verification, if needed

## Checklist

- [x] Commit messages follow `feat/fix/chore`
- [x] Tests added or updated for behavior changes
- [x] Docs and `CHANGELOG.md` updated when needed
- [x] If this is a release PR, `VERSION.txt` and `CHANGELOG.md` changed together
- [x] Breaking changes include migration notes
- [x] No secrets, private keys, or local absolute paths included

## Risks / Rollback

- Risk level: Low. This only emits an optional request field when callers explicitly configured `MaxTokens`.
- Rollback plan: Revert this commit to omit `max_tokens` again for OpenAI-compatible chat requests.