### PR TITLE
feat(llm): add an Antigravity CLI provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ cd frontend/console && npm run test:ci # stable frontend CI test slice
 | `pulse` | Watchdog (1-min): cron failures, stuck runs, disk, telegram, reflection → `pulse_decide` |
 | `reflection` | Nightly (02:00-05:00): experience extraction + empty session cleanup |
 | `ops` | System health, cleanup planning + approval workflow |
-| `llm` | Provider abstraction (anthropic/openai/openai-codex/gemini/gemini-native/claude-code-cli) + 3-tier Router |
+| `llm` | Provider abstraction (anthropic/openai/openai-codex/gemini/gemini-native/claude-code-cli/antigravity-cli) + 3-tier Router |
 | `memory` | Semantic: Gemini embeddings, cosine similarity, JSONL entries |
 | `tool` | Built-in tools: file ops, exec, web fetch/search, agent runtime, telegram, memory |
 | `serverauth` | Bearer token auth, SHA256, three tiers (legacy/user/admin), loopback bypass |
@@ -67,6 +67,17 @@ cd frontend/console && npm run test:ci # stable frontend CI test slice
 - Permission mode: `llm.claude_code_cli.permission_mode` (`auto`/`default`/`acceptEdits`/`plan`/`dontAsk`/`bypassPermissions`) → `--permission-mode`. 빈 값/오타는 `auto`로 graceful degrade
 - Durable coding harness: `work_ledger.scheduler.external_harness.config_path`가 비어 있지 않을 때만 `claude-code` scheduler adapter를 등록한다. owner-only JSON은 workspace 밖에 두고, 실행은 별도 managed worktree에서 `--safe-mode --strict-mcp-config --no-chrome --permission-mode dontAsk`와 scoped tool/turn/cost 제한을 강제한다. 로컬 Claude 인증은 재사용하지만 임의 env/argv/MCP/plugin/credential 주입은 허용하지 않는다
 - **단일 사용자 전용**: Agent SDK 크레딧이 개인 계정 귀속이라 다중 사용자 서버로는 부적합. claude.ai 로그인을 외부에 *제공*하는 형태로 노출 금지(Anthropic 정책)
+
+**antigravity-cli provider:**
+- 로컬 `agy` CLI 재사용. `agy --output-format stream-json --print <text>`로 헤드리스 호출하고 중첩 NDJSON 이벤트(`init`/`step_update`/`result`)를 파싱한다. 최소 지원 프로토콜은 CLI 1.1.8에서 도입됐다
+- **자격증명이 TARS를 통과하지 않는다**: CLI가 시스템 키링의 자기 Google 로그인을 쓰므로 `api_key`/`base_url`이 없다. 사용자는 먼저 대화형 `agy`에서 인증해야 한다
+- 시스템 프롬프트 플래그가 없어서 system 메시지를 프롬프트 앞 블록으로 접어 넣는다
+- **세션 재개 지원**: stream의 `conversation_id`를 `ChatResponse.SessionID`에 싣고 다음 턴 `--conversation <id>`로 넘긴다. 재개 턴에는 저장된 과거 transcript/system block을 다시 보내지 않는다
+- `ReasoningEffort` → `--effort low|medium|high`, JSON schema 응답 → `--json-schema`. 모델은 `agy models`가 보여주는 slug를 tier에 명시하고 TARS는 변동 가능한 기본 모델을 하드코딩하지 않는다
+- `AGY_CLI_MODE`는 `accept-edits`/`plan`만 허용한다. 오타·미인식 값은 flag를 생략해 CLI의 기본 permission policy로 떨어지고, `--dangerously-skip-permissions`로 승격하는 경로는 의도적으로 없다
+- 도구는 CLI 것이며 TARS tool registry로 재실행하지 않는다. 실행 기록은 `ProviderExecutedTools`에 observation-only로 올린다. 실제 권한은 사용자의 Antigravity 설정이 결정한다
+- `AGY_CLI_PATH` / `AGY_CLI_TIMEOUT` / `AGY_CLI_MODE`이 provider 환경 override다
+- 테스트는 stream 파서가 순수 함수라 서브프로세스 없이 검증한다 — POSIX 셸 스텁이 필요한 claude-code-cli 테스트와 달리 Windows에서도 돌아간다
 
 **Extension pattern — IMPORTANT:**
 - **Do NOT add domain features as builtin Go tools or MCP tools** — every registered tool inflates system prompt on every chat turn

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -11,7 +11,8 @@ llm:
   # Each alias defines "where to call + how to authenticate" — no model
   # here. At minimum one provider must be defined. Credentials come
   # from environment variables. Supported kinds: anthropic, openai,
-  # kimi, openai-codex, gemini, gemini-native, claude-code-cli.
+  # kimi, openai-codex, gemini, gemini-native, claude-code-cli,
+  # antigravity-cli.
   providers:
     codex:
       kind: openai-codex

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -15,30 +15,31 @@ How each `internal/llm` provider handles the fields in `llm.ChatOptions`. Caller
 | `gemini`          | Gemini OpenAI-compat       | `openai_compat_client.go` (label)   |
 | `gemini-native`   | Google Gemini REST         | `gemini_native*.go`                 |
 | `claude-code-cli` | local `claude` CLI         | `claude_code_cli.go`                |
+| `antigravity-cli` | local `agy` CLI            | `antigravity_cli.go`                |
 
 ## ChatOptions × Provider
 
-| Field                        | anthropic | openai | kimi  | openai-codex | gemini (compat) | gemini-native | claude-code-cli |
-|------------------------------|-----------|--------|------|--------------|-----------------|---------------|-----------------|
-| `OnDelta` (streaming)        | ✅        | ✅     | ✅   | ✅           | ✅              | ✅            | ✅              |
-| `Tools`                      | ✅        | ✅     | ✅   | ✅           | ✅              | ✅            | ❌ (silent)     |
-| `ToolChoice` auto/none/required | ✅     | ✅     | ✅   | ✅           | ✅              | ✅            | ❌ (silent)     |
-| `ToolChoice` specific        | ✅        | ✅     | ✅   | ✅           | ✅              | ✅            | ❌ (silent)     |
-| `ResponseFormat` text        | ✅ (default) | ✅  | ✅   | ✅           | ✅              | ❌ (silent)   | ❌ (silent)     |
-| `ResponseFormat` json_object | ❌ (silent) | ✅  | ✅   | ✅           | ✅              | ❌ (silent)   | ❌ (silent)     |
-| `ResponseFormat` json_schema | ❌ (silent) | ✅  | ✅   | ✅           | ✅              | ❌ (silent)   | ❌ (silent)     |
-| `ReasoningEffort`            | ❌ (silent) | ✅  | ✅   | ✅           | ❌ (skipped)    | partial¹      | ❌ (silent)     |
-| `ThinkingBudget`             | ✅        | ❌     | ❌   | ❌           | ❌              | ✅            | ❌ (silent)     |
-| `ServiceTier`                | ❌ (silent) | ✅  | ✅   | ✅           | ❌ (skipped)    | ❌ (silent)   | ❌ (silent)     |
-| `ResumeSessionID`            | ❌ (silent) | ❌  | ❌   | ❌           | ❌              | ❌            | ✅ `--resume`   |
-| `ClaudeCodeMCPServers`       | ❌ (silent) | ❌  | ❌   | ❌           | ❌              | ❌            | ✅ temporary config |
-| `ClaudeCodePermissionMode`   | ❌ (silent) | ❌  | ❌   | ❌           | ❌              | ❌            | ✅ validated mode |
-| `ClaudeCodeSkills`           | ❌ (silent) | ❌  | ❌   | ❌           | ❌              | ❌            | ✅ temporary plugin |
-| `ClaudeCodePermissionDeny`   | ❌ (silent) | ❌  | ❌   | ❌           | ❌              | ❌            | ✅ tightening-only settings |
-| `ClaudeCodeHarness`          | ❌ (silent) | ❌  | ❌   | ❌           | ❌              | ❌            | ✅ safe/tool/budget controls |
-| `ContentBlocks` text         | ✅        | ✅     | ✅   | ✅           | ✅              | ✅            | ❌               |
-| `ContentBlocks` image        | ✅        | ✅     | ✅   | ✅           | ✅              | ✅            | ❌               |
-| `ContentBlocks` document/PDF | ✅        | ⛔ error² | ⛔ error² | ⛔ error²  | ⛔ error²       | partial³      | ❌ (silent)     |
+| Field                        | anthropic | openai | kimi  | openai-codex | gemini (compat) | gemini-native | claude-code-cli | antigravity-cli |
+|------------------------------|-----------|--------|------|--------------|-----------------|---------------|-----------------|-----------------|
+| `OnDelta` (streaming)        | ✅        | ✅     | ✅   | ✅           | ✅              | ✅            | ✅              | ✅ |
+| `Tools`                      | ✅        | ✅     | ✅   | ✅           | ✅              | ✅            | ❌ (silent)     | ❌ (silent) |
+| `ToolChoice` auto/none/required | ✅     | ✅     | ✅   | ✅           | ✅              | ✅            | ❌ (silent)     | ❌ (silent) |
+| `ToolChoice` specific        | ✅        | ✅     | ✅   | ✅           | ✅              | ✅            | ❌ (silent)     | ❌ (silent) |
+| `ResponseFormat` text        | ✅ (default) | ✅  | ✅   | ✅           | ✅              | ❌ (silent)   | ❌ (silent)     | ✅ (default) |
+| `ResponseFormat` json_object | ❌ (silent) | ✅  | ✅   | ✅           | ✅              | ❌ (silent)   | ❌ (silent)     | ❌ (silent) |
+| `ResponseFormat` json_schema | ❌ (silent) | ✅  | ✅   | ✅           | ✅              | ❌ (silent)   | ❌ (silent)     | ✅ `--json-schema` |
+| `ReasoningEffort`            | ❌ (silent) | ✅  | ✅   | ✅           | ❌ (skipped)    | partial¹      | ❌ (silent)     | ✅ `--effort` |
+| `ThinkingBudget`             | ✅        | ❌     | ❌   | ❌           | ❌              | ✅            | ❌ (silent)     | ❌ (silent) |
+| `ServiceTier`                | ❌ (silent) | ✅  | ✅   | ✅           | ❌ (skipped)    | ❌ (silent)   | ❌ (silent)     | ❌ (silent) |
+| `ResumeSessionID`            | ❌ (silent) | ❌  | ❌   | ❌           | ❌              | ❌            | ✅ `--resume`   | ✅ `--conversation` |
+| `ClaudeCodeMCPServers`       | ❌ (silent) | ❌  | ❌   | ❌           | ❌              | ❌            | ✅ temporary config | ❌ (silent) |
+| `ClaudeCodePermissionMode`   | ❌ (silent) | ❌  | ❌   | ❌           | ❌              | ❌            | ✅ validated mode | ❌ (silent) |
+| `ClaudeCodeSkills`           | ❌ (silent) | ❌  | ❌   | ❌           | ❌              | ❌            | ✅ temporary plugin | ❌ (silent) |
+| `ClaudeCodePermissionDeny`   | ❌ (silent) | ❌  | ❌   | ❌           | ❌              | ❌            | ✅ tightening-only settings | ❌ (silent) |
+| `ClaudeCodeHarness`          | ❌ (silent) | ❌  | ❌   | ❌           | ❌              | ❌            | ✅ safe/tool/budget controls | ❌ (silent) |
+| `ContentBlocks` text         | ✅        | ✅     | ✅   | ✅           | ✅              | ✅            | ❌               | ❌ |
+| `ContentBlocks` image        | ✅        | ✅     | ✅   | ✅           | ✅              | ✅            | ❌               | ❌ |
+| `ContentBlocks` document/PDF | ✅        | ⛔ error² | ⛔ error² | ⛔ error²  | ⛔ error²       | partial³      | ❌ (silent)     | ❌ (silent) |
 
 ¹ Gemini-native maps `ReasoningEffort` to `thinkingBudget` heuristically; explicit `ThinkingBudget` overrides.
 ² Returns a `pdf_unsupported_by_provider` ProviderError at build time (RF-046). Convert PDFs to text/images before sending.
@@ -63,6 +64,7 @@ How each `internal/llm` provider handles the fields in `llm.ChatOptions`. Caller
 | openai (Chat)| `response_format: {type:"json_schema", json_schema:{name,schema,strict}}` |
 | kimi (Chat)  | `response_format: {type:"json_schema", json_schema:{name,schema,strict}}` |
 | openai-codex | `text.format: {type:"json_schema", name, schema, strict}` (Responses API flattens) |
+| antigravity-cli | `--json-schema '<schema>'` (applies to terminal `result`) |
 
 The two OpenAI surfaces use different envelopes — `internal/llm` exposes a single `ResponseFormat` struct and each client serializes accordingly.
 
@@ -77,6 +79,43 @@ settings, plugins, MCP servers, or credentials. Stream result events also map
 `num_turns` and `total_cost_usd` into `ChatResponse.Turns` and
 `ChatResponse.Usage.CostUSD` so the durable scheduler can enforce and report
 actual usage.
+
+### Antigravity CLI
+
+`antigravity-cli` shells out to a locally installed `agy` the same way
+`claude-code-cli` shells out to `claude`, via
+`agy --output-format stream-json --print <text>`. The provider targets the
+structured headless protocol introduced in Antigravity CLI 1.1.8.
+
+- **No credential passes through TARS.** `agy` owns its Google login and reads
+  cached credentials from the system keyring. Authenticate once in an
+  interactive `agy` session before using this provider. The kind takes no
+  `api_key` and no `base_url`.
+- **Model selection is explicit.** Use a slug reported by `agy models` in each
+  TARS tier. TARS does not hard-code a default slug because the available set
+  changes with the account and CLI release.
+- **No system-prompt flag.** System messages are folded into a leading prompt
+  block. On resumed turns that block and the old transcript are not replayed.
+- **Resumable sessions.** The stream's `conversation_id` becomes
+  `ChatResponse.SessionID`; subsequent turns pass it through
+  `--conversation`, avoiding transcript replay.
+- **Execution mode fails safe.** `AGY_CLI_MODE` may select `accept-edits` or
+  `plan`. Unknown values omit `--mode`, leaving the CLI's own permission policy
+  in force. TARS deliberately exposes no path to
+  `--dangerously-skip-permissions`.
+- **Tools are the CLI's, not TARS'.** `ChatOptions.Tools` and `ToolChoice` are
+  ignored. Calls already executed by `agy` are reported on
+  `ChatResponse.ProviderExecutedTools` for audit only and are never
+  re-dispatched through TARS. The effective file/command authority comes from
+  the user's Antigravity permission settings.
+- **Structured output and reasoning.** `ResponseFormat` `json_schema` maps to
+  `--json-schema`; `ReasoningEffort` maps to `--effort low|medium|high`.
+- **Usage** comes from the terminal result's `usage` object. Input, output, and
+  cache-read tokens map into `llm.Usage`; `thinking_tokens` and `total_tokens`
+  have no provider-neutral destination today. The CLI reports no cost, so
+  `Usage.CostUSD` stays 0.
+- `AGY_CLI_PATH`, `AGY_CLI_TIMEOUT`, and `AGY_CLI_MODE` are the provider's
+  environment overrides.
 
 ### `ReasoningEffort` and `ServiceTier` (OpenAI)
 

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -95,8 +95,8 @@ type RunOptions struct {
 	ProviderTool     func(ctx context.Context, event Event) error
 	ReplayToolResult func(ctx context.Context, request ToolReplayRequest) (ToolReplayResult, bool)
 	// ResumeSessionID seeds the first iteration's ChatOptions.ResumeSessionID
-	// so resumable providers (claude-code-cli) continue an existing upstream
-	// session rather than starting a new one. Subsequent iterations
+	// so resumable providers (claude-code-cli and antigravity-cli) continue an
+	// existing upstream session rather than starting a new one. Subsequent iterations
 	// auto-update from the previous response's SessionID so the whole loop
 	// stays attached to the same upstream session.
 	ResumeSessionID string
@@ -182,8 +182,8 @@ func (l *Loop) Run(ctx context.Context, initial []llm.ChatMessage, opts RunOptio
 		}
 		l.emit(ctx, afterLLMEvent)
 
-		// Surface tools the upstream provider already executed (claude-code-cli
-		// runs Read/Edit/Bash/etc inside its own subprocess and reports them
+		// Surface tools the upstream provider already executed (CLI-backed
+		// providers run tools inside their own subprocesses and report them
 		// via stream-json tool_use blocks). These do NOT enter the tool
 		// execution branch below; they're observation-only audit signals.
 		for _, ptc := range resp.ProviderExecutedTools {

--- a/internal/config/defaults_apply.go
+++ b/internal/config/defaults_apply.go
@@ -288,7 +288,7 @@ func applyAgentRuntimeDefaults(cfg *Config, defaults Config) {
 //
 // For each provider pool entry:
 //   - AuthMode defaults based on Kind (openai-codex → oauth,
-//     claude-code-cli → cli, everything else → api-key)
+//     claude-code-cli and antigravity-cli → cli, everything else → api-key)
 //   - BaseURL defaults to the canonical endpoint for the Kind
 //   - APIKey defaults to the conventional env var for the Kind
 //     when the user did not set one explicitly

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -114,8 +114,9 @@ type LLMConfig struct {
 // provider can serve multiple models.
 //
 // Kind identifies the provider type ("anthropic", "openai", "openai-codex",
-// "gemini", "gemini-native", "kimi", "claude-code-cli") and maps to the value
-// passed to llm.NewProvider.Provider. The config package does not
+// "gemini", "gemini-native", "kimi", "claude-code-cli",
+// "antigravity-cli") and maps
+// to the value passed to llm.NewProvider.Provider. The config package does not
 // validate Kind against a closed list — llm.NewProvider returns a clear
 // error for unknown kinds, keeping the config package free of an
 // internal/llm import.

--- a/internal/llm/antigravity_cli.go
+++ b/internal/llm/antigravity_cli.go
@@ -1,0 +1,535 @@
+package llm
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// antigravity-cli provider: reuses a locally installed `agy` the same way
+// claude-code-cli reuses `claude`. Google cut Gemini Code Assist off for
+// individual accounts on 2026-06-18 — which took the Gemini CLI's Google
+// sign-in with it — and points those users at the Antigravity family instead,
+// so this is the CLI-backed Google provider that still works without an API
+// key. `agy` authenticates through the system keyring, falling back to a
+// browser sign-in, so TARS never handles the credential.
+//
+// Wire protocol: `agy --print <text> --output-format stream-json` emits
+// newline-delimited JSON on stdout. Events are *nested* under a key named by
+// the `event` discriminator:
+//
+//	{"event":"init","conversation_id":"…","init":{…}}
+//	{"event":"step_update","step_update":{"step_type":"agent_response","text_delta":"…",…}}
+//	{"event":"result","result":{"status":"SUCCESS","response":"…","usage":{…},…}}
+const (
+	antigravityCLIProviderLabel = "antigravity-cli"
+	antigravityCLIPathEnv       = "AGY_CLI_PATH"
+	antigravityCLITimeoutEnv    = "AGY_CLI_TIMEOUT"
+	// antigravityCLIModeEnv overrides --mode. It is an env var rather than a
+	// ChatOptions field because nothing in TARS' config surface sets it yet;
+	// when the config surface grows one, thread it through ChatOptions like
+	// ClaudeCodePermissionMode and keep this as the fallback.
+	antigravityCLIModeEnv = "AGY_CLI_MODE"
+	// defaultAntigravityCLITimeout bounds a single agy invocation from the
+	// outside. `agy` has its own --print-timeout (5m by default) which is set
+	// to match; this outer bound is what still fires if the process wedges
+	// before its own timer arms.
+	defaultAntigravityCLITimeout = 5 * time.Minute
+	// antigravityCLIWaitDelay bounds how long Wait blocks on pipe I/O after
+	// the process is signaled on cancellation. Shared by the platform-specific
+	// process configuration.
+	antigravityCLIWaitDelay = 5 * time.Second
+	// Tool output is embedded in one NDJSON line. The scanner default (64 KiB)
+	// is too small for ordinary build/test logs, while an explicit ceiling keeps
+	// a corrupt or hostile subprocess from growing memory without bound.
+	maxAntigravityCLIEventBytes = 16 * 1024 * 1024
+)
+
+// antigravityCLIPerfEnv holds low-risk environment defaults. Applied as
+// defaults only: a value already present in the inherited environment is left
+// untouched so operators keep the final say. Order is fixed for deterministic
+// process environments.
+var antigravityCLIPerfEnv = []struct{ key, value string }{
+	{"NO_COLOR", "1"},
+}
+
+type AntigravityCLIClient struct {
+	cliPath string
+	workDir string
+	model   string
+}
+
+// FindAntigravityCLIPath resolves the agy executable, honouring AGY_CLI_PATH
+// before falling back to a PATH lookup.
+func FindAntigravityCLIPath() (string, error) {
+	if configured := strings.TrimSpace(os.Getenv(antigravityCLIPathEnv)); configured != "" {
+		path, err := exec.LookPath(configured)
+		if err != nil {
+			return "", fmt.Errorf("%s executable not found: %s", antigravityCLIProviderLabel, configured)
+		}
+		return path, nil
+	}
+	path, err := exec.LookPath("agy")
+	if err != nil {
+		return "", fmt.Errorf("%s executable not found in PATH; install Antigravity CLI or set %s", antigravityCLIProviderLabel, antigravityCLIPathEnv)
+	}
+	return path, nil
+}
+
+// NewAntigravityCLIClient builds a client. An empty model is left unset so the
+// CLI picks its own default — unlike Claude Code there is no stable short
+// alias to hardcode, and a wrong --model value fails the whole turn.
+func NewAntigravityCLIClient(workDir, model string) (*AntigravityCLIClient, error) {
+	cliPath, err := FindAntigravityCLIPath()
+	if err != nil {
+		return nil, err
+	}
+	trimmedWorkDir := strings.TrimSpace(workDir)
+	if trimmedWorkDir == "" {
+		trimmedWorkDir = "."
+	}
+	return &AntigravityCLIClient{
+		cliPath: cliPath,
+		workDir: trimmedWorkDir,
+		model:   strings.TrimSpace(model),
+	}, nil
+}
+
+func (c *AntigravityCLIClient) Ask(ctx context.Context, prompt string) (string, error) {
+	return askFromSinglePrompt(ctx, c.Chat, prompt, strings.TrimSpace)
+}
+
+func (c *AntigravityCLIClient) Chat(ctx context.Context, messages []ChatMessage, opts ChatOptions) (ChatResponse, error) {
+	if c == nil {
+		return ChatResponse{}, fmt.Errorf("%s client is not configured", antigravityCLIProviderLabel)
+	}
+	resumeID := strings.TrimSpace(opts.ResumeSessionID)
+	// The transcript is assembled before the system block so a turn with no
+	// user or assistant content is caught here. Folding the system block in
+	// first would mask it: the preamble is never empty.
+	var transcript string
+	if resumeID != "" {
+		// The CLI holds the prior context under <conversation_id>; replaying
+		// the transcript would re-bill it and can confuse the saved state.
+		transcript = extractLatestUserMessage(messages)
+	} else {
+		transcript = buildAntigravityCLITranscript(messages)
+	}
+	if transcript == "" {
+		return ChatResponse{}, fmt.Errorf("%s prompt is empty", antigravityCLIProviderLabel)
+	}
+	// On a resumed turn the system block already reached the model and lives
+	// in the saved conversation, so re-sending it would duplicate it.
+	systemPrompt := ""
+	if resumeID == "" {
+		systemPrompt = collectAntigravityCLISystemPrompt(messages)
+	}
+	prompt := composeAntigravityCLIPrompt(systemPrompt, transcript)
+
+	timeout := parseAntigravityCLITimeout(os.Getenv(antigravityCLITimeoutEnv))
+	args := buildAntigravityCLIArgs(antigravityCLIArgSpec{
+		Model:           c.model,
+		Prompt:          prompt,
+		ConversationID:  resumeID,
+		Mode:            os.Getenv(antigravityCLIModeEnv),
+		ReasoningEffort: opts.ReasoningEffort,
+		JSONSchema:      antigravityCLIJSONSchema(opts.ResponseFormat),
+		PrintTimeout:    timeout,
+	})
+
+	// Bound the invocation from the outside too, so a process that wedges
+	// before arming its own --print-timeout still fails predictably.
+	ctx, cancel := context.WithTimeout(ctx, timeout+antigravityCLIWaitDelay)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, c.cliPath, args...)
+	cmd.Dir = c.workDir
+	cmd.Env = antigravityCLIEnv(os.Environ())
+	// On cancellation kill the whole descendant tree, not just the direct
+	// child: the CLI spawns descendants that inherit the stdout pipe, and a
+	// survivor holds it open so the stream read would block past the deadline.
+	configureAntigravityCLIProcess(cmd)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return ChatResponse{}, newProviderError(antigravityCLIProviderLabel, "request", fmt.Errorf("stdout pipe: %w", err))
+	}
+	if err := cmd.Start(); err != nil {
+		return ChatResponse{}, newProviderError(antigravityCLIProviderLabel, "request", fmt.Errorf("start cli: %w", err))
+	}
+
+	resp, parseErr := parseAntigravityCLIStream(stdout, opts)
+	waitErr := cmd.Wait()
+	if ctx.Err() == context.DeadlineExceeded {
+		return ChatResponse{}, newProviderError(antigravityCLIProviderLabel, "request", fmt.Errorf("cli timed out after %s", timeout))
+	}
+	if ctx.Err() != nil {
+		return ChatResponse{}, newProviderError(antigravityCLIProviderLabel, "request", fmt.Errorf("cli canceled: %w", ctx.Err()))
+	}
+	if parseErr != nil {
+		return ChatResponse{}, parseErr
+	}
+	if waitErr != nil {
+		errText := strings.TrimSpace(stderr.String())
+		if errText != "" {
+			return ChatResponse{}, newProviderError(antigravityCLIProviderLabel, "request", fmt.Errorf("cli failed: %w: %s", waitErr, errText))
+		}
+		return ChatResponse{}, newProviderError(antigravityCLIProviderLabel, "request", fmt.Errorf("cli failed: %w", waitErr))
+	}
+	return resp, nil
+}
+
+// antigravityCLIArgSpec is the full set of inputs that shape one invocation.
+// Grouping them keeps buildAntigravityCLIArgs testable without a live process
+// and stops the argument order from drifting between call sites.
+type antigravityCLIArgSpec struct {
+	Model           string
+	Prompt          string
+	ConversationID  string
+	Mode            string
+	ReasoningEffort string
+	JSONSchema      string
+	PrintTimeout    time.Duration
+}
+
+// buildAntigravityCLIArgs assembles the headless invocation. The prompt goes
+// last so a prompt that happens to look like a flag cannot be parsed as one.
+func buildAntigravityCLIArgs(spec antigravityCLIArgSpec) []string {
+	args := []string{"--output-format", "stream-json"}
+	if spec.PrintTimeout > 0 {
+		args = append(args, "--print-timeout", spec.PrintTimeout.String())
+	}
+	// An empty model is omitted rather than guessed: the CLI's own default is
+	// correct, and an invalid slug fails the turn.
+	if model := strings.TrimSpace(spec.Model); model != "" {
+		args = append(args, "--model", model)
+	}
+	if mode := resolveAntigravityCLIMode(spec.Mode); mode != "" {
+		args = append(args, "--mode", mode)
+	}
+	if effort := resolveAntigravityCLIEffort(spec.ReasoningEffort); effort != "" {
+		args = append(args, "--effort", effort)
+	}
+	if schema := strings.TrimSpace(spec.JSONSchema); schema != "" {
+		args = append(args, "--json-schema", schema)
+	}
+	if id := strings.TrimSpace(spec.ConversationID); id != "" {
+		args = append(args, "--conversation", id)
+	}
+	return append(args, "--print", spec.Prompt)
+}
+
+// resolveAntigravityCLIMode validates the requested mode against the values
+// the CLI accepts and returns "" for anything else, which omits the flag and
+// leaves the CLI's own default (permission requests are reviewed) in place.
+// `--dangerously-skip-permissions` is deliberately unreachable from here: no
+// value of an env var should silently auto-approve every tool call.
+func resolveAntigravityCLIMode(raw string) string {
+	switch trimmed := strings.ToLower(strings.TrimSpace(raw)); trimmed {
+	case "accept-edits", "plan":
+		return trimmed
+	default:
+		return ""
+	}
+}
+
+// resolveAntigravityCLIEffort maps TARS' provider-agnostic reasoning effort
+// onto the three levels the CLI accepts. Unsupported values omit the flag
+// rather than failing, matching how the other providers treat the field.
+func resolveAntigravityCLIEffort(raw string) string {
+	switch strings.TrimSpace(strings.ToLower(raw)) {
+	case "low", "minimal", "min", "none":
+		return "low"
+	case "medium", "med":
+		return "medium"
+	case "high", "veryhigh", "very-high", "very_high", "xhigh":
+		return "high"
+	default:
+		return ""
+	}
+}
+
+// antigravityCLIJSONSchema extracts a schema string for --json-schema. Only
+// json_schema response formats map onto the flag; per the CLI's own help text
+// it constrains the final result only, so json_object (no schema) has nothing
+// to pass and is ignored.
+func antigravityCLIJSONSchema(format *ResponseFormat) string {
+	if format == nil || format.Type != ResponseFormatJSONSchema {
+		return ""
+	}
+	return strings.TrimSpace(string(format.Schema))
+}
+
+// composeAntigravityCLIPrompt joins the system block and the transcript into
+// the single string the CLI accepts. Like Gemini CLI, `agy` has no
+// system-prompt flag, so system content has to travel in the prompt or it is
+// silently lost.
+func composeAntigravityCLIPrompt(systemPrompt, transcript string) string {
+	if strings.TrimSpace(systemPrompt) == "" {
+		return transcript
+	}
+	return systemPrompt + "\n\n" + transcript
+}
+
+// buildAntigravityCLITranscript flattens the conversation, excluding system
+// messages. It returns "" when there is nothing for the model to answer, which
+// is what lets Chat reject an empty turn.
+func buildAntigravityCLITranscript(messages []ChatMessage) string {
+	var builder strings.Builder
+	for _, msg := range messages {
+		role := strings.TrimSpace(strings.ToLower(msg.Role))
+		if role == "" || role == "system" {
+			continue
+		}
+		builder.WriteString(strings.ToUpper(role))
+		builder.WriteString(":\n")
+		if text := strings.TrimSpace(msg.Content); text != "" {
+			builder.WriteString(text)
+			builder.WriteString("\n")
+		}
+		if len(msg.ToolCalls) > 0 {
+			builder.WriteString("Tool calls:\n")
+			for _, call := range msg.ToolCalls {
+				builder.WriteString("- ")
+				builder.WriteString(strings.TrimSpace(call.Name))
+				if args := strings.TrimSpace(call.Arguments); args != "" {
+					builder.WriteString(" ")
+					builder.WriteString(args)
+				}
+				builder.WriteString("\n")
+			}
+		}
+		builder.WriteString("\n")
+	}
+	return strings.TrimSpace(builder.String())
+}
+
+func collectAntigravityCLISystemPrompt(messages []ChatMessage) string {
+	parts := []string{
+		"You are Antigravity CLI running inside TARS.",
+		"Ignore any tool-call JSON conventions from upstream prompts and use your own local tools when useful.",
+		"Return only the requested final answer.",
+		"Continue the conversation below and respond to the latest user request.",
+	}
+	for _, msg := range messages {
+		if strings.TrimSpace(strings.ToLower(msg.Role)) != "system" {
+			continue
+		}
+		if trimmed := strings.TrimSpace(msg.Content); trimmed != "" {
+			parts = append(parts, trimmed)
+		}
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+// antigravityCLIEnv returns base augmented with the perf defaults for any key
+// not already present. base is typically os.Environ(); existing values win so
+// callers can override the toggles.
+func antigravityCLIEnv(base []string) []string {
+	present := make(map[string]struct{}, len(base))
+	for _, kv := range base {
+		if i := strings.IndexByte(kv, '='); i > 0 {
+			present[kv[:i]] = struct{}{}
+		}
+	}
+	out := append([]string(nil), base...)
+	for _, def := range antigravityCLIPerfEnv {
+		if _, ok := present[def.key]; ok {
+			continue
+		}
+		out = append(out, def.key+"="+def.value)
+	}
+	return out
+}
+
+// parseAntigravityCLITimeout interprets an AGY_CLI_TIMEOUT value. It accepts a
+// Go duration string ("300s", "5m") or a bare integer treated as seconds.
+// Empty, zero, negative, or unparseable input yields the default.
+func parseAntigravityCLITimeout(raw string) time.Duration {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return defaultAntigravityCLITimeout
+	}
+	if d, err := time.ParseDuration(raw); err == nil {
+		if d > 0 {
+			return d
+		}
+		return defaultAntigravityCLITimeout
+	}
+	if secs, err := strconv.Atoi(raw); err == nil && secs > 0 {
+		return time.Duration(secs) * time.Second
+	}
+	return defaultAntigravityCLITimeout
+}
+
+// parseAntigravityCLIStream consumes the nested NDJSON event stream.
+//
+// Assistant text arrives as `text_delta` fragments on agent_response steps and
+// again, complete, as `result.response`. The result is authoritative — the
+// fragments are only forwarded to OnDelta — so streaming and non-streaming
+// callers see the same final content and nothing is double-counted.
+func parseAntigravityCLIStream(stdout io.Reader, opts ChatOptions) (ChatResponse, error) {
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxAntigravityCLIEventBytes)
+
+	var (
+		deltaText      strings.Builder
+		finalText      string
+		toolCalls      []ToolCall
+		usage          Usage
+		stopReason     string
+		conversationID string
+		turns          int
+		sawResult      bool
+	)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		var envelope map[string]any
+		if err := json.Unmarshal([]byte(line), &envelope); err != nil {
+			return ChatResponse{}, newProviderError(antigravityCLIProviderLabel, "parse", fmt.Errorf("decode stream event: %w", err))
+		}
+
+		event := strings.TrimSpace(asString(envelope["event"]))
+		// Every event carries the conversation id, either at the envelope
+		// level (init) or inside its payload.
+		payload, _ := envelope[event].(map[string]any)
+		if id := firstNonEmptyTrimmed(asString(envelope["conversation_id"]), asString(payload["conversation_id"])); id != "" {
+			conversationID = id
+		}
+
+		switch event {
+		case "init":
+			// conversation_id captured above; the rest (cwd, tools,
+			// permission_mode) is diagnostic only.
+		case "step_update":
+			switch strings.TrimSpace(asString(payload["step_type"])) {
+			case "agent_response":
+				if delta := asString(payload["text_delta"]); delta != "" {
+					deltaText.WriteString(delta)
+					if opts.OnDelta != nil {
+						opts.OnDelta(delta)
+					}
+				}
+			case "tool":
+				if call, ok := antigravityCLIToolCall(payload); ok {
+					toolCalls = append(toolCalls, call)
+				}
+			}
+		case "result":
+			sawResult = true
+			stopReason = strings.TrimSpace(asString(payload["status"]))
+			finalText = strings.TrimSpace(asString(payload["response"]))
+			turns = asInt(payload["num_turns"])
+			usage = extractAntigravityCLIUsage(payload["usage"])
+			if !isAntigravityCLISuccess(stopReason) {
+				message := firstNonEmptyTrimmed(
+					antigravityCLIErrorMessage(payload["error"]),
+					finalText,
+					fmt.Sprintf("%s request failed with status %q", antigravityCLIProviderLabel, stopReason),
+				)
+				return ChatResponse{}, newProviderError(antigravityCLIProviderLabel, "request", fmt.Errorf("%s", message))
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return ChatResponse{}, newProviderError(antigravityCLIProviderLabel, "stream", fmt.Errorf("read stream response: %w", err))
+	}
+	// A stream that ends without a result event means the process died
+	// mid-turn. Returning the partial deltas would look like a complete
+	// answer, so fail instead and let the caller retry.
+	if !sawResult {
+		return ChatResponse{}, newProviderError(antigravityCLIProviderLabel, "stream", fmt.Errorf("stream ended without a result event"))
+	}
+
+	content := finalText
+	if content == "" {
+		content = strings.TrimSpace(deltaText.String())
+	}
+	return ChatResponse{
+		Message: ChatMessage{
+			Role: "assistant",
+			// The CLI self-executed any tool calls inside its own subprocess;
+			// surfacing them as Message.ToolCalls would make the agent loop
+			// re-dispatch work that is already done. The audit trail lives on
+			// ProviderExecutedTools instead.
+			Content:   content,
+			ToolCalls: nil,
+		},
+		Usage:      usage,
+		StopReason: stopReason,
+		Turns:      turns,
+		// The id round-trips through ChatOptions.ResumeSessionID into
+		// --conversation, so multi-turn skips replaying the transcript.
+		SessionID:             conversationID,
+		ProviderExecutedTools: toolCalls,
+	}, nil
+}
+
+// isAntigravityCLISuccess reports whether a result status means the turn
+// completed. SUCCESS is the only successful terminal status in the documented
+// closed vocabulary. The comparison is case-insensitive, but missing or
+// unknown statuses fail closed so malformed output cannot look successful.
+func isAntigravityCLISuccess(status string) bool {
+	return strings.EqualFold(strings.TrimSpace(status), "SUCCESS")
+}
+
+// antigravityCLIToolCall converts a tool step into a ToolCall. Details live
+// under tool_info; a step without one (for example an ACTIVE step that has not
+// resolved its arguments yet) is skipped rather than recorded blank.
+func antigravityCLIToolCall(payload map[string]any) (ToolCall, bool) {
+	info, ok := payload["tool_info"].(map[string]any)
+	if !ok {
+		return ToolCall{}, false
+	}
+	name := firstNonEmptyTrimmed(asString(info["name"]), asString(payload["tool_name"]))
+	if name == "" {
+		return ToolCall{}, false
+	}
+	arguments := ""
+	if params, present := info["parameters"]; present && params != nil {
+		if encoded, err := json.Marshal(params); err == nil {
+			arguments = string(encoded)
+		}
+	}
+	return ToolCall{Name: name, Arguments: arguments}, true
+}
+
+// extractAntigravityCLIUsage maps the CLI's usage object onto Usage. The wire
+// format also reports thinking_tokens and total_tokens, but Usage has no
+// provider-neutral fields for those values. The CLI reports no cost, so
+// CostUSD stays zero.
+func extractAntigravityCLIUsage(raw any) Usage {
+	stats, ok := raw.(map[string]any)
+	if !ok {
+		return Usage{}
+	}
+	return Usage{
+		InputTokens:     asInt(stats["input_tokens"]),
+		OutputTokens:    asInt(stats["output_tokens"]),
+		CacheReadTokens: asInt(stats["cache_read_tokens"]),
+	}
+}
+
+// antigravityCLIErrorMessage pulls a human-readable message out of an error
+// object, which the CLI shapes as {type, message}.
+func antigravityCLIErrorMessage(raw any) string {
+	errMap, ok := raw.(map[string]any)
+	if !ok {
+		return strings.TrimSpace(asString(raw))
+	}
+	return firstNonEmptyTrimmed(asString(errMap["message"]), asString(errMap["type"]))
+}

--- a/internal/llm/antigravity_cli.go
+++ b/internal/llm/antigravity_cli.go
@@ -62,9 +62,10 @@ var antigravityCLIPerfEnv = []struct{ key, value string }{
 }
 
 type AntigravityCLIClient struct {
-	cliPath string
-	workDir string
-	model   string
+	cliPath        string
+	workDir        string
+	model          string
+	commandContext func(context.Context, string, ...string) *exec.Cmd
 }
 
 // FindAntigravityCLIPath resolves the agy executable, honouring AGY_CLI_PATH
@@ -97,9 +98,10 @@ func NewAntigravityCLIClient(workDir, model string) (*AntigravityCLIClient, erro
 		trimmedWorkDir = "."
 	}
 	return &AntigravityCLIClient{
-		cliPath: cliPath,
-		workDir: trimmedWorkDir,
-		model:   strings.TrimSpace(model),
+		cliPath:        cliPath,
+		workDir:        trimmedWorkDir,
+		model:          strings.TrimSpace(model),
+		commandContext: exec.CommandContext,
 	}, nil
 }
 
@@ -150,7 +152,7 @@ func (c *AntigravityCLIClient) Chat(ctx context.Context, messages []ChatMessage,
 	ctx, cancel := context.WithTimeout(ctx, timeout+antigravityCLIWaitDelay)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, c.cliPath, args...)
+	cmd := c.commandContext(ctx, c.cliPath, args...)
 	cmd.Dir = c.workDir
 	cmd.Env = antigravityCLIEnv(os.Environ())
 	// On cancellation kill the whole descendant tree, not just the direct

--- a/internal/llm/antigravity_cli_test.go
+++ b/internal/llm/antigravity_cli_test.go
@@ -3,7 +3,9 @@ package llm
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -618,6 +620,62 @@ func TestAntigravityCLIClient_ChatRejectsAnEmptyPrompt(t *testing.T) {
 	} else if !strings.Contains(err.Error(), "prompt is empty") {
 		t.Errorf("error = %v, want an empty-prompt error", err)
 	}
+}
+
+func TestAntigravityCLIClient_ChatExecutesCLI(t *testing.T) {
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "agy-stub"+exeSuffix())
+	if err := os.WriteFile(stub, []byte("stub"), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	t.Setenv(antigravityCLIPathEnv, stub)
+	t.Setenv(antigravityCLITimeoutEnv, "2s")
+	t.Setenv("GO_WANT_ANTIGRAVITY_HELPER_PROCESS", "1")
+
+	client, err := NewAntigravityCLIClient(dir, "gemini-3-pro")
+	if err != nil {
+		t.Fatalf("NewAntigravityCLIClient: %v", err)
+	}
+	var gotPath string
+	var gotArgs []string
+	client.commandContext = func(ctx context.Context, path string, args ...string) *exec.Cmd {
+		gotPath = path
+		gotArgs = append([]string(nil), args...)
+		return exec.CommandContext(ctx, os.Args[0], "-test.run=TestAntigravityCLIHelperProcess")
+	}
+
+	messages := []ChatMessage{
+		{Role: "system", Content: "Be concise."},
+		{Role: "user", Content: "Say ACK."},
+	}
+	resp, err := client.Chat(context.Background(), messages, ChatOptions{ReasoningEffort: "high"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp.Message.Content != "ACK" || resp.SessionID != agyConvID {
+		t.Errorf("response = %+v", resp)
+	}
+	if gotPath != stub {
+		t.Errorf("executable = %q, want %q", gotPath, stub)
+	}
+	wantArgs := buildAntigravityCLIArgs(antigravityCLIArgSpec{
+		Model:           "gemini-3-pro",
+		Prompt:          composeAntigravityCLIPrompt(collectAntigravityCLISystemPrompt(messages), buildAntigravityCLITranscript(messages)),
+		ReasoningEffort: "high",
+		PrintTimeout:    2 * time.Second,
+	})
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Errorf("args = %#v, want %#v", gotArgs, wantArgs)
+	}
+}
+
+func TestAntigravityCLIHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_ANTIGRAVITY_HELPER_PROCESS") != "1" {
+		return
+	}
+	fmt.Fprintln(os.Stdout, agyInitEvent())
+	fmt.Fprintln(os.Stdout, agyResultEvent("ACK"))
+	os.Exit(0)
 }
 
 // Opt-in live coverage for the locally authenticated CLI. Normal CI skips it:

--- a/internal/llm/antigravity_cli_test.go
+++ b/internal/llm/antigravity_cli_test.go
@@ -1,0 +1,678 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The stream-json protocol is parsed by a pure function, so these tests feed it
+// directly instead of driving a stubbed process. That keeps them fast and,
+// unlike the claude-code-cli tests (which need a POSIX shell stub and are why
+// internal/llm is excluded from the Windows job), runnable on every platform.
+//
+// Event shapes mirror the documented NDJSON from Antigravity CLI 1.1.13: a flat
+// envelope with an `event` discriminator whose payload is nested under a key of
+// the same name.
+
+const agyConvID = "c3b66b04-872b-4fbe-a3a4-058a026ef20a"
+
+func agyStream(lines ...string) string { return strings.Join(lines, "\n") }
+
+func agyInitEvent() string {
+	return `{"event":"init","conversation_id":"` + agyConvID +
+		`","init":{"cwd":"/home/user/project","tools":["run_command","write_to_file"],"permission_mode":"request-review"}}`
+}
+
+func agyResultEvent(response string) string {
+	return `{"event":"result","result":{"conversation_id":"` + agyConvID +
+		`","status":"SUCCESS","response":"` + response +
+		`","duration_seconds":6.88,"num_turns":1,"usage":{"input_tokens":10418,"output_tokens":589,"thinking_tokens":551,"cache_read_tokens":8113,"total_tokens":11007}}}`
+}
+
+func TestParseAntigravityCLIStream_HappyPath(t *testing.T) {
+	stream := agyStream(
+		agyInitEvent(),
+		`{"event":"step_update","step_update":{"conversation_id":"`+agyConvID+`","step_index":0,"state":"DONE","step_type":"user_input"}}`,
+		`{"event":"step_update","step_update":{"conversation_id":"`+agyConvID+`","step_index":3,"state":"DONE","step_type":"agent_response","text_delta":"Git rebase rewrites history.","duration_seconds":6.28}}`,
+		`{"event":"step_update","step_update":{"conversation_id":"`+agyConvID+`","step_index":4,"state":"DONE","step_type":"checkpoint","duration_seconds":0.53}}`,
+		agyResultEvent("Git rebase rewrites history."),
+	)
+
+	resp, err := parseAntigravityCLIStream(strings.NewReader(stream), ChatOptions{})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if resp.Message.Content != "Git rebase rewrites history." {
+		t.Errorf("content = %q", resp.Message.Content)
+	}
+	if resp.Message.Role != "assistant" {
+		t.Errorf("role = %q, want assistant", resp.Message.Role)
+	}
+	// The conversation id round-trips into --conversation, so unlike the
+	// Gemini CLI this provider really can resume.
+	if resp.SessionID != agyConvID {
+		t.Errorf("session id = %q, want %q", resp.SessionID, agyConvID)
+	}
+	if resp.StopReason != "SUCCESS" {
+		t.Errorf("stop reason = %q, want SUCCESS", resp.StopReason)
+	}
+	if resp.Turns != 1 {
+		t.Errorf("turns = %d, want 1", resp.Turns)
+	}
+	if resp.Usage.InputTokens != 10418 || resp.Usage.OutputTokens != 589 || resp.Usage.CacheReadTokens != 8113 {
+		t.Errorf("usage = %+v", resp.Usage)
+	}
+	// The CLI reports no per-call cost.
+	if resp.Usage.CostUSD != 0 {
+		t.Errorf("cost = %v, want 0", resp.Usage.CostUSD)
+	}
+}
+
+// text_delta fragments stream to OnDelta, but result.response is authoritative
+// for the final content — otherwise a streaming caller and a non-streaming one
+// would disagree, or the text would be counted twice.
+func TestParseAntigravityCLIStream_ResultResponseWinsOverDeltas(t *testing.T) {
+	stream := agyStream(
+		agyInitEvent(),
+		`{"event":"step_update","step_update":{"step_type":"agent_response","state":"ACTIVE","text_delta":"Git "}}`,
+		`{"event":"step_update","step_update":{"step_type":"agent_response","state":"ACTIVE","text_delta":"rebase "}}`,
+		`{"event":"step_update","step_update":{"step_type":"agent_response","state":"DONE","text_delta":"rewrites history."}}`,
+		agyResultEvent("Git rebase rewrites history."),
+	)
+
+	var deltas []string
+	resp, err := parseAntigravityCLIStream(
+		strings.NewReader(stream),
+		ChatOptions{OnDelta: func(text string) { deltas = append(deltas, text) }},
+	)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if resp.Message.Content != "Git rebase rewrites history." {
+		t.Errorf("content = %q, want the result response exactly once", resp.Message.Content)
+	}
+	want := []string{"Git ", "rebase ", "rewrites history."}
+	if !reflect.DeepEqual(deltas, want) {
+		t.Errorf("deltas = %#v, want %#v", deltas, want)
+	}
+}
+
+// If the result carries no response text, the accumulated deltas are the only
+// thing left to answer with.
+func TestParseAntigravityCLIStream_FallsBackToDeltasWhenResponseEmpty(t *testing.T) {
+	stream := agyStream(
+		agyInitEvent(),
+		`{"event":"step_update","step_update":{"step_type":"agent_response","state":"DONE","text_delta":"partial answer"}}`,
+		`{"event":"result","result":{"conversation_id":"`+agyConvID+`","status":"SUCCESS","response":"","num_turns":1}}`,
+	)
+
+	resp, err := parseAntigravityCLIStream(strings.NewReader(stream), ChatOptions{})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if resp.Message.Content != "partial answer" {
+		t.Errorf("content = %q, want the accumulated deltas", resp.Message.Content)
+	}
+}
+
+func TestParseAntigravityCLIStream_ToolStepsAreObservationalOnly(t *testing.T) {
+	stream := agyStream(
+		agyInitEvent(),
+		`{"event":"step_update","step_update":{"step_index":1,"state":"DONE","step_type":"tool","tool_name":"run_command",`+
+			`"tool_info":{"name":"run_command","parameters":{"command":"go test ./..."},"output":"ok"}}}`,
+		`{"event":"step_update","step_update":{"step_type":"agent_response","state":"DONE","text_delta":"tests pass"}}`,
+		agyResultEvent("tests pass"),
+	)
+
+	resp, err := parseAntigravityCLIStream(strings.NewReader(stream), ChatOptions{})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	// The CLI already ran the tool. Re-dispatching it through TARS' registry
+	// would repeat the work, so Message.ToolCalls must stay empty.
+	if len(resp.Message.ToolCalls) != 0 {
+		t.Errorf("Message.ToolCalls = %#v, want empty", resp.Message.ToolCalls)
+	}
+	if len(resp.ProviderExecutedTools) != 1 {
+		t.Fatalf("ProviderExecutedTools = %#v, want 1 entry", resp.ProviderExecutedTools)
+	}
+	got := resp.ProviderExecutedTools[0]
+	if got.Name != "run_command" {
+		t.Errorf("tool name = %q", got.Name)
+	}
+	var args map[string]any
+	if err := json.Unmarshal([]byte(got.Arguments), &args); err != nil {
+		t.Fatalf("arguments %q is not JSON: %v", got.Arguments, err)
+	}
+	if args["command"] != "go test ./..." {
+		t.Errorf("arguments = %v", args)
+	}
+}
+
+// A tool step without tool_info (an ACTIVE step that has not resolved its
+// arguments yet) is skipped rather than recorded as a blank call.
+func TestParseAntigravityCLIStream_ToolStepWithoutInfoIsSkipped(t *testing.T) {
+	stream := agyStream(
+		agyInitEvent(),
+		`{"event":"step_update","step_update":{"state":"ACTIVE","step_type":"tool","tool_name":"run_command"}}`,
+		agyResultEvent("done"),
+	)
+
+	resp, err := parseAntigravityCLIStream(strings.NewReader(stream), ChatOptions{})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(resp.ProviderExecutedTools) != 0 {
+		t.Errorf("ProviderExecutedTools = %#v, want empty", resp.ProviderExecutedTools)
+	}
+}
+
+func TestParseAntigravityCLIStream_Errors(t *testing.T) {
+	tests := []struct {
+		name       string
+		stream     string
+		wantErrSub string
+	}{
+		{
+			name: "a non-success status surfaces the error message",
+			stream: agyStream(agyInitEvent(),
+				`{"event":"result","result":{"status":"ERROR","error":{"type":"AuthError","message":"authentication required"}}}`),
+			wantErrSub: "authentication required",
+		},
+		{
+			name:       "a non-success status without an error object still fails",
+			stream:     agyStream(agyInitEvent(), `{"event":"result","result":{"status":"CANCELLED"}}`),
+			wantErrSub: `status "CANCELLED"`,
+		},
+		{
+			name:       "a result with no terminal status fails closed",
+			stream:     agyStream(agyInitEvent(), `{"event":"result","result":{"response":"looks complete"}}`),
+			wantErrSub: "looks complete",
+		},
+		{
+			// The process died mid-turn. Returning the partial deltas would
+			// look like a complete answer.
+			name: "a stream without a result event fails",
+			stream: agyStream(agyInitEvent(),
+				`{"event":"step_update","step_update":{"step_type":"agent_response","state":"ACTIVE","text_delta":"half an ans"}}`),
+			wantErrSub: "without a result event",
+		},
+		{
+			name:       "malformed json fails loudly",
+			stream:     `{"event":"step_update",`,
+			wantErrSub: "decode stream event",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseAntigravityCLIStream(strings.NewReader(tc.stream), ChatOptions{})
+			if err == nil {
+				t.Fatalf("expected an error containing %q", tc.wantErrSub)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrSub) {
+				t.Errorf("error = %v, want it to contain %q", err, tc.wantErrSub)
+			}
+		})
+	}
+}
+
+func TestParseAntigravityCLIStream_IgnoresBlankLinesAndUnknownEvents(t *testing.T) {
+	stream := agyStream(
+		``,
+		agyInitEvent(),
+		`   `,
+		`{"event":"something_new_upstream_added","payload":{"a":1}}`,
+		`{"event":"step_update","step_update":{"step_type":"subagent","state":"DONE"}}`,
+		agyResultEvent("ok"),
+		``,
+	)
+
+	resp, err := parseAntigravityCLIStream(strings.NewReader(stream), ChatOptions{})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if resp.Message.Content != "ok" {
+		t.Errorf("content = %q, want ok", resp.Message.Content)
+	}
+}
+
+func TestParseAntigravityCLIStream_AcceptsLargeToolOutputEvent(t *testing.T) {
+	// Tool output is carried inside one NDJSON object. Keep this above the old
+	// 1 MiB scanner limit to prevent a regression to bufio.Scanner defaults.
+	toolOutput := strings.Repeat("x", 2*1024*1024)
+	toolEvent, err := json.Marshal(map[string]any{
+		"event": "step_update",
+		"step_update": map[string]any{
+			"state":     "DONE",
+			"step_type": "tool",
+			"tool_info": map[string]any{
+				"name":       "run_command",
+				"parameters": map[string]any{"command": "go test ./..."},
+				"output":     toolOutput,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal tool event: %v", err)
+	}
+
+	stream := agyStream(agyInitEvent(), string(toolEvent), agyResultEvent("done"))
+	resp, err := parseAntigravityCLIStream(strings.NewReader(stream), ChatOptions{})
+	if err != nil {
+		t.Fatalf("parse large event: %v", err)
+	}
+	if len(resp.ProviderExecutedTools) != 1 {
+		t.Fatalf("ProviderExecutedTools = %#v, want 1 entry", resp.ProviderExecutedTools)
+	}
+}
+
+func TestBuildAntigravityCLIArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		spec antigravityCLIArgSpec
+		want []string
+	}{
+		{
+			name: "minimal turn omits every optional flag",
+			spec: antigravityCLIArgSpec{Prompt: "Say hello."},
+			want: []string{"--output-format", "stream-json", "--print", "Say hello."},
+		},
+		{
+			name: "model, mode, effort and timeout are threaded through",
+			spec: antigravityCLIArgSpec{
+				Model:           "gemini-3-pro",
+				Prompt:          "Refactor it.",
+				Mode:            "accept-edits",
+				ReasoningEffort: "high",
+				PrintTimeout:    90 * time.Second,
+			},
+			want: []string{
+				"--output-format", "stream-json",
+				"--print-timeout", "1m30s",
+				"--model", "gemini-3-pro",
+				"--mode", "accept-edits",
+				"--effort", "high",
+				"--print", "Refactor it.",
+			},
+		},
+		{
+			name: "a resumed turn passes --conversation",
+			spec: antigravityCLIArgSpec{Prompt: "And again.", ConversationID: agyConvID},
+			want: []string{
+				"--output-format", "stream-json",
+				"--conversation", agyConvID,
+				"--print", "And again.",
+			},
+		},
+		{
+			name: "a json schema is passed verbatim",
+			spec: antigravityCLIArgSpec{Prompt: "Extract it.", JSONSchema: `{"type":"object"}`},
+			want: []string{
+				"--output-format", "stream-json",
+				"--json-schema", `{"type":"object"}`,
+				"--print", "Extract it.",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildAntigravityCLIArgs(tc.spec)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("args =\n  %#v\nwant\n  %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+// The prompt is last and introduced by --print, so a prompt that looks like a
+// flag cannot be parsed as one.
+func TestBuildAntigravityCLIArgs_PromptCannotBeMistakenForAFlag(t *testing.T) {
+	args := buildAntigravityCLIArgs(antigravityCLIArgSpec{
+		Prompt: "--dangerously-skip-permissions --mode accept-edits",
+	})
+	if args[len(args)-2] != "--print" {
+		t.Fatalf("prompt must be introduced by --print, got %#v", args)
+	}
+	if args[len(args)-1] != "--dangerously-skip-permissions --mode accept-edits" {
+		t.Fatalf("prompt should be the final argument, got %#v", args)
+	}
+	for _, arg := range args[:len(args)-1] {
+		if arg == "--dangerously-skip-permissions" || arg == "--mode" {
+			t.Fatalf("prompt text leaked into argv: %#v", args)
+		}
+	}
+}
+
+// No env-var value may reach --dangerously-skip-permissions: auto-approving
+// every tool call is not something a stray environment variable should do.
+func TestResolveAntigravityCLIMode(t *testing.T) {
+	tests := map[string]string{
+		"accept-edits":                   "accept-edits",
+		"ACCEPT-EDITS":                   "accept-edits",
+		"plan":                           "plan",
+		" plan ":                         "plan",
+		"":                               "",
+		"yolo":                           "",
+		"dangerously-skip-permissions":   "",
+		"--dangerously-skip-permissions": "",
+		"acceptEdits":                    "",
+		"nonsense":                       "",
+	}
+	for input, want := range tests {
+		if got := resolveAntigravityCLIMode(input); got != want {
+			t.Errorf("resolveAntigravityCLIMode(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestResolveAntigravityCLIEffort(t *testing.T) {
+	tests := map[string]string{
+		"low":       "low",
+		"minimal":   "low",
+		"min":       "low",
+		"none":      "low",
+		"medium":    "medium",
+		"med":       "medium",
+		"high":      "high",
+		"xhigh":     "high",
+		"very-high": "high",
+		"HIGH":      "high",
+		"":          "",
+		"nonsense":  "",
+	}
+	for input, want := range tests {
+		if got := resolveAntigravityCLIEffort(input); got != want {
+			t.Errorf("resolveAntigravityCLIEffort(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestAntigravityCLIJSONSchema(t *testing.T) {
+	schema := json.RawMessage(`{"type":"object","properties":{"a":{"type":"string"}}}`)
+	if got := antigravityCLIJSONSchema(&ResponseFormat{Type: ResponseFormatJSONSchema, Schema: schema}); got != string(schema) {
+		t.Errorf("json_schema = %q, want the schema verbatim", got)
+	}
+	// Only json_schema maps onto the flag; the CLI constrains the final result
+	// only, so json_object has no schema to pass.
+	for _, format := range []*ResponseFormat{
+		nil,
+		{Type: ResponseFormatText},
+		{Type: ResponseFormatJSONObject},
+		{Type: ResponseFormatJSONSchema},
+	} {
+		if got := antigravityCLIJSONSchema(format); got != "" {
+			t.Errorf("format %+v produced %q, want empty", format, got)
+		}
+	}
+}
+
+func TestComposeAntigravityCLIPrompt_FoldsSystemMessagesIn(t *testing.T) {
+	// The CLI has no system-prompt flag, so system content has to reach the
+	// model through the prompt or it is silently lost.
+	messages := []ChatMessage{
+		{Role: "system", Content: "Answer only in Korean."},
+		{Role: "user", Content: "Hello."},
+		{Role: "assistant", Content: "안녕하세요."},
+		{Role: "user", Content: "Again please."},
+	}
+	prompt := composeAntigravityCLIPrompt(
+		collectAntigravityCLISystemPrompt(messages),
+		buildAntigravityCLITranscript(messages),
+	)
+	for _, want := range []string{"Answer only in Korean.", "Hello.", "안녕하세요.", "Again please."} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("prompt is missing %q:\n%s", want, prompt)
+		}
+	}
+	if strings.Index(prompt, "Answer only in Korean.") > strings.Index(prompt, "Hello.") {
+		t.Errorf("system block should precede the transcript:\n%s", prompt)
+	}
+}
+
+// The transcript must be empty when there is nothing to answer — that is the
+// signal Chat uses to reject a turn. Folding the system block in first would
+// mask it, since the preamble is never empty.
+func TestBuildAntigravityCLITranscript_EmptyWithoutConversationalContent(t *testing.T) {
+	for _, messages := range [][]ChatMessage{
+		nil,
+		{{Role: "system", Content: "You are helpful."}},
+		{{Role: "system", Content: "a"}, {Role: "system", Content: "b"}},
+	} {
+		if got := buildAntigravityCLITranscript(messages); got != "" {
+			t.Errorf("transcript for %#v = %q, want empty", messages, got)
+		}
+	}
+	if got := buildAntigravityCLITranscript([]ChatMessage{{Role: "user", Content: "hi"}}); got == "" {
+		t.Error("a user turn must produce a transcript")
+	}
+}
+
+func TestComposeAntigravityCLIPrompt_BlankSystemBlockAddsNoSeparator(t *testing.T) {
+	if got := composeAntigravityCLIPrompt("", "Again please."); got != "Again please." {
+		t.Errorf("prompt = %q, want the bare transcript", got)
+	}
+	if got := composeAntigravityCLIPrompt("   ", "Again please."); got != "Again please." {
+		t.Errorf("a blank system block must not add separators, got %q", got)
+	}
+}
+
+func TestParseAntigravityCLITimeout(t *testing.T) {
+	tests := map[string]time.Duration{
+		"":         defaultAntigravityCLITimeout,
+		"   ":      defaultAntigravityCLITimeout,
+		"90s":      90 * time.Second,
+		"2m":       2 * time.Minute,
+		"120":      120 * time.Second,
+		"0":        defaultAntigravityCLITimeout,
+		"-30s":     defaultAntigravityCLITimeout,
+		"nonsense": defaultAntigravityCLITimeout,
+	}
+	for input, want := range tests {
+		if got := parseAntigravityCLITimeout(input); got != want {
+			t.Errorf("parseAntigravityCLITimeout(%q) = %v, want %v", input, got, want)
+		}
+	}
+}
+
+func TestAntigravityCLIEnv_DoesNotOverrideOperatorValues(t *testing.T) {
+	base := []string{"PATH=/usr/bin", "NO_COLOR=0"}
+	got := antigravityCLIEnv(base)
+
+	joined := strings.Join(got, "\n")
+	if !strings.Contains(joined, "NO_COLOR=0") || strings.Contains(joined, "NO_COLOR=1") {
+		t.Errorf("an inherited NO_COLOR must win, got:\n%s", joined)
+	}
+	if len(base) != 2 {
+		t.Errorf("base was mutated: %#v", base)
+	}
+}
+
+func TestExtractAntigravityCLIUsage(t *testing.T) {
+	usage := extractAntigravityCLIUsage(map[string]any{
+		"input_tokens":      float64(10418),
+		"output_tokens":     float64(589),
+		"thinking_tokens":   float64(551),
+		"cache_read_tokens": float64(8113),
+		"total_tokens":      float64(11007),
+	})
+	if usage.InputTokens != 10418 || usage.OutputTokens != 589 || usage.CacheReadTokens != 8113 {
+		t.Errorf("usage = %+v", usage)
+	}
+	// A missing or wrongly-shaped usage object must not panic.
+	if got := extractAntigravityCLIUsage(nil); got != (Usage{}) {
+		t.Errorf("nil usage = %+v, want zero value", got)
+	}
+	if got := extractAntigravityCLIUsage("not an object"); got != (Usage{}) {
+		t.Errorf("string usage = %+v, want zero value", got)
+	}
+}
+
+func TestIsAntigravityCLISuccess(t *testing.T) {
+	for _, status := range []string{"SUCCESS", "success", " Success "} {
+		if !isAntigravityCLISuccess(status) {
+			t.Errorf("isAntigravityCLISuccess(%q) = false, want true", status)
+		}
+	}
+	for _, status := range []string{"", "OK", "COMPLETED", "ERROR", "CANCELED", "INTERRUPTED", "INVALID", "WAITING", "RUNNING", "whatever"} {
+		if isAntigravityCLISuccess(status) {
+			t.Errorf("isAntigravityCLISuccess(%q) = true, want false", status)
+		}
+	}
+}
+
+func TestFindAntigravityCLIPath_HonoursTheEnvOverride(t *testing.T) {
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "agy-stub"+exeSuffix())
+	if err := os.WriteFile(stub, []byte("stub"), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+
+	t.Setenv(antigravityCLIPathEnv, stub)
+	got, err := FindAntigravityCLIPath()
+	if err != nil {
+		t.Fatalf("FindAntigravityCLIPath: %v", err)
+	}
+	if got != stub {
+		t.Errorf("path = %q, want %q", got, stub)
+	}
+
+	t.Setenv(antigravityCLIPathEnv, filepath.Join(dir, "definitely-absent"+exeSuffix()))
+	if _, err := FindAntigravityCLIPath(); err == nil {
+		t.Fatal("an unresolvable override should error")
+	} else if !strings.Contains(err.Error(), antigravityCLIProviderLabel) {
+		t.Errorf("error should name the provider, got: %v", err)
+	}
+}
+
+// An empty model is left unset rather than guessed: there is no stable short
+// alias to hardcode and an invalid --model value fails the whole turn.
+func TestNewAntigravityCLIClient_Defaults(t *testing.T) {
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "agy-stub"+exeSuffix())
+	if err := os.WriteFile(stub, []byte("stub"), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	t.Setenv(antigravityCLIPathEnv, stub)
+
+	client, err := NewAntigravityCLIClient("", "")
+	if err != nil {
+		t.Fatalf("NewAntigravityCLIClient: %v", err)
+	}
+	if client.workDir != "." {
+		t.Errorf("workDir = %q, want \".\"", client.workDir)
+	}
+	if client.model != "" {
+		t.Errorf("model = %q, want empty so the CLI picks its own default", client.model)
+	}
+}
+
+// NewProvider must route "antigravity-cli" to this client without resolving any
+// TARS-held credential — the CLI owns the Google login.
+func TestNewProvider_RoutesAntigravityCLIWithoutACredential(t *testing.T) {
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "agy-stub"+exeSuffix())
+	if err := os.WriteFile(stub, []byte("stub"), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	t.Setenv(antigravityCLIPathEnv, stub)
+	// Deliberately no API key in the environment.
+	t.Setenv("GEMINI_API_KEY", "")
+
+	client, err := NewProvider(ProviderOptions{
+		Provider: "antigravity-cli",
+		WorkDir:  dir,
+	})
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	if _, ok := client.(*AntigravityCLIClient); !ok {
+		t.Fatalf("client = %T, want *AntigravityCLIClient", client)
+	}
+}
+
+func TestAntigravityCLIClient_ChatRejectsAnEmptyPrompt(t *testing.T) {
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "agy-stub"+exeSuffix())
+	if err := os.WriteFile(stub, []byte("stub"), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	t.Setenv(antigravityCLIPathEnv, stub)
+
+	client, err := NewAntigravityCLIClient(dir, "")
+	if err != nil {
+		t.Fatalf("NewAntigravityCLIClient: %v", err)
+	}
+	// Only a system message: nothing for the model to answer, so the client
+	// must fail before spawning the (non-executable) stub.
+	if _, err := client.Chat(context.Background(), []ChatMessage{
+		{Role: "system", Content: "You are helpful."},
+	}, ChatOptions{}); err == nil {
+		t.Fatal("expected an empty-prompt error")
+	} else if !strings.Contains(err.Error(), "prompt is empty") {
+		t.Errorf("error = %v, want an empty-prompt error", err)
+	}
+}
+
+// Opt-in live coverage for the locally authenticated CLI. Normal CI skips it:
+// it requires a user-owned Antigravity login and consumes account quota.
+// Run with TARS_TEST_ANTIGRAVITY_LIVE=1 and optionally AGY_CLI_PATH=<path>.
+func TestAntigravityCLIClient_LiveConversationResume(t *testing.T) {
+	if os.Getenv("TARS_TEST_ANTIGRAVITY_LIVE") != "1" {
+		t.Skip("set TARS_TEST_ANTIGRAVITY_LIVE=1 to exercise the authenticated CLI")
+	}
+
+	client, err := NewProvider(ProviderOptions{
+		Provider: "antigravity-cli",
+		WorkDir:  ".",
+	})
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+
+	firstMessages := []ChatMessage{
+		{Role: "user", Content: "Remember the codeword ORCHID for the next turn. Reply with exactly: ACK"},
+	}
+	first, err := client.Chat(context.Background(), firstMessages, ChatOptions{})
+	if err != nil {
+		t.Fatalf("first Chat: %v", err)
+	}
+	if got := strings.TrimSpace(first.Message.Content); got != "ACK" {
+		t.Fatalf("first response = %q, want ACK", got)
+	}
+	if strings.TrimSpace(first.SessionID) == "" {
+		t.Fatal("first response did not expose a resumable conversation id")
+	}
+
+	secondMessages := append(firstMessages,
+		ChatMessage{Role: "assistant", Content: first.Message.Content},
+		ChatMessage{Role: "user", Content: "Reply with only the codeword I asked you to remember. No punctuation."},
+	)
+	second, err := client.Chat(context.Background(), secondMessages, ChatOptions{
+		ResumeSessionID: first.SessionID,
+	})
+	if err != nil {
+		t.Fatalf("resumed Chat: %v", err)
+	}
+	if got := strings.TrimSpace(second.Message.Content); got != "ORCHID" {
+		t.Fatalf("resumed response = %q, want ORCHID", got)
+	}
+	if second.SessionID != first.SessionID {
+		t.Fatalf("resumed session id = %q, want %q", second.SessionID, first.SessionID)
+	}
+}
+
+// exeSuffix keeps the stub resolvable by exec.LookPath, which on Windows only
+// accepts names carrying a PATHEXT extension.
+func exeSuffix() string {
+	if runtime.GOOS == "windows" {
+		return ".exe"
+	}
+	return ""
+}

--- a/internal/llm/antigravity_cli_test.go
+++ b/internal/llm/antigravity_cli_test.go
@@ -673,8 +673,9 @@ func TestAntigravityCLIHelperProcess(t *testing.T) {
 	if os.Getenv("GO_WANT_ANTIGRAVITY_HELPER_PROCESS") != "1" {
 		return
 	}
-	fmt.Fprintln(os.Stdout, agyInitEvent())
-	fmt.Fprintln(os.Stdout, agyResultEvent("ACK"))
+	if _, err := fmt.Fprintln(os.Stdout, agyStream(agyInitEvent(), agyResultEvent("ACK"))); err != nil {
+		os.Exit(1)
+	}
 	os.Exit(0)
 }
 

--- a/internal/llm/antigravity_cli_unix.go
+++ b/internal/llm/antigravity_cli_unix.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+package llm
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// configureAntigravityCLIProcess runs agy in its own process group and, on
+// context cancellation, SIGKILLs the whole group. The CLI spawns descendants
+// (e.g. stdio MCP servers) that inherit the stdout pipe; killing only the
+// direct child leaves them holding the pipe open, so the stream read would
+// block past the deadline. WaitDelay bounds any residual pipe wait.
+func configureAntigravityCLIProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		// Negative pid targets the whole process group created by Setpgid.
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	cmd.WaitDelay = antigravityCLIWaitDelay
+}

--- a/internal/llm/antigravity_cli_windows.go
+++ b/internal/llm/antigravity_cli_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package llm
+
+import "os/exec"
+
+// configureAntigravityCLIProcess bounds the invocation on Windows via WaitDelay.
+// Windows has no POSIX process groups, so we rely on exec.CommandContext's
+// default cancel (which terminates agy) plus WaitDelay: if a descendant
+// (e.g. an stdio MCP server) outlives agy and keeps the stdout pipe open,
+// WaitDelay makes os/exec force-close the pipe so the stream read unblocks at
+// the deadline instead of hanging. Orphaned descendants then exit on their own
+// once their stdio breaks.
+func configureAntigravityCLIProcess(cmd *exec.Cmd) {
+	cmd.WaitDelay = antigravityCLIWaitDelay
+}

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -145,7 +145,7 @@ type ChatOptions struct {
 	// ServiceTier controls provider-side latency tier when supported.
 	ServiceTier string
 	// ResumeSessionID, when non-empty, asks providers that expose a resumable
-	// upstream session (currently only claude-code-cli) to continue that
+	// upstream session (currently claude-code-cli and antigravity-cli) to continue that
 	// session instead of replaying the full transcript. The caller is
 	// expected to read ChatResponse.SessionID on the first turn and feed it
 	// back here on subsequent turns. Providers that don't support resume
@@ -237,11 +237,11 @@ type ChatResponse struct {
 	// providers that do not expose this value.
 	Turns int
 	// SessionID is set by providers that expose a resumable upstream session
-	// (currently only claude-code-cli via stream-json). Empty for stateless
+	// (currently claude-code-cli and antigravity-cli via stream-json). Empty for stateless
 	// providers.
 	SessionID string
 	// ProviderExecutedTools enumerates tool invocations the upstream provider
-	// has *already* executed on its own (currently only claude-code-cli,
+	// has *already* executed on its own (currently claude-code-cli and antigravity-cli,
 	// which runs Read/Edit/Bash/Glob/etc internally and reports them as
 	// stream-json tool_use blocks). These are observation-only — callers
 	// must NOT route them through TARS' tool registry, since the work is
@@ -315,6 +315,13 @@ func NewProvider(opts ProviderOptions) (Client, error) {
 	if provider == "claude-code-cli" {
 		zlog.Debug().Str("provider", provider).Msg("llm provider ready")
 		return NewClaudeCodeCLIClient(opts.WorkDir, opts.Model)
+	}
+	// antigravity-cli authenticates through the CLI's own Google login, so it
+	// is constructed before ResolveProviderCredential — there is no TARS-held
+	// credential to resolve.
+	if provider == "antigravity-cli" {
+		zlog.Debug().Str("provider", provider).Msg("llm provider ready")
+		return NewAntigravityCLIClient(opts.WorkDir, opts.Model)
 	}
 
 	cred, err := auth.ResolveProviderCredential(authConfig)

--- a/internal/llmdefaults/defaults.go
+++ b/internal/llmdefaults/defaults.go
@@ -6,13 +6,14 @@ import (
 )
 
 const (
-	ProviderOpenAI        = "openai"
-	ProviderOpenAICodex   = "openai-codex"
-	ProviderClaudeCodeCLI = "claude-code-cli"
-	ProviderGemini        = "gemini"
-	ProviderGeminiNative  = "gemini-native"
-	ProviderAnthropic     = "anthropic"
-	ProviderKimi          = "kimi"
+	ProviderOpenAI         = "openai"
+	ProviderOpenAICodex    = "openai-codex"
+	ProviderClaudeCodeCLI  = "claude-code-cli"
+	ProviderAntigravityCLI = "antigravity-cli"
+	ProviderGemini         = "gemini"
+	ProviderGeminiNative   = "gemini-native"
+	ProviderAnthropic      = "anthropic"
+	ProviderKimi           = "kimi"
 
 	OpenAIBaseURL       = "https://api.openai.com/v1"
 	OpenAIModel         = "gpt-4o-mini"
@@ -58,6 +59,13 @@ var kindDefaults = map[string]KindDefaults{
 	ProviderClaudeCodeCLI: {
 		AuthMode:                 "cli",
 		Model:                    ClaudeCodeCLIModel,
+		AuthModeWhenAPIKeyAbsent: "cli",
+	},
+	// antigravity-cli carries no BaseURL, Model or APIKeyEnv: the CLI holds
+	// its own Google login and talks to its own backend, so TARS never sees a
+	// credential or an endpoint, and the CLI picks its own default model.
+	ProviderAntigravityCLI: {
+		AuthMode:                 "cli",
 		AuthModeWhenAPIKeyAbsent: "cli",
 	},
 	ProviderGemini: {

--- a/internal/llmdefaults/defaults_test.go
+++ b/internal/llmdefaults/defaults_test.go
@@ -1,0 +1,16 @@
+package llmdefaults
+
+import "testing"
+
+func TestAntigravityCLIDefaults(t *testing.T) {
+	got, ok := ForKind(" Antigravity-CLI ")
+	if !ok {
+		t.Fatal("antigravity-cli defaults are not registered")
+	}
+	if got.AuthMode != "cli" || got.AuthModeWhenAPIKeyAbsent != "cli" {
+		t.Errorf("auth defaults = %+v, want cli", got)
+	}
+	if got.BaseURL != "" || got.Model != "" || got.OAuthProvider != "" || len(got.APIKeyEnv) != 0 {
+		t.Errorf("antigravity-cli must leave endpoint, model, OAuth, and API-key defaults empty: %+v", got)
+	}
+}

--- a/pkg/llm/exports.go
+++ b/pkg/llm/exports.go
@@ -36,6 +36,7 @@ type Client = internal.Client
 type ProviderOptions = internal.ProviderOptions
 type ProviderError = internal.ProviderError
 type ClaudeCodeCLIClient = internal.ClaudeCodeCLIClient
+type AntigravityCLIClient = internal.AntigravityCLIClient
 type ModelFetcher = internal.ModelFetcher
 type Role = internal.Role
 
@@ -102,4 +103,10 @@ func FindClaudeCodeCLIPath() (string, error) { return internal.FindClaudeCodeCLI
 
 func NewClaudeCodeCLIClient(workDir, model string) (*ClaudeCodeCLIClient, error) {
 	return internal.NewClaudeCodeCLIClient(workDir, model)
+}
+
+func FindAntigravityCLIPath() (string, error) { return internal.FindAntigravityCLIPath() }
+
+func NewAntigravityCLIClient(workDir, model string) (*AntigravityCLIClient, error) {
+	return internal.NewAntigravityCLIClient(workDir, model)
 }


### PR DESCRIPTION
## Summary

- add an `antigravity-cli` provider backed by a locally authenticated `agy` subprocess
- parse the official `init` / `step_update` / `result` NDJSON protocol, including streamed text, usage, and observation-only tool calls
- preserve multi-turn context with `conversation_id` and `--conversation`
- map reasoning effort and JSON-schema response options to the CLI while keeping dangerous permission bypasses unreachable
- add Windows/Unix process handling, public exports, provider defaults, capability documentation, and unit/live integration coverage

## Why

Antigravity CLI exposes a supported structured headless protocol and owns its Google authentication in the system keyring. TARS can therefore offer a Google-backed local CLI provider without accepting or storing an API key.

The provider intentionally leaves the model unset unless a tier supplies an `agy models` slug, uses the user's Antigravity permission policy for self-executed tools, and never re-dispatches those tools through the TARS registry.

## User and developer impact

Users can select `kind: antigravity-cli` after installing and authenticating Antigravity CLI 1.1.8 or newer. Responses stream through the normal TARS callbacks, upstream conversations resume across turns, and token usage plus provider-executed tools remain visible to existing accounting and audit paths.

## Validation

- authenticated Antigravity CLI 1.1.13 smoke test: `PONG`, terminal status `SUCCESS`
- opt-in live provider test: first turn `ACK`, resumed turn recalled `ORCHID` through the same conversation ID
- `go test ./internal/llm -run Antigravity -count=1`
- `go test ./internal/llmdefaults ./pkg/llm ./internal/config ./internal/agent -count=1`
- `go build ./...`
- `go vet ./...`
- Linux and macOS cross-target vet for `internal/llm` and `pkg/llm`
