### PR TITLE
ci: run the Go test suite on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,31 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Cross-compile public packages for Windows
+      - name: Cross-compile the module for Windows
         run: make windows-build-check
+
+  windows-test:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        # The repository's scripts are POSIX sh; bash ships with the runner's
+        # git installation. Without this, steps would run under PowerShell.
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      # Invoked directly rather than through make: GNU Make is not guaranteed
+      # on the Windows runner image, and the script is what developers run
+      # locally anyway.
+      - name: Run Go tests on Windows
+        run: ./scripts/windows_test.sh
 
   test:
     if: github.event_name == 'push'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,8 +170,14 @@ TARS 기능 변경 시 홈페이지 콘텐츠도 갱신 필요 (매 변경마다
 
 `.github/workflows/ci.yml`:
 1. **security** — gitleaks + ripgrep secrets scan
-2. **pr-diff** — pull requests run Svelte console checks, `npm run test:ci`, `make lint-diff` (with new-line `errcheck`/`staticcheck`), and `make test-cover-diff` against the PR base SHA
-3. **test** — pushes to main run Node 24 → frontend console checks/test slice → Playwright → Go test + coverage threshold → Codecov
+2. **windows-build** — `make windows-build-check`, cross-compiling the whole module for Windows on ubuntu
+3. **windows-test** — `scripts/windows_test.sh` on `windows-latest`. The only job that runs tests on Windows; everything else is Linux
+4. **pr-diff** — pull requests run Svelte console checks, `npm run test:ci`, `make lint-diff` (with new-line `errcheck`/`staticcheck`), and `make test-cover-diff` against the PR base SHA
+5. **test** — pushes to main run Node 24 → frontend console checks/test slice → Playwright → Go test + coverage threshold → Codecov
+
+`scripts/windows_test.sh` carries two lists of Windows-failing tests — packages excluded wholesale, and individual tests skipped in otherwise-green packages. **Both are debt, not policy**: shrink them rather than adding to them. Reproduce the job locally on Windows with `make windows-test`.
+
+Note that the Linux-only test jobs cannot cover `*_windows.go` files at all, so SonarCloud's `new_coverage` gate reads low on PRs that add platform-split code.
 
 `.github/workflows/codeql.yml`:
 1. **Analyze (go)** — CodeQL autobuild + analysis for Go source

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ AGENT_HARNESS_COMMIT ?= $(GIT_COMMIT)
 .PHONY: help \
 	test test-v test-one test-nocache test-race test-cover test-cover-check test-diff test-cover-diff \
 	agent-harness-eval agent-harness-baseline \
-	build build-bins windows-build-check release-asset clean tidy fmt vet lint \
+	build build-bins windows-build-check windows-test release-asset clean tidy fmt vet lint \
 	lint-diff ci-static-analysis-check github-actions-hardening-check codeql-workflow-check sonarcloud-workflow-check \
 	ensure-console-assets console-install console-build \
 	browser-install \
@@ -105,6 +105,7 @@ help:
 	@echo "  make test-cover-check - require total coverage >= COVER_MIN ($(COVER_MIN)%)"
 	@echo "  make test-diff     - test changed Go packages + coverage check against DIFF_BASE"
 	@echo "  make test-cover-diff - require changed-line coverage >= DIFF_COVER_MIN ($(DIFF_COVER_MIN)%)"
+	@echo "  make windows-test  - run the suite the way the CI Windows job does (run this on Windows)"
 	@echo "  make agent-harness-eval - run the deterministic agent/harness scenario pack"
 	@echo "  make agent-harness-baseline - write versioned JSONL + Markdown baseline reports"
 	@echo ""
@@ -213,6 +214,12 @@ build-bins: ensure-console-assets
 # platform splits in internal/onboarding, internal/ops, and internal/tarsserver.
 windows-build-check:
 	GOOS=windows GOARCH=amd64 $(GO) build ./...
+
+# windows-test runs the suite the way the CI Windows job does. It only means
+# anything when run on Windows — elsewhere it just runs most of the suite with
+# a few tests skipped for no reason.
+windows-test:
+	GO="$(GO)" ./scripts/windows_test.sh
 
 # ensure-console-assets bootstraps the embedded Svelte console only
 # when the dist/ directory is empty (e.g. fresh clone, dev build).

--- a/scripts/windows_test.sh
+++ b/scripts/windows_test.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Runs the Go test suite on Windows.
+#
+# tars builds and runs natively on Windows, but a set of tests still assume a
+# unix host. This script runs everything else, so the Windows job is a real
+# gate that fails on regressions rather than a permanently red job nobody
+# reads. Both lists below are debt, not policy: shrink them.
+#
+# Run it the same way CI does:
+#   ./scripts/windows_test.sh
+set -euo pipefail
+
+GO="${GO:-go}"
+TEST_TIMEOUT="${TEST_TIMEOUT:-300s}"
+
+# Packages whose Windows failures are broad enough that listing individual
+# tests would be unmaintainable. Excluding a package loses its passing tests
+# too, so prefer SKIPPED_TESTS whenever the count is small.
+#
+# internal/workscheduler must stay here for a different reason: it does not
+# fail on Windows, it hangs, and a hang costs the runner its whole timeout.
+EXCLUDED_PACKAGES=(
+  github.com/devlikebear/tars/cmd/tars                 # init/service/doctor assume launchd and unix workspace layout
+  github.com/devlikebear/tars/internal/agentruntime    # command executor timeouts and effect receipt file modes
+  github.com/devlikebear/tars/internal/auth            # credential files asserted at mode 0600
+  github.com/devlikebear/tars/internal/executionplane  # artifact URIs, symlinks, and POSIX runner assumptions
+  github.com/devlikebear/tars/internal/llm             # claude-code-cli tests drive POSIX shell script stubs
+  github.com/devlikebear/tars/internal/tarsserver      # sandboxes that shell out, plus macOS/Linux notifier paths
+  github.com/devlikebear/tars/internal/workerprotocol  # ssh/container/symlink policy assumptions
+  github.com/devlikebear/tars/internal/workscheduler   # hangs on Windows — see the note above
+)
+
+# Individual tests in packages that otherwise pass. Verified causes:
+#   * mode 0600 assertions — Windows Chmod only toggles the read-only bit, so
+#     a file's mode always reads back as 0666.
+#   * read-only directory negative tests — Windows still permits creating
+#     files inside a directory marked read-only.
+#   * symlink creation — needs Developer Mode or elevation on Windows.
+SKIPPED_TESTS=(
+  TestWrite_DoesNotCorruptOnReadOnlyDir                                        # read-only directory
+  TestManager_UpdateApprovalStatus_SetsReviewedAtAndPersists                   # mode 0600
+  TestManager_SaveApprovalsPreservesExistingFileWhenAtomicTempCannotBeCreated  # read-only directory
+  TestOpenAppliesSchemaWALAndForeignKeys                                       # mode 0600
+  TestQuarantineSourceCopiesWithoutDeletingOriginalAndIsIdempotent             # mode 0600
+  TestBackupAndRestorePreserveCommittedWALState                                # mode 0600
+  TestTracker_UpdateLimitsWritesPrivateFile                                    # mode 0600
+  TestTracker_UpdateLimitsPreservesExistingFileAndMemoryWhenAtomicTempCannotBeCreated # read-only directory
+  TestEngineRejectsArtifactAccessThroughEscapingDirectorySymlink               # symlink privilege
+  TestEngineVerifiesConfinedArtifactTreesAndExpectedDigests                    # symlink privilege
+  TestAppendInboxCandidateAndReviewActions                                     # unexamined
+  TestExtractionInboxAppendListAndReview                                       # unexamined
+  TestMirrorToWorkspace_CompanionFiles                                         # unexamined
+)
+
+packages="$("${GO}" list ./...)"
+for excluded in "${EXCLUDED_PACKAGES[@]}"; do
+  packages="$(printf '%s\n' "${packages}" | grep -vxF "${excluded}" || true)"
+done
+
+if [[ -z "${packages}" ]]; then
+  echo "no packages left to test after exclusions" >&2
+  exit 1
+fi
+
+skip_pattern="$(printf '%s|' "${SKIPPED_TESTS[@]}")"
+skip_pattern="^(${skip_pattern%|})$"
+
+echo "Running $(printf '%s\n' "${packages}" | wc -l | tr -d '[:space:]') packages, skipping ${#SKIPPED_TESTS[@]} tests"
+
+# shellcheck disable=SC2086 # packages is a newline-separated list meant to split
+exec "${GO}" test -timeout "${TEST_TIMEOUT}" -skip "${skip_pattern}" ${packages}


### PR DESCRIPTION
## Summary

Nothing ran tests on Windows. `windows-build` cross-compiles from ubuntu, which catches unix-only syscalls but not behaviour — so every Windows fix in #914 was verified by hand, and nothing stops them regressing.

Adds a `windows-test` job on `windows-latest` driving `scripts/windows_test.sh`.

**49 of 64 packages pass on Windows as-is.** The remaining 15 are split by how they fail:

- **8 packages excluded wholesale** — 102 failing tests between them; listing those individually would be unmaintainable.
- **13 tests skipped** in 7 packages that otherwise pass — this keeps those packages under the gate rather than losing their passing tests too.

`internal/workscheduler` is excluded for a different reason: it **hangs** rather than fails, and a hang costs the runner its entire timeout. That is a real bug, filed as a follow-up below.

### Why a script instead of inline `go test`

It carries the two lists with their reasons, and it lets a developer reproduce the job locally with `make windows-test` instead of reverse-engineering YAML.

### Skip reasons

Verified, not guessed:

- **mode 0600 assertions** — Windows `Chmod` only toggles the read-only bit, so a file's mode always reads back `0666`.
- **read-only directory negative tests** — Windows still permits creating files inside a directory marked read-only, so the failure the test expects never happens.
- **symlink creation** — needs Developer Mode or elevation.

Three entries are marked `unexamined` rather than given a cause I had not confirmed.

## Test plan

- [x] `./scripts/windows_test.sh` on Windows 11 — exit 0, all selected packages green
- [x] `make ci-static-analysis-check`
- [x] `make github-actions-hardening-check`
- [x] `make codeql-workflow-check`
- [x] `make sonarcloud-workflow-check`
- [ ] The job itself on a GitHub `windows-latest` runner — this PR is the first run

Also fixes two smaller things found on the way: the `windows-build` step was still named "Cross-compile **public packages** for Windows" after #914 widened it to the whole module, and `scripts/windows_test.sh` needed an explicit `100755` mode in the index — committed from Windows it would have landed `100644` and failed to execute.

## Follow-ups this makes visible

Both lists in the script are debt, not policy, and CLAUDE.md now says so. In rough order of value:

1. **`internal/workscheduler` hangs on Windows** — passes standalone, fails in a full package run, hangs on repeat. Deadlock or timing; unexamined.
2. **File mode assertions** — `os.Chmod` cannot express owner-only on Windows. Either implement a real ACL or make the assertions honest per-platform. This is the largest single group across `ops`, `workstore`, `usage`, `atomicwrite`, `auth`.
3. The three `unexamined` skips in `memory` and `skill`.

Note that a Linux test job cannot cover `*_windows.go` files at all, which is why SonarCloud's `new_coverage` gate reads low on PRs that add platform-split code. This job does not change that — Sonar analyses source text, not the compiled set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)