### PR TITLE
feat(windows): build and run tars natively on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,28 @@
+# Keep the working tree on LF everywhere, including Windows checkouts.
+# The Makefile drives bash scripts under scripts/, and git's default
+# core.autocrlf=true on Windows would check them out with CRLF, which bash
+# rejects ("bad interpreter: ...^M").
+* text=auto eol=lf
+
+# Scripts must stay LF even on Windows: bash rejects CRLF shebangs and bodies.
+*.sh text eol=lf
+
+# Windows-native scripts are the one exception.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+# Never touch binary assets.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.icns binary
+*.pdf binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.otf binary
+*.db binary
+*.sqlite binary

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
 GO ?= go
+# GOEXE is ".exe" on Windows and empty elsewhere. Without it a native Windows
+# build produces an extension-less file that the shell refuses to execute.
+# Run make from Git Bash (or any sh-providing shell) on Windows — the recipes
+# below are POSIX sh, not cmd.exe.
+GOEXE ?= $(shell $(GO) env GOEXE)
 BIN_DIR ?= bin
 DIST_DIR ?= dist
 VERSION_FILE ?= VERSION.txt
@@ -20,7 +25,7 @@ GOLANGCI_LINT_VERSION ?= v2.12.2
 GOLANGCI_LINT ?= $(GO) run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 TARS_CONFIG ?= ./workspace/config/tars.config.yaml
 ROOT_DIR := $(abspath .)
-TARS_BIN := $(abspath $(BIN_DIR)/tars)
+TARS_BIN := $(abspath $(BIN_DIR)/tars$(GOEXE))
 LAUNCH_AGENTS_DIR ?= $(HOME)/Library/LaunchAgents
 LAUNCHCTL_DOMAIN ?= gui/$(shell id -u)
 SERVER_LABEL ?= io.tars.server
@@ -194,20 +199,20 @@ agent-harness-baseline:
 
 build: ensure-console-assets
 	mkdir -p $(BIN_DIR)
-	CGO_LDFLAGS="$(CGO_LDFLAGS_EXTRA)" $(GO) build -ldflags "$(GO_LDFLAGS)" -o $(BIN_DIR)/tars ./cmd/tars
+	CGO_LDFLAGS="$(CGO_LDFLAGS_EXTRA)" $(GO) build -ldflags "$(GO_LDFLAGS)" -o $(BIN_DIR)/tars$(GOEXE) ./cmd/tars
 
 build-bins: ensure-console-assets
 	mkdir -p $(BIN_DIR)
-	CGO_LDFLAGS="$(CGO_LDFLAGS_EXTRA)" $(GO) build -ldflags "$(GO_LDFLAGS)" -o $(BIN_DIR)/tars ./cmd/tars
+	CGO_LDFLAGS="$(CGO_LDFLAGS_EXTRA)" $(GO) build -ldflags "$(GO_LDFLAGS)" -o $(BIN_DIR)/tars$(GOEXE) ./cmd/tars
 
-# windows-build-check cross-compiles the public packages that downstream
-# consumers import (e.g. linetta's desktop engine imports pkg/llm and
-# pkg/session and ships a Windows build). The full module is unix-only
-# (syscall use in internal/onboarding, internal/ops), so only ./pkg/... is
-# checked. This guards against unix-only code leaking into the public API,
-# which tars' own (Linux-only) test job would otherwise miss.
+# windows-build-check cross-compiles the whole module for Windows. tars' own
+# test job runs on Linux only, so this is what keeps unix-only syscalls from
+# creeping back in — both in the public packages downstream consumers import
+# (linetta's desktop engine imports pkg/llm and pkg/session and ships a Windows
+# build) and in cmd/tars itself, which is buildable on Windows as of the
+# platform splits in internal/onboarding, internal/ops, and internal/tarsserver.
 windows-build-check:
-	GOOS=windows GOARCH=amd64 $(GO) build ./pkg/...
+	GOOS=windows GOARCH=amd64 $(GO) build ./...
 
 # ensure-console-assets bootstraps the embedded Svelte console only
 # when the dist/ directory is empty (e.g. fresh clone, dev build).

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	golang.design/x/hotkey v0.4.1
 	golang.org/x/crypto v0.52.0
+	golang.org/x/sys v0.45.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.39.1
@@ -28,7 +29,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.design/x/mainthread v0.3.0 // indirect
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
-	golang.org/x/sys v0.45.0 // indirect
 	modernc.org/libc v1.66.10 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/internal/agentruntime/git_unavailable_test.go
+++ b/internal/agentruntime/git_unavailable_test.go
@@ -1,0 +1,44 @@
+package agentruntime
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	gitrepo "github.com/devlikebear/tars/internal/git"
+)
+
+// stubGitUnavailable makes git resolution fail for the duration of the test.
+// gitrepo.Executable is a func var so this seam exists; these tests must not
+// run in parallel with anything that shells out to git.
+func stubGitUnavailable(t *testing.T) {
+	t.Helper()
+	previous := gitrepo.Executable
+	gitrepo.Executable = func() (string, error) {
+		return "", fmt.Errorf("%w: nothing installed", gitrepo.ErrGitUnavailable)
+	}
+	t.Cleanup(func() { gitrepo.Executable = previous })
+}
+
+// The diff timeline is a best-effort enrichment, so both helpers degrade to
+// "no diff" rather than failing the run when git cannot be found.
+func TestGitOutputDegradesWhenGitIsUnavailable(t *testing.T) {
+	stubGitUnavailable(t)
+
+	if out, ok := gitOutput(t.TempDir(), "status", "--porcelain"); ok {
+		t.Fatalf("expected no output without git, got %q", out)
+	}
+}
+
+func TestGitNoIndexPatchDegradesWhenGitIsUnavailable(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "untracked.txt"), []byte("hello\n"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	stubGitUnavailable(t)
+
+	if out, ok := gitNoIndexPatch(dir, "untracked.txt"); ok {
+		t.Fatalf("expected no patch without git, got %q", out)
+	}
+}

--- a/internal/agentruntime/runtime_diff_timeline.go
+++ b/internal/agentruntime/runtime_diff_timeline.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	gitrepo "github.com/devlikebear/tars/internal/git"
 )
 
 const maxDiffTimelinePatchBytes = 12000
@@ -265,9 +267,13 @@ func gitNoIndexPatch(repoRoot string, path string) (string, bool) {
 	if info, err := os.Stat(absPath); err != nil || info.IsDir() {
 		return "", false
 	}
+	gitPath, err := gitrepo.Executable()
+	if err != nil {
+		return "", false
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "/usr/bin/git", "-C", repoRoot, "diff", "--no-index", "--", os.DevNull, absPath)
+	cmd := exec.CommandContext(ctx, gitPath, "-C", repoRoot, "diff", "--no-index", "--", os.DevNull, absPath)
 	out, err := cmd.CombinedOutput()
 	if len(out) == 0 {
 		return "", false
@@ -282,9 +288,13 @@ func gitNoIndexPatch(repoRoot string, path string) (string, bool) {
 }
 
 func gitOutput(workspaceDir string, args ...string) (string, bool) {
+	gitPath, err := gitrepo.Executable()
+	if err != nil {
+		return "", false
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "/usr/bin/git", append([]string{"-C", workspaceDir}, args...)...)
+	cmd := exec.CommandContext(ctx, gitPath, append([]string{"-C", workspaceDir}, args...)...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", false

--- a/internal/exepath/resolve.go
+++ b/internal/exepath/resolve.go
@@ -1,0 +1,67 @@
+// Package exepath resolves absolute paths to the external executables tars
+// shells out to.
+//
+// tars used to name these by absolute path (/usr/bin/git, /bin/sh,
+// /usr/bin/patch) so that exec never received a bare name for the OS to
+// resolve against PATH at run time. Those paths do not exist on every
+// platform, so resolution has to be dynamic — but the guarantee is kept: a
+// caller either gets an absolute path or an error.
+package exepath
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// ErrNotFound reports that none of the candidates existed. Callers wrap it
+// with a sentinel naming the tool they were looking for.
+var ErrNotFound = errors.New("executable not found")
+
+// Candidates describes where to look for an executable, in priority order.
+type Candidates struct {
+	// DefaultPath is the platform's canonical absolute location, tried first
+	// so platforms that have one keep byte-identical behaviour. Empty when the
+	// platform has no such location.
+	DefaultPath string
+
+	// LookupNames are searched on PATH, in order. A result that is not
+	// absolute is rejected rather than returned.
+	LookupNames []string
+
+	// Fallbacks supplies absolute paths to try last, for tools that are
+	// installed but unreachable by name. It is only called if the earlier
+	// steps miss, since building the list can itself be expensive.
+	Fallbacks func() []string
+}
+
+// Resolve returns the first candidate that exists, or ErrNotFound.
+func Resolve(candidates Candidates) (string, error) {
+	if candidates.DefaultPath != "" && isFile(candidates.DefaultPath) {
+		return candidates.DefaultPath, nil
+	}
+	for _, name := range candidates.LookupNames {
+		path, err := exec.LookPath(name)
+		if err != nil {
+			continue
+		}
+		if filepath.IsAbs(path) {
+			return path, nil
+		}
+	}
+	if candidates.Fallbacks != nil {
+		for _, path := range candidates.Fallbacks() {
+			if isFile(path) {
+				return path, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("%w: tried %v", ErrNotFound, candidates.LookupNames)
+}
+
+func isFile(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/internal/exepath/resolve_test.go
+++ b/internal/exepath/resolve_test.go
@@ -1,0 +1,135 @@
+package exepath
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// writeExecutable creates a file LookPath will accept as runnable. Windows
+// decides by extension against PATHEXT rather than a permission bit, so the
+// name differs per platform while the lookup name stays the same.
+func writeExecutable(t *testing.T, dir, name string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		name += ".bat"
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write executable: %v", err)
+	}
+	return path
+}
+
+func TestResolvePrefersDefaultPath(t *testing.T) {
+	dir := t.TempDir()
+	preferred := writeExecutable(t, dir, "preferred")
+	fallbackDir := t.TempDir()
+	fallback := writeExecutable(t, fallbackDir, "fallback")
+
+	got, err := Resolve(Candidates{
+		DefaultPath: preferred,
+		LookupNames: []string{"definitely-not-a-real-tool"},
+		Fallbacks:   func() []string { return []string{fallback} },
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != preferred {
+		t.Fatalf("expected the default path %q, got %q", preferred, got)
+	}
+}
+
+func TestResolveSkipsDefaultPathThatIsADirectory(t *testing.T) {
+	dir := t.TempDir()
+	fallback := writeExecutable(t, dir, "fallback")
+
+	got, err := Resolve(Candidates{
+		DefaultPath: dir,
+		Fallbacks:   func() []string { return []string{fallback} },
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != fallback {
+		t.Fatalf("expected the fallback %q, got %q", fallback, got)
+	}
+}
+
+func TestResolveFindsNameOnPath(t *testing.T) {
+	dir := t.TempDir()
+	want := writeExecutable(t, dir, "tars-probe")
+	t.Setenv("PATH", dir)
+
+	got, err := Resolve(Candidates{
+		DefaultPath: filepath.Join(t.TempDir(), "absent"),
+		LookupNames: []string{"missing-first", "tars-probe"},
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != want {
+		t.Fatalf("expected %q from PATH, got %q", want, got)
+	}
+}
+
+// TestResolveRejectsRelativePathLookup guards the reason these paths were
+// hardcoded to begin with: a PATH entry relative to the working directory must
+// never yield the executable tars runs.
+func TestResolveRejectsRelativePathLookup(t *testing.T) {
+	dir := t.TempDir()
+	relativeDir := "bin"
+	if err := os.MkdirAll(filepath.Join(dir, relativeDir), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeExecutable(t, filepath.Join(dir, relativeDir), "tars-probe")
+	t.Chdir(dir)
+	t.Setenv("PATH", relativeDir)
+
+	_, err := Resolve(Candidates{LookupNames: []string{"tars-probe"}})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for a relative PATH hit, got %v", err)
+	}
+}
+
+func TestResolveUsesFallbacksInOrder(t *testing.T) {
+	dir := t.TempDir()
+	second := writeExecutable(t, dir, "second")
+	t.Setenv("PATH", t.TempDir())
+
+	got, err := Resolve(Candidates{
+		LookupNames: []string{"definitely-not-a-real-tool"},
+		Fallbacks: func() []string {
+			return []string{filepath.Join(dir, "absent"), second}
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != second {
+		t.Fatalf("expected the second fallback %q, got %q", second, got)
+	}
+}
+
+func TestResolveReturnsErrNotFoundWhenEverythingMisses(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	_, err := Resolve(Candidates{
+		DefaultPath: filepath.Join(t.TempDir(), "absent"),
+		LookupNames: []string{"definitely-not-a-real-tool"},
+		Fallbacks:   func() []string { return []string{filepath.Join(t.TempDir(), "also-absent")} },
+	})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestResolveToleratesNilFallbacks(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	if _, err := Resolve(Candidates{LookupNames: []string{"definitely-not-a-real-tool"}}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -222,6 +222,11 @@ func (c *Client) RepositoryRoot(ctx context.Context, startDir string) (string, e
 	}
 	out, err := runGit(ctx, startDir, gitSubcommandRevParse, "--show-toplevel")
 	if err != nil {
+		// A missing git binary is not a statement about startDir, so it must
+		// not be reported as "not a git repository".
+		if errors.Is(err, ErrGitUnavailable) {
+			return "", err
+		}
 		return "", ErrNotRepository
 	}
 	root := strings.TrimSpace(string(out))
@@ -591,9 +596,13 @@ func runGit(ctx context.Context, startDir string, args ...string) ([]byte, error
 	if err := validateGitInvocation(startDir, args); err != nil {
 		return nil, err
 	}
+	gitPath, err := Executable()
+	if err != nil {
+		return nil, err
+	}
 	cmdArgs := append([]string{"-C", startDir}, args...)
-	cmd := exec.CommandContext(ctx, "/usr/bin/git")
-	cmd.Args = append([]string{"/usr/bin/git"}, cmdArgs...)
+	cmd := exec.CommandContext(ctx, gitPath)
+	cmd.Args = append([]string{gitPath}, cmdArgs...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return out, fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))

--- a/internal/git/executable.go
+++ b/internal/git/executable.go
@@ -1,0 +1,46 @@
+package git
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+)
+
+// ErrGitUnavailable reports that no git executable could be located. It is
+// deliberately distinct from ErrNotRepository: a missing git binary and a
+// directory that simply is not a repository call for very different fixes, and
+// collapsing them made "not a git repository" the symptom of a missing git on
+// platforms without defaultGitPath.
+var ErrGitUnavailable = errors.New("git executable not found")
+
+// Executable returns the absolute path of the git binary to run.
+//
+// Callers get an absolute path or an error — never a bare "git" that the OS
+// would resolve against PATH at exec time, which is what the previous
+// hardcoded /usr/bin/git was guarding against. defaultGitPath keeps that
+// guarantee for free on platforms where git has a canonical location; where it
+// does not (Windows, and unix installs that put git elsewhere), PATH is
+// consulted once and the result is required to be absolute.
+//
+// The result is cached: git does not move while the process runs, and every
+// git subcommand would otherwise re-walk PATH.
+var Executable = sync.OnceValues(resolveExecutable)
+
+func resolveExecutable() (string, error) {
+	if defaultGitPath != "" {
+		if info, err := os.Stat(defaultGitPath); err == nil && !info.IsDir() {
+			return defaultGitPath, nil
+		}
+	}
+	path, err := exec.LookPath("git")
+	if err != nil {
+		return "", fmt.Errorf("%w: %v", ErrGitUnavailable, err)
+	}
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("%w: %q is not an absolute path", ErrGitUnavailable, path)
+	}
+	return path, nil
+}

--- a/internal/git/executable.go
+++ b/internal/git/executable.go
@@ -3,10 +3,9 @@ package git
 import (
 	"errors"
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"sync"
+
+	"github.com/devlikebear/tars/internal/exepath"
 )
 
 // ErrGitUnavailable reports that no git executable could be located. It is
@@ -16,31 +15,18 @@ import (
 // platforms without defaultGitPath.
 var ErrGitUnavailable = errors.New("git executable not found")
 
-// Executable returns the absolute path of the git binary to run.
-//
-// Callers get an absolute path or an error — never a bare "git" that the OS
-// would resolve against PATH at exec time, which is what the previous
-// hardcoded /usr/bin/git was guarding against. defaultGitPath keeps that
-// guarantee for free on platforms where git has a canonical location; where it
-// does not (Windows, and unix installs that put git elsewhere), PATH is
-// consulted once and the result is required to be absolute.
-//
-// The result is cached: git does not move while the process runs, and every
-// git subcommand would otherwise re-walk PATH.
+// Executable returns the absolute path of the git binary to run. The result is
+// cached: git does not move while the process runs, and every git subcommand
+// would otherwise re-walk PATH.
 var Executable = sync.OnceValues(resolveExecutable)
 
 func resolveExecutable() (string, error) {
-	if defaultGitPath != "" {
-		if info, err := os.Stat(defaultGitPath); err == nil && !info.IsDir() {
-			return defaultGitPath, nil
-		}
-	}
-	path, err := exec.LookPath("git")
+	path, err := exepath.Resolve(exepath.Candidates{
+		DefaultPath: defaultGitPath,
+		LookupNames: []string{"git"},
+	})
 	if err != nil {
 		return "", fmt.Errorf("%w: %v", ErrGitUnavailable, err)
-	}
-	if !filepath.IsAbs(path) {
-		return "", fmt.Errorf("%w: %q is not an absolute path", ErrGitUnavailable, path)
 	}
 	return path, nil
 }

--- a/internal/git/executable_unix.go
+++ b/internal/git/executable_unix.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package git
+
+// defaultGitPath is where git lives on a stock macOS or Linux install. Trying
+// it before PATH keeps the original hardcoded-path behaviour on the platforms
+// that had it, so no lookup order changes there.
+const defaultGitPath = "/usr/bin/git"

--- a/internal/git/executable_windows.go
+++ b/internal/git/executable_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package git
+
+// Windows has no canonical install location for git — Git for Windows defaults
+// to C:\Program Files\Git\cmd\git.exe, scoop/winget/portable installs land
+// elsewhere, and none of them are guaranteed. Leave the default empty so
+// resolution goes straight to PATH.
+const defaultGitPath = ""

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -167,6 +167,10 @@ func TestClientDiscardMutationRestoresWorktree(t *testing.T) {
 	runGitCmd(t, repo, "init", "-b", "main")
 	runGitCmd(t, repo, "config", "user.email", "tars@example.test")
 	runGitCmd(t, repo, "config", "user.name", "TARS Test")
+	// This is the only test here that asserts the exact bytes of a file git
+	// checked out, so it must not inherit the developer's core.autocrlf. Git
+	// for Windows defaults it to true, which would restore "hello\r\n".
+	runGitCmd(t, repo, "config", "core.autocrlf", "false")
 	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("hello\n"), 0o644); err != nil {
 		t.Fatalf("write readme: %v", err)
 	}

--- a/internal/git/install_test.go
+++ b/internal/git/install_test.go
@@ -1,0 +1,42 @@
+package git
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestInstallRoots(t *testing.T) {
+	roots := InstallRoots()
+
+	if runtime.GOOS != "windows" {
+		if roots != nil {
+			t.Fatalf("expected no install roots off Windows, got %v", roots)
+		}
+		return
+	}
+
+	// On Windows the roots are derived from the resolved git binary, so an
+	// environment without git legitimately has none.
+	if _, err := Executable(); err != nil {
+		t.Skipf("git not available: %v", err)
+	}
+	if len(roots) == 0 {
+		t.Fatal("expected install roots to be derived from the resolved git binary")
+	}
+	for _, root := range roots {
+		if !filepath.IsAbs(root) {
+			t.Fatalf("install root %q is not absolute", root)
+		}
+	}
+}
+
+func TestExecutableIsAbsolute(t *testing.T) {
+	path, err := Executable()
+	if err != nil {
+		t.Skipf("git not available: %v", err)
+	}
+	if !filepath.IsAbs(path) {
+		t.Fatalf("expected an absolute git path, got %q", path)
+	}
+}

--- a/internal/git/install_unix.go
+++ b/internal/git/install_unix.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package git
+
+// InstallRoots has nothing to offer on unix. Git is not distributed as a
+// bundle carrying the other tools tars shells out to — those live at their own
+// standard absolute paths or on PATH — so there is no install root to search.
+func InstallRoots() []string { return nil }

--- a/internal/git/install_windows.go
+++ b/internal/git/install_windows.go
@@ -1,0 +1,39 @@
+//go:build windows
+
+package git
+
+import "path/filepath"
+
+// installRootSearchDepth is how far above git.exe the installation root can
+// sit. git resolves to <root>\cmd\git.exe on a stock install but to
+// <root>\mingw64\bin\git.exe from inside a Git Bash environment, so the root is
+// two or three levels up depending on which one PATH happened to yield.
+const installRootSearchDepth = 3
+
+// InstallRoots returns candidate Git for Windows installation roots, nearest
+// first, derived from the resolved git binary.
+//
+// Git for Windows bundles a full MSYS2 environment — sh.exe, bash.exe,
+// patch.exe and more under <root>\usr\bin — but its installer only puts
+// <root>\cmd on PATH. Those tools are therefore installed yet unreachable by
+// name. Since tars already requires git, walking up from it locates them.
+//
+// The roots are candidates, not guarantees: callers must check that the file
+// they want actually exists under one.
+func InstallRoots() []string {
+	gitPath, err := Executable()
+	if err != nil {
+		return nil
+	}
+	var roots []string
+	dir := filepath.Dir(gitPath)
+	for depth := 0; depth < installRootSearchDepth; depth++ {
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+		roots = append(roots, dir)
+	}
+	return roots
+}

--- a/internal/git/unavailable_test.go
+++ b/internal/git/unavailable_test.go
@@ -1,0 +1,42 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// stubExecutable makes git resolution fail for the duration of the test.
+// Executable is a func var precisely so this seam exists; these tests must not
+// run in parallel with anything that shells out to git.
+func stubExecutable(t *testing.T, err error) {
+	t.Helper()
+	previous := Executable
+	Executable = func() (string, error) { return "", err }
+	t.Cleanup(func() { Executable = previous })
+}
+
+// TestRepositoryRootReportsMissingGitDistinctly is the regression this
+// distinction exists for: with git unresolvable, every call used to come back
+// as "not a git repository", which sent anyone debugging it at the directory
+// instead of at their missing git.
+func TestRepositoryRootReportsMissingGitDistinctly(t *testing.T) {
+	stubExecutable(t, fmt.Errorf("%w: no git here", ErrGitUnavailable))
+
+	_, err := NewClient().RepositoryRoot(context.Background(), t.TempDir())
+	if !errors.Is(err, ErrGitUnavailable) {
+		t.Fatalf("expected ErrGitUnavailable, got %v", err)
+	}
+	if errors.Is(err, ErrNotRepository) {
+		t.Fatal("a missing git binary must not be reported as a missing repository")
+	}
+}
+
+func TestStatusPropagatesMissingGit(t *testing.T) {
+	stubExecutable(t, fmt.Errorf("%w: no git here", ErrGitUnavailable))
+
+	if _, err := NewClient().Status(context.Background(), t.TempDir()); !errors.Is(err, ErrGitUnavailable) {
+		t.Fatalf("expected ErrGitUnavailable, got %v", err)
+	}
+}

--- a/internal/onboarding/spawn.go
+++ b/internal/onboarding/spawn.go
@@ -6,7 +6,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"syscall"
 )
 
 // SpawnOptions describes a detached child process. The child inherits
@@ -30,7 +29,8 @@ type SpawnResult struct {
 // SpawnDetached starts a background process that survives the parent
 // exiting. Stdout/stderr go to LogPath (created if needed). Used by
 // `tars init` when running in --no-service mode (or on non-darwin
-// systems) to start `tars serve` without blocking.
+// systems) to start `tars serve` without blocking. Detaching itself is
+// OS-specific and lives in configureDetachedProcess.
 func SpawnDetached(opts SpawnOptions) (SpawnResult, error) {
 	exe := strings.TrimSpace(opts.Executable)
 	if exe == "" {
@@ -43,7 +43,7 @@ func SpawnDetached(opts SpawnOptions) (SpawnResult, error) {
 	if logPath == "" {
 		output, err = os.OpenFile(os.DevNull, os.O_WRONLY, 0)
 		if err != nil {
-			return SpawnResult{}, fmt.Errorf("open /dev/null: %w", err)
+			return SpawnResult{}, fmt.Errorf("open %s: %w", os.DevNull, err)
 		}
 	} else {
 		if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
@@ -65,7 +65,7 @@ func SpawnDetached(opts SpawnOptions) (SpawnResult, error) {
 	}
 	cmd.Stdout = output
 	cmd.Stderr = output
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	configureDetachedProcess(cmd)
 
 	if err := cmd.Start(); err != nil {
 		return SpawnResult{}, fmt.Errorf("start %s: %w", exe, err)

--- a/internal/onboarding/spawn_test.go
+++ b/internal/onboarding/spawn_test.go
@@ -9,18 +9,70 @@ import (
 	"time"
 )
 
-func TestSpawnDetached_RunsAndReturnsPID(t *testing.T) {
+// echoCommand returns a program that prints to stdout and exits.
+//
+// Windows deliberately avoids Git-for-Windows' sh.exe: SpawnDetached hands the
+// child a log handle opened with O_APPEND, which on Windows means
+// FILE_APPEND_DATA without FILE_WRITE_DATA, and the MSYS2 runtime backing
+// sh.exe fails such writes and exits 1. Native programs — including tars
+// itself, the only thing SpawnDetached actually launches — write to it fine, so
+// the native shell is the representative fixture here.
+func echoCommand(t *testing.T) (string, []string) {
+	t.Helper()
 	if runtime.GOOS == "windows" {
-		t.Skip("detached spawn helper currently targets unix-like OSes")
+		bin, err := exec.LookPath("cmd.exe")
+		if err != nil {
+			t.Skipf("cmd.exe not available: %v", err)
+		}
+		return bin, []string{"/c", "echo hello"}
 	}
-	logFile := filepath.Join(t.TempDir(), "spawn.log")
 	bin, err := exec.LookPath("sh")
 	if err != nil {
 		t.Skipf("sh not available: %v", err)
 	}
+	return bin, []string{"-c", "echo hello && sleep 0.05"}
+}
+
+// exitCommand returns a program that exits immediately without output.
+func exitCommand(t *testing.T) (string, []string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		bin, err := exec.LookPath("cmd.exe")
+		if err != nil {
+			t.Skipf("cmd.exe not available: %v", err)
+		}
+		return bin, []string{"/c", "exit"}
+	}
+	bin, err := exec.LookPath("true")
+	if err != nil {
+		t.Skipf("true not available: %v", err)
+	}
+	return bin, nil
+}
+
+// waitForContent polls until path is non-empty. Process startup latency varies
+// widely across platforms, so poll instead of sleeping a fixed interval.
+func waitForContent(t *testing.T, path string) []byte {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		data, err := os.ReadFile(path)
+		if err == nil && len(data) > 0 {
+			return data
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected log content at %s, got %d bytes (last err: %v)", path, len(data), err)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+func TestSpawnDetached_RunsAndReturnsPID(t *testing.T) {
+	logFile := filepath.Join(t.TempDir(), "spawn.log")
+	bin, args := echoCommand(t)
 	res, err := SpawnDetached(SpawnOptions{
 		Executable: bin,
-		Args:       []string{"-c", "echo hello && sleep 0.05"},
+		Args:       args,
 		LogPath:    logFile,
 	})
 	if err != nil {
@@ -29,15 +81,7 @@ func TestSpawnDetached_RunsAndReturnsPID(t *testing.T) {
 	if res.PID <= 0 {
 		t.Fatalf("expected positive pid, got %d", res.PID)
 	}
-	// give it a moment to write
-	time.Sleep(150 * time.Millisecond)
-	data, err := os.ReadFile(logFile)
-	if err != nil {
-		t.Fatalf("read log: %v", err)
-	}
-	if string(data) == "" {
-		t.Fatalf("expected log content, got empty file")
-	}
+	waitForContent(t, logFile)
 }
 
 func TestSpawnDetached_RejectsMissingExecutable(t *testing.T) {
@@ -48,15 +92,9 @@ func TestSpawnDetached_RejectsMissingExecutable(t *testing.T) {
 }
 
 func TestSpawnDetached_CreatesLogParentDir(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("detached spawn helper currently targets unix-like OSes")
-	}
-	bin, err := exec.LookPath("true")
-	if err != nil {
-		t.Skipf("true not available: %v", err)
-	}
+	bin, args := exitCommand(t)
 	logFile := filepath.Join(t.TempDir(), "nested", "deeper", "spawn.log")
-	if _, err := SpawnDetached(SpawnOptions{Executable: bin, LogPath: logFile}); err != nil {
+	if _, err := SpawnDetached(SpawnOptions{Executable: bin, Args: args, LogPath: logFile}); err != nil {
 		t.Fatalf("spawn detached: %v", err)
 	}
 	if _, err := os.Stat(filepath.Dir(logFile)); err != nil {

--- a/internal/onboarding/spawn_unix.go
+++ b/internal/onboarding/spawn_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package onboarding
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// configureDetachedProcess puts the child in its own session so it is not
+// killed when the parent's terminal or process group goes away.
+func configureDetachedProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}

--- a/internal/onboarding/spawn_windows.go
+++ b/internal/onboarding/spawn_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package onboarding
+
+import (
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// configureDetachedProcess is the Windows counterpart to setsid. Windows has no
+// sessions in the POSIX sense, so detaching means two creation flags:
+// DETACHED_PROCESS keeps the child off the parent's console (otherwise closing
+// the console window would take the server with it, and a console would flash
+// when `tars init` runs from Explorer), and CREATE_NEW_PROCESS_GROUP stops
+// Ctrl-C/Ctrl-Break in the parent's console from being delivered to the child.
+func configureDetachedProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.DETACHED_PROCESS | windows.CREATE_NEW_PROCESS_GROUP,
+	}
+}

--- a/internal/ops/manager.go
+++ b/internal/ops/manager.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/devlikebear/tars/internal/config"
@@ -100,12 +99,10 @@ func (m *Manager) Status(ctx context.Context) (Status, error) {
 		return Status{}, fmt.Errorf("ops manager is nil")
 	}
 	now := m.nowFn().UTC()
-	var fs syscall.Statfs_t
-	if err := syscall.Statfs(strings.TrimSpace(m.homeDir), &fs); err != nil {
+	total, free, err := diskUsage(strings.TrimSpace(m.homeDir))
+	if err != nil {
 		return Status{}, err
 	}
-	total := fs.Blocks * uint64(fs.Bsize)
-	free := fs.Bavail * uint64(fs.Bsize)
 	usedPercent := float64(0)
 	if total > 0 {
 		usedPercent = (float64(total-free) / float64(total)) * 100

--- a/internal/ops/manager_disk_unix.go
+++ b/internal/ops/manager_disk_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package ops
+
+import "syscall"
+
+// diskUsage reports the total and user-available bytes of the filesystem
+// holding path. Free is the unprivileged-available figure (Bavail), not the
+// raw free count, so the used percentage matches what the user can act on.
+func diskUsage(path string) (total uint64, free uint64, err error) {
+	var fs syscall.Statfs_t
+	if err := syscall.Statfs(path, &fs); err != nil {
+		return 0, 0, err
+	}
+	return fs.Blocks * uint64(fs.Bsize), fs.Bavail * uint64(fs.Bsize), nil
+}

--- a/internal/ops/manager_disk_windows.go
+++ b/internal/ops/manager_disk_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package ops
+
+import "golang.org/x/sys/windows"
+
+// diskUsage reports the total and user-available bytes of the volume holding
+// path. GetDiskFreeSpaceEx is the Windows analogue of statfs; its
+// freeBytesAvailableToCaller output honours per-user disk quotas the same way
+// statfs' Bavail excludes root-reserved blocks, so both platforms report the
+// space this process could actually use.
+func diskUsage(path string) (total uint64, free uint64, err error) {
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, 0, err
+	}
+	var freeToCaller, totalBytes, totalFree uint64
+	if err := windows.GetDiskFreeSpaceEx(pathPtr, &freeToCaller, &totalBytes, &totalFree); err != nil {
+		return 0, 0, err
+	}
+	return totalBytes, freeToCaller, nil
+}

--- a/internal/ops/manager_status_test.go
+++ b/internal/ops/manager_status_test.go
@@ -1,0 +1,42 @@
+package ops
+
+import (
+	"context"
+	"testing"
+)
+
+// TestManager_StatusReportsDiskAndProcessCounts exercises the platform-split
+// diskUsage helper, which had no test on either platform. Both implementations
+// report the space available to this process, so the only portable assertions
+// are the invariants: a non-empty volume, free space that cannot exceed it, and
+// a percentage in range.
+func TestManager_StatusReportsDiskAndProcessCounts(t *testing.T) {
+	mgr := NewManager(t.TempDir(), Options{HomeDir: t.TempDir()})
+
+	status, err := mgr.Status(context.Background())
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if status.DiskTotalBytes == 0 {
+		t.Fatal("expected a non-zero total disk size")
+	}
+	if status.DiskFreeBytes > status.DiskTotalBytes {
+		t.Fatalf("free %d exceeds total %d", status.DiskFreeBytes, status.DiskTotalBytes)
+	}
+	if status.DiskUsedPercent < 0 || status.DiskUsedPercent > 100 {
+		t.Fatalf("used percent %.2f is out of range", status.DiskUsedPercent)
+	}
+	if status.ProcessCount <= 0 {
+		t.Fatalf("expected a positive process count, got %d", status.ProcessCount)
+	}
+	if status.Timestamp.IsZero() {
+		t.Fatal("expected a timestamp")
+	}
+}
+
+func TestManager_StatusRejectsNilManager(t *testing.T) {
+	var mgr *Manager
+	if _, err := mgr.Status(context.Background()); err == nil {
+		t.Fatal("expected an error from a nil manager")
+	}
+}

--- a/internal/ops/manager_system.go
+++ b/internal/ops/manager_system.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package ops
 
 import (
@@ -6,6 +8,7 @@ import (
 	"strings"
 )
 
+// processCount counts system-wide processes by parsing `ps`.
 func processCount() (int, error) {
 	out, err := exec.Command("/bin/ps", "-A", "-o", "pid=").Output()
 	if err != nil {

--- a/internal/ops/manager_system_windows.go
+++ b/internal/ops/manager_system_windows.go
@@ -1,0 +1,45 @@
+//go:build windows
+
+package ops
+
+import (
+	"errors"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// processCount counts system-wide processes via a toolhelp snapshot.
+//
+// The unix path shells out to `ps`, but the Windows equivalent (`tasklist`) is
+// slow to start and prints localized headers that would have to be parsed
+// around. The snapshot API is both faster and locale-independent.
+//
+// Processes the caller cannot open still appear in the snapshot, so the count
+// covers the whole system rather than just this user's processes, matching
+// `ps -A`.
+func processCount() (int, error) {
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = windows.CloseHandle(snapshot) }()
+
+	var entry windows.ProcessEntry32
+	// Size must be filled in before the first call or the walk fails.
+	entry.Size = uint32(unsafe.Sizeof(entry))
+	if err := windows.Process32First(snapshot, &entry); err != nil {
+		return 0, err
+	}
+	count := 0
+	for {
+		count++
+		if err := windows.Process32Next(snapshot, &entry); err != nil {
+			// ERROR_NO_MORE_FILES is the documented end-of-walk signal.
+			if errors.Is(err, windows.ERROR_NO_MORE_FILES) {
+				return count, nil
+			}
+			return 0, err
+		}
+	}
+}

--- a/internal/ops/manager_test.go
+++ b/internal/ops/manager_test.go
@@ -506,7 +506,7 @@ func TestManager_IsSafeCleanupPath_OnlyAllowsConfiguredRoots(t *testing.T) {
 	}
 }
 
-func TestProcessCountUsesSystemPs(t *testing.T) {
+func TestProcessCountReturnsPositiveCount(t *testing.T) {
 	count, err := processCount()
 	if err != nil {
 		t.Fatalf("process count: %v", err)

--- a/internal/proofverifier/artifact_edges_test.go
+++ b/internal/proofverifier/artifact_edges_test.go
@@ -149,7 +149,10 @@ func TestEngineDiscoversGitWorkspaceAndProcessRunnerOutcomes(t *testing.T) {
 	}
 
 	for _, args := range [][]string{{"init"}, {"config", "user.name", "TARS Test"}, {"config", "user.email", "tars@example.test"}} {
-		command := append([]string{"-C", root}, args...)
+		// root goes through a POSIX shell, so it must be single-quoted: a
+		// Windows temp path is full of backslashes, which the shell would
+		// otherwise consume as escapes and hand git a mangled directory.
+		command := append([]string{"-C", "'" + root + "'"}, args...)
 		if result, err := (processCommandRunner{}).Run(context.Background(), root, "git "+strings.Join(command, " "), time.Second); err != nil || result.ExitCode != 0 {
 			t.Fatalf("git %v result=%+v err=%v", args, result, err)
 		}

--- a/internal/proofverifier/shell_unavailable_test.go
+++ b/internal/proofverifier/shell_unavailable_test.go
@@ -1,0 +1,27 @@
+package proofverifier
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/devlikebear/tars/internal/shellexec"
+)
+
+// TestProcessRunnerFailsWhenNoShellIsAvailable covers the branch that reports a
+// missing shell as an error rather than a failed verification, which would
+// otherwise look like the verified command itself did not pass.
+func TestProcessRunnerFailsWhenNoShellIsAvailable(t *testing.T) {
+	previous := shellexec.Executable
+	shellexec.Executable = func() (string, error) {
+		return "", fmt.Errorf("%w: nothing installed", shellexec.ErrShellUnavailable)
+	}
+	t.Cleanup(func() { shellexec.Executable = previous })
+
+	_, err := (processCommandRunner{}).Run(context.Background(), t.TempDir(), "printf ok", time.Second)
+	if !errors.Is(err, shellexec.ErrShellUnavailable) {
+		t.Fatalf("expected ErrShellUnavailable, got %v", err)
+	}
+}

--- a/internal/proofverifier/verifier.go
+++ b/internal/proofverifier/verifier.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/devlikebear/tars/internal/shellexec"
 	"github.com/devlikebear/tars/internal/workscheduler"
 	"github.com/devlikebear/tars/internal/workstore"
 )
@@ -582,16 +583,20 @@ func cloneHTTPClient(source *http.Client, timeout time.Duration, validate func(c
 type processCommandRunner struct{}
 
 func (processCommandRunner) Run(ctx context.Context, directory, command string, timeout time.Duration) (CommandResult, error) {
+	shell, err := shellexec.Executable()
+	if err != nil {
+		return CommandResult{}, fmt.Errorf("proofverifier: %w", err)
+	}
 	commandCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	startedAt := time.Now()
-	cmd := exec.CommandContext(commandCtx, "/bin/sh", "-lc", command)
+	cmd := exec.CommandContext(commandCtx, shell, "-lc", command)
 	cmd.Dir = directory
 	cmd.Env = verifierEnvironment()
 	var stdout, stderr strings.Builder
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	err := cmd.Run()
+	err = cmd.Run()
 	result := CommandResult{Stdout: stdout.String(), Stderr: stderr.String(), Duration: time.Since(startedAt)}
 	if commandCtx.Err() != nil {
 		result.ExitCode = -1

--- a/internal/shellexec/shell.go
+++ b/internal/shellexec/shell.go
@@ -1,0 +1,52 @@
+// Package shellexec resolves the POSIX shell used to run command strings that
+// users, skills, and agents supply.
+//
+// Those strings are written as shell script — pipes, &&, $VAR, quoting — so
+// they need a POSIX shell, not merely "some shell". cmd.exe would mis-execute
+// them rather than fail cleanly, which is why Windows resolution looks for sh
+// or bash instead of falling back to the native interpreter.
+package shellexec
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+)
+
+// ErrShellUnavailable reports that no POSIX shell could be located. Callers
+// should surface it rather than substituting another interpreter: silently
+// running a POSIX command string through something else is worse than not
+// running it.
+var ErrShellUnavailable = errors.New("posix shell not found")
+
+// Executable returns the absolute path of the POSIX shell to run.
+//
+// Like git.Executable, the result is always absolute — never a bare "sh" left
+// for the OS to resolve at exec time — and is cached for the process lifetime.
+var Executable = sync.OnceValues(resolveExecutable)
+
+func resolveExecutable() (string, error) {
+	if defaultShellPath != "" {
+		if info, err := os.Stat(defaultShellPath); err == nil && !info.IsDir() {
+			return defaultShellPath, nil
+		}
+	}
+	for _, name := range shellLookupNames {
+		path, err := exec.LookPath(name)
+		if err != nil {
+			continue
+		}
+		if filepath.IsAbs(path) {
+			return path, nil
+		}
+	}
+	for _, path := range fallbackShellPaths() {
+		if info, err := os.Stat(path); err == nil && !info.IsDir() {
+			return path, nil
+		}
+	}
+	return "", fmt.Errorf("%w: tried %v", ErrShellUnavailable, shellLookupNames)
+}

--- a/internal/shellexec/shell.go
+++ b/internal/shellexec/shell.go
@@ -10,10 +10,9 @@ package shellexec
 import (
 	"errors"
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"sync"
+
+	"github.com/devlikebear/tars/internal/exepath"
 )
 
 // ErrShellUnavailable reports that no POSIX shell could be located. Callers
@@ -22,31 +21,18 @@ import (
 // running it.
 var ErrShellUnavailable = errors.New("posix shell not found")
 
-// Executable returns the absolute path of the POSIX shell to run.
-//
-// Like git.Executable, the result is always absolute — never a bare "sh" left
-// for the OS to resolve at exec time — and is cached for the process lifetime.
+// Executable returns the absolute path of the POSIX shell to run, cached for
+// the process lifetime.
 var Executable = sync.OnceValues(resolveExecutable)
 
 func resolveExecutable() (string, error) {
-	if defaultShellPath != "" {
-		if info, err := os.Stat(defaultShellPath); err == nil && !info.IsDir() {
-			return defaultShellPath, nil
-		}
+	path, err := exepath.Resolve(exepath.Candidates{
+		DefaultPath: defaultShellPath,
+		LookupNames: shellLookupNames,
+		Fallbacks:   fallbackShellPaths,
+	})
+	if err != nil {
+		return "", fmt.Errorf("%w: %v", ErrShellUnavailable, err)
 	}
-	for _, name := range shellLookupNames {
-		path, err := exec.LookPath(name)
-		if err != nil {
-			continue
-		}
-		if filepath.IsAbs(path) {
-			return path, nil
-		}
-	}
-	for _, path := range fallbackShellPaths() {
-		if info, err := os.Stat(path); err == nil && !info.IsDir() {
-			return path, nil
-		}
-	}
-	return "", fmt.Errorf("%w: tried %v", ErrShellUnavailable, shellLookupNames)
+	return path, nil
 }

--- a/internal/shellexec/shell_test.go
+++ b/internal/shellexec/shell_test.go
@@ -1,0 +1,46 @@
+package shellexec
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestResolveExecutableReturnsAbsoluteExistingShell calls resolveExecutable
+// rather than Executable so the result is not served from the process-wide
+// cache, which another test or an earlier call may already have populated.
+func TestResolveExecutableReturnsAbsoluteExistingShell(t *testing.T) {
+	shell, err := resolveExecutable()
+	if err != nil {
+		t.Fatalf("resolve shell: %v", err)
+	}
+	if !filepath.IsAbs(shell) {
+		t.Fatalf("expected an absolute path, got %q", shell)
+	}
+	info, err := os.Stat(shell)
+	if err != nil {
+		t.Fatalf("stat resolved shell %q: %v", shell, err)
+	}
+	if info.IsDir() {
+		t.Fatalf("resolved shell %q is a directory", shell)
+	}
+}
+
+// TestResolvedShellRunsPOSIXCommand is the assertion that matters: the point of
+// resolving rather than hardcoding is to end up with something that actually
+// interprets POSIX command strings, which is what every caller feeds it.
+func TestResolvedShellRunsPOSIXCommand(t *testing.T) {
+	shell, err := resolveExecutable()
+	if err != nil {
+		t.Fatalf("resolve shell: %v", err)
+	}
+	out, err := exec.Command(shell, "-c", "echo tars && exit 0").CombinedOutput()
+	if err != nil {
+		t.Fatalf("run command through %q: %v (output %q)", shell, err, out)
+	}
+	if !strings.Contains(string(out), "tars") {
+		t.Fatalf("expected command output to contain %q, got %q", "tars", out)
+	}
+}

--- a/internal/shellexec/shell_unix.go
+++ b/internal/shellexec/shell_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package shellexec
+
+// defaultShellPath is guaranteed by POSIX, so resolution normally stops here
+// and behaves exactly as the previous hardcoded /bin/sh did.
+const defaultShellPath = "/bin/sh"
+
+var shellLookupNames = []string{"sh"}
+
+// fallbackShellPaths has nothing to add on unix: if /bin/sh is missing and sh
+// is not on PATH, the system has no POSIX shell to find.
+func fallbackShellPaths() []string { return nil }

--- a/internal/shellexec/shell_windows.go
+++ b/internal/shellexec/shell_windows.go
@@ -1,0 +1,55 @@
+//go:build windows
+
+package shellexec
+
+import (
+	"path/filepath"
+
+	gitrepo "github.com/devlikebear/tars/internal/git"
+)
+
+// Windows ships no POSIX shell, so there is no default path to try.
+const defaultShellPath = ""
+
+var shellLookupNames = []string{"sh", "bash"}
+
+// shellsUnderGitRoot are the shells Git for Windows installs, relative to the
+// installation root.
+var shellsUnderGitRoot = [][]string{
+	{"usr", "bin", "sh.exe"},
+	{"bin", "bash.exe"},
+	{"usr", "bin", "bash.exe"},
+}
+
+// gitRootSearchDepth is how far above git.exe the installation root can sit.
+// git resolves to <root>\cmd\git.exe on a stock install but to
+// <root>\mingw64\bin\git.exe from inside a Git Bash environment, so the root is
+// two or three levels up depending on which one PATH happened to yield.
+const gitRootSearchDepth = 3
+
+// fallbackShellPaths derives a shell from git's own install.
+//
+// Git for Windows bundles a full MSYS2 environment, but its installer only
+// puts <root>\cmd on PATH — that directory holds git.exe and little else, so
+// sh.exe and bash.exe are usually absent from PATH even though they are
+// installed. tars already requires git, so walking up from git to the
+// installation root finds the shell on a stock install.
+func fallbackShellPaths() []string {
+	gitPath, err := gitrepo.Executable()
+	if err != nil {
+		return nil
+	}
+	var paths []string
+	dir := filepath.Dir(gitPath)
+	for depth := 0; depth < gitRootSearchDepth; depth++ {
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+		for _, parts := range shellsUnderGitRoot {
+			paths = append(paths, filepath.Join(append([]string{dir}, parts...)...))
+		}
+	}
+	return paths
+}

--- a/internal/shellexec/shell_windows.go
+++ b/internal/shellexec/shell_windows.go
@@ -21,34 +21,13 @@ var shellsUnderGitRoot = [][]string{
 	{"usr", "bin", "bash.exe"},
 }
 
-// gitRootSearchDepth is how far above git.exe the installation root can sit.
-// git resolves to <root>\cmd\git.exe on a stock install but to
-// <root>\mingw64\bin\git.exe from inside a Git Bash environment, so the root is
-// two or three levels up depending on which one PATH happened to yield.
-const gitRootSearchDepth = 3
-
-// fallbackShellPaths derives a shell from git's own install.
-//
-// Git for Windows bundles a full MSYS2 environment, but its installer only
-// puts <root>\cmd on PATH — that directory holds git.exe and little else, so
-// sh.exe and bash.exe are usually absent from PATH even though they are
-// installed. tars already requires git, so walking up from git to the
-// installation root finds the shell on a stock install.
+// fallbackShellPaths looks for the shell Git for Windows bundles, which is
+// normally installed but absent from PATH. See git.InstallRoots.
 func fallbackShellPaths() []string {
-	gitPath, err := gitrepo.Executable()
-	if err != nil {
-		return nil
-	}
 	var paths []string
-	dir := filepath.Dir(gitPath)
-	for depth := 0; depth < gitRootSearchDepth; depth++ {
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			break
-		}
-		dir = parent
+	for _, root := range gitrepo.InstallRoots() {
 		for _, parts := range shellsUnderGitRoot {
-			paths = append(paths, filepath.Join(append([]string{dir}, parts...)...))
+			paths = append(paths, filepath.Join(append([]string{root}, parts...)...))
 		}
 	}
 	return paths

--- a/internal/skillhub/sandbox.go
+++ b/internal/skillhub/sandbox.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/devlikebear/tars/internal/config"
 	"github.com/devlikebear/tars/internal/plugin"
+	"github.com/devlikebear/tars/internal/shellexec"
 	"github.com/devlikebear/tars/internal/skill"
 )
 
@@ -335,10 +336,17 @@ func runSkillSmokeCommand(ctx context.Context, workspaceDir string, skillDir str
 		return check
 	}
 
+	shell, err := shellexec.Executable()
+	if err != nil {
+		check.Status = SandboxCheckFailed
+		check.Error = err.Error()
+		return check
+	}
+
 	start := time.Now()
 	cmdCtx, cancel := context.WithTimeout(ctx, defaultSkillSmokeTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(cmdCtx, "/bin/sh", "-c", command)
+	cmd := exec.CommandContext(cmdCtx, shell, "-c", command)
 	cmd.Dir = skillDir
 	cmd.Env = append(os.Environ(),
 		"TARS_SANDBOX=1",

--- a/internal/skillhub/shell_unavailable_test.go
+++ b/internal/skillhub/shell_unavailable_test.go
@@ -1,0 +1,30 @@
+package skillhub
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/devlikebear/tars/internal/shellexec"
+)
+
+// TestSmokeCommandFailsWhenNoShellIsAvailable covers the branch that keeps a
+// missing shell from being mistaken for a failing skill. shellexec.Executable
+// is a func var so this seam exists; the test must not run in parallel with
+// anything that shells out.
+func TestSmokeCommandFailsWhenNoShellIsAvailable(t *testing.T) {
+	previous := shellexec.Executable
+	shellexec.Executable = func() (string, error) {
+		return "", fmt.Errorf("%w: nothing installed", shellexec.ErrShellUnavailable)
+	}
+	t.Cleanup(func() { shellexec.Executable = previous })
+
+	check := runSkillSmokeCommand(context.Background(), t.TempDir(), t.TempDir(), 0, "echo hello")
+	if check.Status != SandboxCheckFailed {
+		t.Fatalf("status = %q, want %q", check.Status, SandboxCheckFailed)
+	}
+	if !strings.Contains(check.Error, shellexec.ErrShellUnavailable.Error()) {
+		t.Fatalf("expected the error to name the missing shell, got %q", check.Error)
+	}
+}

--- a/internal/tarsserver/handler_config.go
+++ b/internal/tarsserver/handler_config.go
@@ -9,7 +9,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/devlikebear/tars/internal/config"
@@ -214,7 +213,7 @@ func handleRestart(w http.ResponseWriter, logger zerolog.Logger) {
 				return
 			}
 			logger.Info().Str("exe", exe).Strs("args", os.Args).Msg("re-executing")
-			if err := syscall.Exec(exe, os.Args, os.Environ()); err != nil {
+			if err := execRestart(exe, os.Args, os.Environ()); err != nil {
 				logger.Error().Err(err).Msg("exec restart failed")
 			}
 		}()

--- a/internal/tarsserver/handler_git_test.go
+++ b/internal/tarsserver/handler_git_test.go
@@ -297,8 +297,19 @@ func TestGitAPIMutationRejectsRootOutsideSessionWorkspace(t *testing.T) {
 
 	mgr := ops.NewManager(workspace, ops.Options{HomeDir: filepath.Join(t.TempDir(), "home")})
 	gitHandler := newGitAPIHandler(workspace, store, mgr, zerolog.New(io.Discard))
-	body := `{"session_id":"` + sess.ID + `","root":"` + outside + `","action":"stage","path":"README.md"}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/git/mutations", strings.NewReader(body))
+	// Marshal rather than concatenate: `outside` is an OS path, and on Windows
+	// its backslashes are invalid JSON escapes, so a hand-built body fails
+	// decoding with 400 and never reaches the containment check under test.
+	body, err := json.Marshal(map[string]string{
+		"session_id": sess.ID,
+		"root":       outside,
+		"action":     "stage",
+		"path":       "README.md",
+	})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/git/mutations", strings.NewReader(string(body)))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	gitHandler.ServeHTTP(rec, req)

--- a/internal/tarsserver/main_serve_api.go
+++ b/internal/tarsserver/main_serve_api.go
@@ -148,6 +148,7 @@ func runServeAPICommand(
 			return &cli.ExitError{Code: 1, Err: err}
 		}
 	}
+	awaitPredecessorExit(opts.APIAddr, logger)
 	if err := apiRuntime.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		logger.Error().Err(err).Msg("failed to serve api")
 		return &cli.ExitError{Code: 1, Err: err}

--- a/internal/tarsserver/notify.go
+++ b/internal/tarsserver/notify.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/devlikebear/tars/internal/serverauth"
+	"github.com/devlikebear/tars/internal/shellexec"
 	"github.com/rs/zerolog"
 )
 
@@ -125,7 +126,11 @@ func (n *commandNotifier) Notify(ctx context.Context, evt notificationEvent) err
 		return nil
 	}
 	if n.command != "" {
-		cmd := exec.CommandContext(ctx, "/bin/sh", "-lc", n.command)
+		shell, err := shellexec.Executable()
+		if err != nil {
+			return fmt.Errorf("notify command: %w", err)
+		}
+		cmd := exec.CommandContext(ctx, shell, "-lc", n.command)
 		cmd.Env = append(os.Environ(),
 			"TARS_NOTIFY_TITLE="+title,
 			"TARS_NOTIFY_MESSAGE="+message,

--- a/internal/tarsserver/restart_exec_unix.go
+++ b/internal/tarsserver/restart_exec_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package tarsserver
+
+import "syscall"
+
+// execRestart replaces the current process image with a fresh copy of the same
+// binary. On success it never returns, so the listening socket is handed over
+// atomically and there is nothing for the successor to wait on.
+func execRestart(exe string, args []string, env []string) error {
+	return syscall.Exec(exe, args, env)
+}

--- a/internal/tarsserver/restart_exec_windows.go
+++ b/internal/tarsserver/restart_exec_windows.go
@@ -1,0 +1,45 @@
+//go:build windows
+
+package tarsserver
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// execRestart starts a successor process and exits.
+//
+// Windows has no execve: syscall.Exec exists only as a stub that always returns
+// EWINDOWS, so the unix path would leave the server dead. Spawning instead
+// means predecessor and successor are briefly alive at the same time and the
+// old process still owns the API port, so the successor is told to wait for the
+// port before binding (see restartPredecessorEnv).
+//
+// This function does not return on success — the process exits so the port is
+// released as soon as possible.
+func execRestart(exe string, args []string, env []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("restart requires at least the program name in args")
+	}
+
+	cmd := exec.Command(exe, args[1:]...)
+	cmd.Env = append(append([]string{}, env...), restartPredecessorEnv+"="+fmt.Sprint(os.Getpid()))
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	// A new process group keeps a Ctrl-C in the old console from reaching the
+	// successor before it has finished starting up.
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windows.CREATE_NEW_PROCESS_GROUP}
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	if err := cmd.Process.Release(); err != nil {
+		return err
+	}
+	os.Exit(0)
+	return nil
+}

--- a/internal/tarsserver/restart_handoff.go
+++ b/internal/tarsserver/restart_handoff.go
@@ -18,8 +18,9 @@ const restartPredecessorEnv = "TARS_RESTART_PREDECESSOR_PID"
 
 // restartHandoffTimeout bounds the wait so a predecessor that refuses to die
 // cannot wedge the successor indefinitely — better to attempt the bind and fail
-// loudly with "address already in use" than to hang with no output.
-const restartHandoffTimeout = 10 * time.Second
+// loudly with "address already in use" than to hang with no output. A variable
+// so tests can exercise the timeout without waiting on it.
+var restartHandoffTimeout = 10 * time.Second
 
 // restartHandoffPollInterval is short enough that a normal handoff (the
 // predecessor exits within milliseconds of spawning us) costs one poll.

--- a/internal/tarsserver/restart_handoff.go
+++ b/internal/tarsserver/restart_handoff.go
@@ -1,0 +1,58 @@
+package tarsserver
+
+import (
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// restartPredecessorEnv marks a process as the successor of a restart handoff.
+// Only the Windows execRestart sets it: there the predecessor is still running
+// (and still holding the API port) when the successor starts. The unix path
+// replaces the process image, so the variable is never set and the wait below
+// is skipped.
+const restartPredecessorEnv = "TARS_RESTART_PREDECESSOR_PID"
+
+// restartHandoffTimeout bounds the wait so a predecessor that refuses to die
+// cannot wedge the successor indefinitely — better to attempt the bind and fail
+// loudly with "address already in use" than to hang with no output.
+const restartHandoffTimeout = 10 * time.Second
+
+// restartHandoffPollInterval is short enough that a normal handoff (the
+// predecessor exits within milliseconds of spawning us) costs one poll.
+const restartHandoffPollInterval = 50 * time.Millisecond
+
+// awaitPredecessorExit blocks until addr is bindable, when this process was
+// started as the successor of a restart. It is a no-op otherwise.
+//
+// It probes the port rather than the predecessor's PID because the port is what
+// actually blocks startup: the predecessor may have already exited while the
+// socket is still being torn down.
+func awaitPredecessorExit(addr string, logger zerolog.Logger) {
+	pid := strings.TrimSpace(os.Getenv(restartPredecessorEnv))
+	if pid == "" {
+		return
+	}
+	// Clear it so a later restart of *this* process does not inherit the marker
+	// and wait on a predecessor that is long gone.
+	_ = os.Unsetenv(restartPredecessorEnv)
+
+	deadline := time.Now().Add(restartHandoffTimeout)
+	for {
+		ln, err := net.Listen("tcp", addr)
+		if err == nil {
+			_ = ln.Close()
+			logger.Info().Str("addr", addr).Str("predecessor_pid", pid).Msg("restart handoff complete")
+			return
+		}
+		if time.Now().After(deadline) {
+			logger.Warn().Str("addr", addr).Str("predecessor_pid", pid).Err(err).
+				Msg("predecessor still holds the api port; binding anyway")
+			return
+		}
+		time.Sleep(restartHandoffPollInterval)
+	}
+}

--- a/internal/tarsserver/restart_handoff_test.go
+++ b/internal/tarsserver/restart_handoff_test.go
@@ -1,0 +1,81 @@
+package tarsserver
+
+import (
+	"io"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// freeAddress returns an address nothing is listening on.
+func freeAddress(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve address: %v", err)
+	}
+	addr := listener.Addr().String()
+	if err := listener.Close(); err != nil {
+		t.Fatalf("release address: %v", err)
+	}
+	return addr
+}
+
+func TestAwaitPredecessorExitIsNoOpWithoutMarker(t *testing.T) {
+	if _, ok := os.LookupEnv(restartPredecessorEnv); ok {
+		t.Fatalf("%s leaked into the test environment", restartPredecessorEnv)
+	}
+	// A busy address proves this returned without probing: had it waited, it
+	// would have blocked until the timeout.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	done := make(chan struct{})
+	go func() {
+		awaitPredecessorExit(listener.Addr().String(), zerolog.New(io.Discard))
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected an immediate return when the marker is unset")
+	}
+}
+
+func TestAwaitPredecessorExitReturnsOncePortIsFree(t *testing.T) {
+	t.Setenv(restartPredecessorEnv, "4242")
+	addr := freeAddress(t)
+
+	awaitPredecessorExit(addr, zerolog.New(io.Discard))
+
+	// The marker is cleared so a later restart of this process does not wait on
+	// a predecessor that is long gone.
+	if value, ok := os.LookupEnv(restartPredecessorEnv); ok {
+		t.Fatalf("expected the marker to be cleared, still set to %q", value)
+	}
+}
+
+func TestAwaitPredecessorExitGivesUpWhenPortStaysBusy(t *testing.T) {
+	t.Setenv(restartPredecessorEnv, "4242")
+	previous := restartHandoffTimeout
+	restartHandoffTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { restartHandoffTimeout = previous })
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	started := time.Now()
+	awaitPredecessorExit(listener.Addr().String(), zerolog.New(io.Discard))
+	if elapsed := time.Since(started); elapsed > 5*time.Second {
+		t.Fatalf("expected the wait to be bounded, took %s", elapsed)
+	}
+}

--- a/internal/tool/apply_patch.go
+++ b/internal/tool/apply_patch.go
@@ -66,11 +66,16 @@ func NewApplyPatchTool(workspaceDir string, enabled bool) Tool {
 				}
 			}
 
+			patchPath, err := patchExecutable()
+			if err != nil {
+				return JSONTextResult(applyPatchResponse{Message: err.Error()}, true), nil
+			}
+
 			args := []string{"-p0", "-u", "--forward", "--batch"}
 			if input.DryRun {
 				args = append(args, "--dry-run")
 			}
-			cmd := exec.CommandContext(ctx, "/usr/bin/patch", args...)
+			cmd := exec.CommandContext(ctx, patchPath, args...)
 			cmd.Dir = workspaceDir
 			cmd.Stdin = strings.NewReader(input.Patch)
 			var stdout bytes.Buffer

--- a/internal/tool/patch_path.go
+++ b/internal/tool/patch_path.go
@@ -1,0 +1,37 @@
+package tool
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+)
+
+// ErrPatchUnavailable reports that the patch utility could not be located.
+// apply_patch surfaces it as its own message so the caller sees a missing
+// dependency rather than a patch that appeared to run and fail.
+var ErrPatchUnavailable = errors.New("patch utility not found")
+
+// patchExecutable returns the absolute path of the patch utility, resolved
+// once per process. Like git.Executable and shellexec.Executable, it never
+// returns a bare name for the OS to resolve at exec time.
+var patchExecutable = sync.OnceValues(resolvePatchExecutable)
+
+func resolvePatchExecutable() (string, error) {
+	if defaultPatchPath != "" {
+		if info, err := os.Stat(defaultPatchPath); err == nil && !info.IsDir() {
+			return defaultPatchPath, nil
+		}
+	}
+	if path, err := exec.LookPath("patch"); err == nil && filepath.IsAbs(path) {
+		return path, nil
+	}
+	for _, path := range bundledPatchPaths() {
+		if info, err := os.Stat(path); err == nil && !info.IsDir() {
+			return path, nil
+		}
+	}
+	return "", fmt.Errorf("%w: install patch or a git distribution that bundles it", ErrPatchUnavailable)
+}

--- a/internal/tool/patch_path.go
+++ b/internal/tool/patch_path.go
@@ -3,10 +3,9 @@ package tool
 import (
 	"errors"
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"sync"
+
+	"github.com/devlikebear/tars/internal/exepath"
 )
 
 // ErrPatchUnavailable reports that the patch utility could not be located.
@@ -15,23 +14,17 @@ import (
 var ErrPatchUnavailable = errors.New("patch utility not found")
 
 // patchExecutable returns the absolute path of the patch utility, resolved
-// once per process. Like git.Executable and shellexec.Executable, it never
-// returns a bare name for the OS to resolve at exec time.
+// once per process.
 var patchExecutable = sync.OnceValues(resolvePatchExecutable)
 
 func resolvePatchExecutable() (string, error) {
-	if defaultPatchPath != "" {
-		if info, err := os.Stat(defaultPatchPath); err == nil && !info.IsDir() {
-			return defaultPatchPath, nil
-		}
+	path, err := exepath.Resolve(exepath.Candidates{
+		DefaultPath: defaultPatchPath,
+		LookupNames: []string{"patch"},
+		Fallbacks:   bundledPatchPaths,
+	})
+	if err != nil {
+		return "", fmt.Errorf("%w: %v: install patch or a git distribution that bundles it", ErrPatchUnavailable, err)
 	}
-	if path, err := exec.LookPath("patch"); err == nil && filepath.IsAbs(path) {
-		return path, nil
-	}
-	for _, path := range bundledPatchPaths() {
-		if info, err := os.Stat(path); err == nil && !info.IsDir() {
-			return path, nil
-		}
-	}
-	return "", fmt.Errorf("%w: install patch or a git distribution that bundles it", ErrPatchUnavailable)
+	return path, nil
 }

--- a/internal/tool/patch_path_unix.go
+++ b/internal/tool/patch_path_unix.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package tool
+
+// defaultPatchPath keeps the previous hardcoded location, so resolution
+// normally stops here and unix behaviour is unchanged.
+const defaultPatchPath = "/usr/bin/patch"
+
+// bundledPatchPaths has nothing to add on unix: patch is a system utility, not
+// something shipped inside another tool's installation.
+func bundledPatchPaths() []string { return nil }

--- a/internal/tool/patch_path_windows.go
+++ b/internal/tool/patch_path_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package tool
+
+import (
+	"path/filepath"
+
+	gitrepo "github.com/devlikebear/tars/internal/git"
+)
+
+// Windows has no system patch utility, so there is no default path to try.
+const defaultPatchPath = ""
+
+// bundledPatchPaths looks for the patch.exe that Git for Windows installs
+// under <root>\usr\bin, which is normally present but absent from PATH. See
+// git.InstallRoots.
+func bundledPatchPaths() []string {
+	var paths []string
+	for _, root := range gitrepo.InstallRoots() {
+		paths = append(paths, filepath.Join(root, "usr", "bin", "patch.exe"))
+	}
+	return paths
+}

--- a/internal/tool/patch_unavailable_test.go
+++ b/internal/tool/patch_unavailable_test.go
@@ -1,0 +1,37 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestApplyPatchReportsMissingPatchUtility covers the branch that turns a
+// missing dependency into its own message. Without it the tool reported
+// "patch apply failed", which reads as though the patch text were bad.
+func TestApplyPatchReportsMissingPatchUtility(t *testing.T) {
+	previous := patchExecutable
+	patchExecutable = func() (string, error) {
+		return "", fmt.Errorf("%w: nothing installed", ErrPatchUnavailable)
+	}
+	t.Cleanup(func() { patchExecutable = previous })
+
+	tool := NewApplyPatchTool(t.TempDir(), true)
+	params := json.RawMessage(`{"patch":"--- a/x.txt\n+++ b/x.txt\n@@ -0,0 +1 @@\n+hello\n"}`)
+	result, err := tool.Execute(context.Background(), params)
+	if err != nil {
+		t.Fatalf("execute apply_patch: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected an error result when patch is unavailable")
+	}
+	if text := result.Text(); !strings.Contains(text, ErrPatchUnavailable.Error()) {
+		t.Fatalf("expected the message to name the missing utility, got %q", text)
+	}
+	if errors.Is(err, ErrPatchUnavailable) {
+		t.Fatal("the tool reports through its result, not a Go error")
+	}
+}

--- a/internal/tool/tool_subagents_plan.go
+++ b/internal/tool/tool_subagents_plan.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
+	"path"
 	"regexp"
 	"strings"
 	"time"
@@ -624,8 +624,14 @@ func normalizePlannerTarget(value string) string {
 	if !strings.Contains(target, "/") {
 		return ""
 	}
-	cleaned := filepath.Clean(target)
-	if cleaned == "." || cleaned == string(filepath.Separator) {
+	// path, not filepath: a target is only recognised as one because it
+	// contains a forward slash (above), it is matched against prompt text, and
+	// it is injected verbatim into a task prompt as the exact path to touch.
+	// filepath.Clean would rewrite "/etc/nginx/nginx.conf" to
+	// "\etc\nginx\nginx.conf" on Windows, which no longer matches the prompt it
+	// came from and is not the path the model should be told to edit.
+	cleaned := path.Clean(target)
+	if cleaned == "." || cleaned == "/" {
 		return ""
 	}
 	return cleaned
@@ -652,8 +658,8 @@ func ensurePlannerTargetsInPlan(plan *subagentFlowInput, targets []string) int {
 
 func plannerTaskForTarget(plan *subagentFlowInput, target string) *subagentFlowTaskInput {
 	var fallback *subagentFlowTaskInput
-	targetBase := strings.ToLower(strings.TrimSpace(filepath.Base(target)))
-	targetDir := strings.ToLower(strings.TrimSpace(filepath.Base(filepath.Dir(target))))
+	targetBase := strings.ToLower(strings.TrimSpace(path.Base(target)))
+	targetDir := strings.ToLower(strings.TrimSpace(path.Base(path.Dir(target))))
 	bestScore := -1
 	var best *subagentFlowTaskInput
 

--- a/internal/workstore/maintenance.go
+++ b/internal/workstore/maintenance.go
@@ -1194,15 +1194,6 @@ func quarantinePaths(dir, sourcePath, digest string, timestamp time.Time) (strin
 	return copyPath, copyPath + ".manifest.json"
 }
 
-func syncDirectory(path string) error {
-	directory, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = directory.Close() }()
-	return directory.Sync()
-}
-
 func removeFile(path string) {
 	_ = os.Remove(path)
 }

--- a/internal/workstore/maintenance.go
+++ b/internal/workstore/maintenance.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -988,7 +987,10 @@ func verifyMigrationsDB(ctx context.Context, db *sql.DB, requireCurrent bool) er
 }
 
 func validateSQLiteFile(ctx context.Context, path string) error {
-	dsnURL := &url.URL{Scheme: "file", Path: path}
+	dsnURL, err := sqliteFileURL(path)
+	if err != nil {
+		return err
+	}
 	query := dsnURL.Query()
 	query.Set("mode", "ro")
 	query.Add("_pragma", "foreign_keys(1)")

--- a/internal/workstore/sqlite_dsn_test.go
+++ b/internal/workstore/sqlite_dsn_test.go
@@ -1,0 +1,48 @@
+package workstore
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSQLiteFileURLHasNoHostAndAnAbsolutePath pins the shape that was wrong on
+// Windows: url.URL{Scheme: "file", Path: `C:\dir\ledger.db`} put the drive
+// letter in the host and percent-encoded every separator, so SQLite could not
+// open the database at all.
+func TestSQLiteFileURLHasNoHostAndAnAbsolutePath(t *testing.T) {
+	dsnURL, err := sqliteFileURL(filepath.Join(t.TempDir(), "ledger.db"))
+	if err != nil {
+		t.Fatalf("build dsn: %v", err)
+	}
+	if dsnURL.Scheme != "file" {
+		t.Fatalf("scheme = %q, want file", dsnURL.Scheme)
+	}
+	if dsnURL.Host != "" {
+		t.Fatalf("host = %q, want empty (a drive letter must not become the host)", dsnURL.Host)
+	}
+	if !strings.HasPrefix(dsnURL.Path, "/") {
+		t.Fatalf("path = %q, want a leading slash", dsnURL.Path)
+	}
+	if strings.Contains(dsnURL.Path, `\`) {
+		t.Fatalf("path = %q, want forward slashes only", dsnURL.Path)
+	}
+	if dsn := dsnURL.String(); !strings.HasPrefix(dsn, "file:///") {
+		t.Fatalf("dsn = %q, want a file:/// prefix", dsn)
+	}
+}
+
+func TestSQLiteFileURLResolvesRelativePaths(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	dsnURL, err := sqliteFileURL("ledger.db")
+	if err != nil {
+		t.Fatalf("build dsn: %v", err)
+	}
+	if !strings.HasPrefix(dsnURL.Path, "/") {
+		t.Fatalf("path = %q, want an absolute path", dsnURL.Path)
+	}
+	if !strings.HasSuffix(dsnURL.Path, "/ledger.db") {
+		t.Fatalf("path = %q, want it to end at the requested file", dsnURL.Path)
+	}
+}

--- a/internal/workstore/store.go
+++ b/internal/workstore/store.go
@@ -457,6 +457,28 @@ var schemaMigrations = []struct {
 	{version: 7, sql: migrationV7},
 }
 
+// sqliteFileURL builds the file: URI SQLite expects for path.
+//
+// Constructing it as url.URL{Scheme: "file", Path: path} breaks on Windows:
+// `C:\dir\ledger.db` renders as file://C:%5Cdir%5Cledger.db, where the drive
+// letter parses as the URI host and every separator is percent-encoded, so the
+// database cannot be opened at all. A file URI wants forward slashes and a
+// leading one ahead of the drive letter: file:///C:/dir/ledger.db.
+//
+// On unix the absolute path already starts with a slash and ToSlash is a
+// no-op, so the resulting DSN is byte-for-byte what it was before.
+func sqliteFileURL(path string) (*url.URL, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("workstore: resolve database path: %w", err)
+	}
+	uriPath := filepath.ToSlash(absolute)
+	if !strings.HasPrefix(uriPath, "/") {
+		uriPath = "/" + uriPath
+	}
+	return &url.URL{Scheme: "file", Path: uriPath}, nil
+}
+
 func Open(ctx context.Context, path string, opts Options) (*Store, error) {
 	if strings.TrimSpace(path) == "" {
 		return nil, fmt.Errorf("workstore: database path is required")
@@ -475,7 +497,10 @@ func Open(ctx context.Context, path string, opts Options) (*Store, error) {
 		return nil, fmt.Errorf("workstore: secure database permissions: %w", err)
 	}
 
-	dsnURL := &url.URL{Scheme: "file", Path: path}
+	dsnURL, err := sqliteFileURL(path)
+	if err != nil {
+		return nil, err
+	}
 	query := dsnURL.Query()
 	query.Add("_pragma", "foreign_keys(1)")
 	query.Add("_pragma", "busy_timeout(5000)")

--- a/internal/workstore/sync_directory_unix.go
+++ b/internal/workstore/sync_directory_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package workstore
+
+import "os"
+
+// syncDirectory flushes a directory entry to disk.
+//
+// Renaming a temporary file over its destination is only atomic once the
+// directory entry itself is durable, so publishTemporaryFile fsyncs the parent
+// directory after the rename. Without it a crash can leave the ledger's backup
+// or export directory referencing a file that never made it to disk.
+func syncDirectory(path string) error {
+	directory, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = directory.Close() }()
+	return directory.Sync()
+}

--- a/internal/workstore/sync_directory_windows.go
+++ b/internal/workstore/sync_directory_windows.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package workstore
+
+import "os"
+
+// syncDirectory verifies the directory but does not flush it, because Windows
+// has no equivalent of the POSIX directory fsync.
+//
+// os.Open on a directory yields a read-only handle, and FlushFileBuffers needs
+// write access, so the unix implementation fails outright here with "Access is
+// denied" — which took every backup, export, and quarantine operation with it.
+// Skipping the flush is not a durability regression: NTFS journals the
+// metadata change that publishes the rename, so there is no directory entry
+// left for user space to force out. Go databases such as bbolt and etcd make
+// the same call.
+//
+// The Stat is kept so a caller naming a directory that does not exist still
+// gets an error rather than a silent success.
+func syncDirectory(path string) error {
+	if _, err := os.Stat(path); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Makes `cmd/tars` build and run on Windows. The module was unix-only, and once it compiled a series of hardcoded unix paths and POSIX-only assumptions surfaced behind it. Each is split behind build tags following the existing `internal/llm/claude_code_cli_{unix,windows}.go` pattern; unix behaviour is unchanged throughout.

| Commit | Fix |
|---|---|
| `05793fe4` | `setsid`, `statfs`, `ps`, and `execve` split per platform; `Makefile` honours `GOEXE`; `.gitattributes` pins the tree to LF |
| `5aedb64f` | Resolve git instead of hardcoding `/usr/bin/git` |
| `98e7eae1` | Resolve a POSIX shell instead of hardcoding `/bin/sh` |
| `8087c5e5` | Resolve patch instead of hardcoding `/usr/bin/patch` |
| `3282ff4d` | Keep planner targets as slash paths (`path`, not `filepath`) |
| `e90299ee` | Build a valid `file:` URI for the SQLite DSN |
| `fdb17614` | Skip the directory fsync Windows cannot perform |

Two of these are not Windows-only cosmetics:

- **SQLite DSN** — `url.URL{Scheme: "file", Path: path}` rendered `C:\dir\ledger.db` as `file://C:%5Cdir%5Cledger.db`, so the drive letter parsed as the URI host and the durable work ledger could not be opened at all.
- **Planner targets** — `filepath.Clean` rewrote `/etc/nginx/nginx.conf` to `\etc\nginx\nginx.conf`. These strings go into task prompts and are matched against prompt text, so the containment check missed and a contradictory "Required exact target path" block was appended.

`windows-build-check` widens from `./pkg/...` to `./...`. CI runs on Linux only, so that target is what keeps unix-only syscalls from creeping back in.

### Behaviour notes

- Executable resolution keeps the reason the paths were hardcoded: the result must be absolute, never a bare name for the OS to resolve at exec time. Unix tries the original absolute path first, so nothing changes where it exists.
- Windows shell resolution deliberately does **not** fall back to `cmd.exe`. The strings involved are POSIX shell script, and `cmd.exe` would mis-execute rather than fail cleanly. Git for Windows bundles `sh.exe` but keeps it off PATH, so `git.InstallRoots` locates it from the resolved git binary.
- The Windows restart path spawns a successor and exits, since Windows has no `execve` (`syscall.Exec` is a stub returning `EWINDOWS`). The successor waits for the API port before binding, because predecessor and successor briefly overlap.
- Skipping the directory fsync on Windows is not a durability regression: NTFS journals the metadata change that publishes the rename. bbolt and etcd resolve it the same way.

## Test plan

- [x] `make vet`
- [x] `go build ./...` for windows, linux, and darwin
- [x] `make windows-build-check` (now the full module)
- [x] `make build` on Windows produces a running `bin/tars.exe`
- [x] `go vet ./...` under `GOOS=linux` and `GOOS=darwin`
- [ ] `make test` on Linux — **not run locally**, no Linux environment available on this machine; CI is the gate

Windows test results, measured against the pre-change commit in a scratch worktree so improvements are attributable:

| Package | Before | After |
|---|---|---|
| `internal/git` | 9 failing | green |
| `internal/skillhub` | failing | green |
| `internal/tool` | 7 failing | green |
| `internal/a2a` | failing | green |
| `internal/ops` | 6 failing | 2 failing |
| `internal/workstore` | all failing | 3 failing |
| `internal/onboarding` | skipped on Windows | green, no longer skipped |

Three tests were asserting things they could not reach on Windows and are fixed here: a JSON body built by concatenation (backslashes are invalid JSON escapes, so a workspace-containment check returned 400 before ever running), a shell command with an unquoted path, and a byte-exact file comparison that inherited the developer's `core.autocrlf`.

## Not addressed

- **File mode assertions** (`0600` vs `0666`) — `os.Chmod` on Windows only toggles the read-only bit, so owner-only intent is not expressed. Real ACL work, or an honest skip; wanted a decision before choosing.
- **Web terminal** — `creack/pty` returns `ErrUnsupported` on Windows. Needs ConPTY, not a shell path change, so its `/bin/sh` fallback is deliberately untouched.
- **Symlink tests** — creating symlinks on Windows needs Developer Mode or elevation.
- **`internal/workscheduler`** — passes standalone but fails in a full package run and hangs on repeat. Looks like a pre-existing timing or deadlock issue; not confirmed, and not touched here.
- **Artifact URIs** — `executionplane` and `workerprotocol` build `file:` URIs the same malformed way, but they are recorded identifiers rather than DSNs, so changing them would alter stored values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)